### PR TITLE
feat: Add Elixir language support

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,5 +1,5 @@
 import { spawn, execSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -87,6 +87,7 @@ export class PolyglotExecutor {
       php: "php",
       perl: "pl",
       r: "R",
+      elixir: "exs",
     };
 
     // Go needs a main package wrapper if not present
@@ -97,6 +98,12 @@ export class PolyglotExecutor {
     // PHP needs opening tag if not present
     if (language === "php" && !code.trimStart().startsWith("<?")) {
       code = `<?php\n${code}`;
+    }
+
+    // Elixir: prepend compiled BEAM paths when inside a Mix project
+    if (language === "elixir" && existsSync(join(this.#projectRoot, "mix.exs"))) {
+      const escaped = JSON.stringify(join(this.#projectRoot, "_build/dev/lib"));
+      code = `Path.wildcard(Path.join(${escaped}, "*/ebin"))\n|> Enum.each(&Code.prepend_path/1)\n\n${code}`;
     }
 
     const fp = join(tmpDir, `script.${extMap[language]}`);
@@ -324,6 +331,8 @@ export class PolyglotExecutor {
         return `my $FILE_CONTENT_PATH = ${escaped};\nopen(my $fh, '<', $FILE_CONTENT_PATH) or die "Cannot open: $!";\nmy $FILE_CONTENT = do { local $/; <$fh> };\nclose($fh);\n${code}`;
       case "r":
         return `FILE_CONTENT_PATH <- ${escaped}\nFILE_CONTENT <- readLines(FILE_CONTENT_PATH, warn=FALSE)\nFILE_CONTENT <- paste(FILE_CONTENT, collapse="\\n")\n${code}`;
+      case "elixir":
+        return `file_content_path = ${escaped}\nfile_content = File.read!(file_content_path)\n${code}`;
     }
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10,7 +10,8 @@ export type Language =
   | "rust"
   | "php"
   | "perl"
-  | "r";
+  | "r"
+  | "elixir";
 
 export interface RuntimeInfo {
   command: string;
@@ -30,6 +31,7 @@ export interface RuntimeMap {
   php: string | null;
   perl: string | null;
   r: string | null;
+  elixir: string | null;
 }
 
 function commandExists(cmd: string): boolean {
@@ -82,6 +84,7 @@ export function detectRuntimes(): RuntimeMap {
       : commandExists("r")
         ? "r"
         : null,
+    elixir: commandExists("elixir") ? "elixir" : null,
   };
 }
 
@@ -140,6 +143,10 @@ export function getRuntimeSummary(runtimes: RuntimeMap): string {
     );
   if (runtimes.r)
     lines.push(`  R:          ${runtimes.r} (${getVersion(runtimes.r)})`);
+  if (runtimes.elixir)
+    lines.push(
+      `  Elixir:     ${runtimes.elixir} (${getVersion(runtimes.elixir)})`,
+    );
 
   if (!bunPreferred) {
     lines.push("");
@@ -161,6 +168,7 @@ export function getAvailableLanguages(runtimes: RuntimeMap): Language[] {
   if (runtimes.php) langs.push("php");
   if (runtimes.perl) langs.push("perl");
   if (runtimes.r) langs.push("r");
+  if (runtimes.elixir) langs.push("elixir");
   return langs;
 }
 
@@ -235,5 +243,11 @@ export function buildCommand(
         throw new Error("R not available. Install R / Rscript.");
       }
       return [runtimes.r, filePath];
+
+    case "elixir":
+      if (!runtimes.elixir) {
+        throw new Error( "Elixir not available. Install elixir.");
+      }
+      return ["elixir", filePath];
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -150,12 +150,13 @@ server.registerTool(
           "php",
           "perl",
           "r",
+          "elixir",
         ])
         .describe("Runtime language"),
       code: z
         .string()
         .describe(
-          "Source code to execute. Use console.log (JS/TS), print (Python/Ruby/Perl/R), echo (Shell), echo (PHP), or fmt.Println (Go) to output a summary to context.",
+          "Source code to execute. Use console.log (JS/TS), print (Python/Ruby/Perl/R), echo (Shell), echo (PHP), fmt.Println (Go), or IO.puts (Elixir) to output a summary to context.",
         ),
       timeout: z
         .number()
@@ -404,12 +405,13 @@ server.registerTool(
           "php",
           "perl",
           "r",
+          "elixir",
         ])
         .describe("Runtime language"),
       code: z
         .string()
         .describe(
-          "Code to process FILE_CONTENT. Print summary via console.log/print/echo.",
+          "Code to process FILE_CONTENT (file_content in Elixir). Print summary via console.log/print/echo/IO.puts.",
         ),
       timeout: z
         .number()


### PR DESCRIPTION
Updates the executor, runtime, and server to support the [Elixir language][0]. For the most part this just looks for the `elixir` command and uses that for running the scripts. But this also adds a couple Elixir-specific changes.

* Elixir variables cannot start with capital letters, so we need to use `file_content_path` and `file_content` instead
* When we are in a mix project, we prefix the script contents with loading the current dev build code so that the script can refer to deps and modules within the current project

[0]: https://elixir-lang.org/