### PR TITLE
fix: use AND instead of OR for multi-word search queries

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -95,7 +95,7 @@ function sanitizeQuery(query: string): string {
     );
 
   if (words.length === 0) return '""';
-  return words.map((w) => `"${w}"`).join(" OR ");
+  return words.map((w) => `"${w}"`).join(" AND ");
 }
 
 function sanitizeTrigramQuery(query: string): string {

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -511,6 +511,29 @@ async function main() {
     store.close();
   });
 
+  await test("multi-word query requires all terms (AND semantics)", () => {
+    const store = createStore();
+    store.index({
+      content: "# Full Match\n\nuseEffect cleanup function example",
+      source: "doc-with-all-words",
+    });
+    store.index({
+      content: "# Partial Match\n\nfunction example only",
+      source: "doc-with-partial-words",
+    });
+
+    const results = store.search("useEffect cleanup function", 10);
+    assert.ok(
+      results.some((r) => r.source === "doc-with-all-words"),
+      "Should include document that contains all query terms",
+    );
+    assert.ok(
+      !results.some((r) => r.source === "doc-with-partial-words"),
+      "Should not include document missing query terms",
+    );
+    store.close();
+  });
+
   await test("empty query returns empty results", () => {
     const store = createStore();
     store.index({


### PR DESCRIPTION
## Summary
Fixes #23 — Multi-word search queries now use AND semantics instead of OR, returning more relevant results when multiple keywords are provided.

## Problem
Previously, `sanitizeQuery()` joined search terms with `OR`, causing queries like `"useEffect cleanup function"` to match any chunk containing **any** of those words. This broadened results instead of narrowing them, contrary to user expectations.

## Changes
- Modified `src/store.ts:98`: Changed `" OR "` → `" AND "`
- Added test case: `multi-word query requires all terms (AND semantics)`

## Before vs After
| Query | Old Behavior | New Behavior |
|-------|-------------|--------------|
| `useEffect cleanup function` | Matches "useEffect" OR "cleanup" OR "function" | Matches "useEffect" AND "cleanup" AND "function" |

## Testing
- New test verifies documents missing query terms are excluded
- Single-word queries remain unaffected (no join applied)
- Empty queries still return empty results

## Checklist
- [x] Code change minimal and focused
- [x] Test added for new behavior
- [x] No breaking changes to existing functionality
- [x] Fixes #23