### PR TITLE
chore: add new plugin and assets to package.json

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "context-mode",
+  "version": "0.9.17",
+  "description": "MCP plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
+  "author": {
+    "name": "Mert Koseoğlu",
+    "email": "code.bm.ksglu@gmail.com"
+  },
+  "homepage": "https://github.com/mksglu/claude-context-mode#readme",
+  "repository": "https://github.com/mksglu/claude-context-mode",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "context-window",
+    "sandbox",
+    "code-execution",
+    "fts5",
+    "bm25",
+    "playwright",
+    "context7"
+  ],
+  "logo": "assets/logo.svg",
+  "mcpServers": {
+    "context-mode": {
+      "command": "npx",
+      "args": ["-y", "context-mode"]
+    }
+  },
+  "skills": "./skills/"
+}

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#8b5cf6"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#c4b5fd"/>
+      <stop offset="100%" style="stop-color:#a78bfa"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
+
+  <!-- Window frame -->
+  <rect x="96" y="120" width="320" height="272" rx="20" fill="white" fill-opacity="0.15" stroke="white" stroke-opacity="0.3" stroke-width="3"/>
+  <line x1="96" y1="168" x2="416" y2="168" stroke="white" stroke-opacity="0.3" stroke-width="3"/>
+
+  <!-- Window dots -->
+  <circle cx="124" cy="144" r="8" fill="#f87171"/>
+  <circle cx="152" cy="144" r="8" fill="#fbbf24"/>
+  <circle cx="180" cy="144" r="8" fill="#34d399"/>
+
+  <!-- Code lines (left - faded, representing raw data) -->
+  <rect x="120" y="192" width="120" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+  <rect x="120" y="212" width="96" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+  <rect x="120" y="232" width="140" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+  <rect x="120" y="252" width="80" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+  <rect x="120" y="272" width="110" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+  <rect x="120" y="292" width="90" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+  <rect x="120" y="312" width="130" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+  <rect x="120" y="332" width="70" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+  <rect x="120" y="352" width="100" height="8" rx="4" fill="white" fill-opacity="0.12"/>
+
+  <!-- Arrow (compression symbol) -->
+  <path d="M280 256 L320 240 L320 250 L360 250 L360 262 L320 262 L320 272 Z" fill="url(#accent)"/>
+
+  <!-- Compressed output (right - bright, representing summary) -->
+  <rect x="340" y="232" width="56" height="10" rx="5" fill="white" fill-opacity="0.9"/>
+  <rect x="340" y="256" width="48" height="10" rx="5" fill="white" fill-opacity="0.9"/>
+  <rect x="340" y="280" width="52" height="10" rx="5" fill="white" fill-opacity="0.9"/>
+
+  <!-- 98% badge -->
+  <rect x="310" y="336" width="96" height="40" rx="20" fill="white" fill-opacity="0.95"/>
+  <text x="358" y="362" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#6366f1">98%</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "server.bundle.mjs",
     "skills",
     ".claude-plugin",
+    ".cursor-plugin",
+    "assets",
     ".mcp.json",
     "start.mjs",
     "README.md",


### PR DESCRIPTION
## What

Add `.cursor-plugin/plugin.json` manifest and `assets/logo.svg` for Cursor Marketplace support.

## Why

Fixes #2 — Cursor restricts non-marketplace plugins. This adds the required manifest so the plugin can be submitted to the Cursor Marketplace.

## How

- Created `.cursor-plugin/plugin.json` mirroring `.claude-plugin/plugin.json` with Cursor-compatible MCP config (`npx -y context-mode` instead of `${CLAUDE_PLUGIN_ROOT}`)
- Added `assets/logo.svg` for marketplace listing
- Added `.cursor-plugin` and `assets` to `package.json` `files` array
- No existing files modified except `package.json` (2 lines added)

## Test plan

- [x] Tested MCP server in Cursor — `execute` tool runs code in sandbox and returns output
- [x] Tested `fetch_and_index` + `search` — fetched React useEffect docs, indexed, and searched for cleanup patterns with correct results
- [x] Existing `.claude-plugin/` structure untouched and backward-compatible

### Test output

N/A — no code changes, only manifest and asset files added.

### Before/After comparison

N/A — additive change only.

## Local development setup

N/A — no code changes.

## Checklist

- [x] I've checked [existing PRs](https://github.com/mksglu/claude-context-mode/pulls) to make sure this isn't a duplicate
- [x] I'm targeting the `main` branch
- [ ] ~~I've run the full test suite locally~~ (no code changes)
- [ ] ~~New functionality includes tests~~ (manifest only)
- [x] No breaking changes to existing tool interfaces
- [ ] ~~I've compared output quality before and after my change~~ (no code changes)