### PR TITLE
fix: handle EBUSY on Windows temp dir cleanup

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -83,7 +83,12 @@ export class PolyglotExecutor {
 
       return await this.#spawn(cmd, tmpDir, timeout);
     } finally {
-      rmSync(tmpDir, { recursive: true, force: true });
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // On Windows, EBUSY/EPERM is common due to delayed handle release
+        // after child process exit. Silently ignore — OS cleans temp dirs.
+      }
     }
   }
 

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -1034,6 +1034,53 @@ IO.puts("has users: #{String.contains?(file_content, "users")}")
     assert.ok(r.stdout.includes("Hello"));
   });
 
+  // ===== TEMP CLEANUP RESILIENCE =====
+  console.log("\n--- Temp Cleanup Resilience ---\n");
+
+  await test("concurrent executions all return valid results (EBUSY resilience)", async () => {
+    // On Windows, rapid concurrent executions often trigger EBUSY when
+    // rmSync tries to delete the temp dir while Windows still holds handles.
+    // With the current code, rmSync throwing in the finally block masks
+    // the actual execution result — execute() rejects instead of resolving.
+    // This test verifies that ALL concurrent executions return valid ExecResult.
+    const count = 15;
+    const promises = Array.from({ length: count }, (_, i) =>
+      executor.execute({
+        language: "javascript",
+        code: `
+          const fs = require('fs');
+          const path = require('path');
+          for (let j = 0; j < 3; j++) {
+            fs.writeFileSync(path.join(process.cwd(), 'f' + j + '.tmp'), 'data');
+          }
+          console.log("ok-${i}");
+        `,
+      }),
+    );
+    const results = await Promise.all(promises);
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i];
+      assert.equal(typeof r.exitCode, "number", `Execution ${i}: exitCode not a number`);
+      assert.equal(typeof r.stdout, "string", `Execution ${i}: stdout not a string`);
+      assert.equal(typeof r.stderr, "string", `Execution ${i}: stderr not a string`);
+      assert.equal(typeof r.timedOut, "boolean", `Execution ${i}: timedOut not a boolean`);
+      assert.equal(r.exitCode, 0, `Execution ${i} failed with stderr: ${r.stderr}`);
+      assert.ok(r.stdout.includes(`ok-${i}`), `Missing output for execution ${i}`);
+    }
+  });
+
+  await test("PATH-dependent tools accessible from executor shell", async () => {
+    // Verifies that the executor's sanitized env preserves PATH correctly.
+    // On Windows, tools like gh/node installed via Scoop/Chocolatey must be
+    // visible from the spawned shell process. If PATH is broken, this fails.
+    const r = await executor.execute({
+      language: "shell",
+      code: 'node --version',
+    });
+    assert.equal(r.exitCode, 0, `node not found in executor env, stderr: ${r.stderr}`);
+    assert.ok(r.stdout.trim().startsWith("v"), `Expected version string, got: ${r.stdout}`);
+  });
+
   // ===== WINDOWS SHELL SUPPORT =====
   console.log("\n--- Windows Shell Support ---\n");
 


### PR DESCRIPTION
## Summary

Fixes the `EBUSY: resource busy or locked, rmdir` error reported in #26 (follow-up).

- **Root cause**: On Windows, `rmSync` in the `finally` block of `execute()` throws `EBUSY` because Windows holds file handles briefly after child process exit. This masked the actual execution result — `execute()` rejected instead of resolving with the `ExecResult`.
- **Fix**: Wrap `rmSync` in try-catch so cleanup failures don't lose execution results. OS cleans temp dirs eventually.
- **Side effect**: The `gh: command not found` error reported in #26 was a cascade — Claude Code fell back to its own Bash tool (MSYS2) after our `execute` failed with EBUSY. Once EBUSY is fixed, `execute` returns the result properly and `gh` works through our executor (we pass `process.env.PATH`).

## Test plan

- [x] Added concurrent execution resilience test (15 parallel executions with temp file writes)
- [x] Added PATH tool accessibility test (verifies `node` is reachable from executor shell)
- [x] TypeScript typecheck passes
- [x] All 65 tests pass locally (macOS)
- [ ] CI passes on ubuntu-latest, macos-latest, windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)