### PR TITLE
fix: pass CLAUDE_PROJECT_DIR so execute_file resolves relative paths

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
+CLAUDE_PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR"
 
 # Bundle exists (CI-built) — start instantly, install native module in background
 if [ -f server.bundle.mjs ]; then
   [ -d node_modules/better-sqlite3 ] || npm install better-sqlite3 --no-package-lock --no-save --silent 2>/dev/null &
-  exec node server.bundle.mjs
+  CLAUDE_PROJECT_DIR="$CLAUDE_PROJECT_DIR" exec node server.bundle.mjs
 fi
 
 # Fallback: no bundle (dev or npm install) — full build
 [ -d node_modules ] || npm install --silent 2>/dev/null
 [ -f build/server.js ] || npx tsc --silent 2>/dev/null
-exec node build/server.js
+CLAUDE_PROJECT_DIR="$CLAUDE_PROJECT_DIR" exec node build/server.js


### PR DESCRIPTION
## Summary

- `start.sh` does `cd "$DIR"` into the plugin install directory before launching node, so `process.cwd()` in the server becomes the plugin directory
- Relative paths passed to `execute_file` then resolve against the wrong directory
- Fix captures `$(pwd)` before the `cd` and passes it as `CLAUDE_PROJECT_DIR` env var to the node process

## Changes

- Capture `CLAUDE_PROJECT_DIR` (defaulting to `$(pwd)`) on line 2, before the `cd`
- Pass it to both `exec node` invocations (bundle and fallback paths)

## Test plan

- [x ] Verify `execute_file` with a relative path resolves against the project directory, not the plugin directory



Fixed Error 1 — Silent misread 
```
  package.json — printed context-mode instead of project folder. The relative path resolved to the context-mode
   plugin's own package.json at
  /Users/dunika/.claude/plugins/cache/claude-context-mode/context-mode/0.7.2/package.json, not the
  project's.

  The test was: execute_file with path package.json, code const pkg = JSON.parse(FILE_CONTENT);
  console.log(pkg.name); — should have printed the project folder, printed context-mode instead.
```

<img width="860" height="79" alt="image" src="https://github.com/user-attachments/assets/7cb07ec0-d337-4f0e-af07-d16474bde506" />


Fixed Error 2 — ENOENT 
```
  Error processing apps/web-app/src/app/feedback/client.tsx (exit 1):
  1 | const FILE_CONTENT_PATH = "/Users/dunika/.claude/plugins/cache/claude-context-mode/context-mode/0.7.2
  /apps/web-app/src/app/feedback/client.tsx";
  2 | const FILE_CONTENT = require("fs").readFileSync(FILE_CONTENT_PATH, "utf-8");
            ^
  ENOENT: No such file or directory
     errno: -2
   syscall: "open"
     path: "/Users/dunika/.claude/plugins/cache/claude-context-mode/context-mode/0.7.2/apps/web-app/src/app
  /feedback/client.tsx"

        at /private/var/folders/1g/xh57x2qd1y77fml0bc_mk0q00000gn/T/ctx-mode-SCL3Cb/script.js:2:7
```

<img width="855" height="93" alt="image" src="https://github.com/user-attachments/assets/cef52148-23d5-44fc-a968-f127f3f53105" />
