### PR TITLE
fix(hooks): intent-aware Read guidance and git command denial in sandbox

### DIFF
--- a/hooks/pretooluse.mjs
+++ b/hooks/pretooluse.mjs
@@ -251,8 +251,19 @@ if (tool === "Task") {
   });
 }
 
-// ─── MCP execute: security check for shell commands ───
+// ─── MCP execute: git guard + security check for shell commands ───
 if (tool.includes("context-mode") && tool.endsWith("__execute")) {
+  // Git commands don't work in the sandbox (no .git directory)
+  if (toolInput.language === "shell" && /(^|\s|&&|\||\;)git\s/.test(toolInput.code ?? "")) {
+    outputAndExit({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        reason: "git commands do not work in the sandbox (no .git directory). Use Bash for all git operations (git log, git diff, git status, etc.).",
+      },
+    });
+  }
+
   if (security && toolInput.language === "shell") {
     const code = toolInput.code ?? "";
     const policies = security.readBashPolicies(process.env.CLAUDE_PROJECT_DIR);
@@ -327,8 +338,20 @@ if (tool.includes("context-mode") && tool.endsWith("__execute_file")) {
   process.exit(0);
 }
 
-// ─── MCP batch_execute: check each command individually ───
+// ─── MCP batch_execute: git guard + security check for each command ───
 if (tool.includes("context-mode") && tool.endsWith("__batch_execute")) {
+  // Git commands don't work in the sandbox (no .git directory)
+  const batchCmds = toolInput.commands ?? [];
+  if (batchCmds.some(e => /(^|\s|&&|\||\;)git\s/.test(e.command ?? ""))) {
+    outputAndExit({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        reason: "git commands do not work in the sandbox (no .git directory). Use Bash for all git operations (git log, git diff, git status, etc.).",
+      },
+    });
+  }
+
   if (security) {
     const commands = toolInput.commands ?? [];
     const policies = security.readBashPolicies(process.env.CLAUDE_PROJECT_DIR);

--- a/hooks/routing-block.mjs
+++ b/hooks/routing-block.mjs
@@ -23,6 +23,7 @@ export const ROUTING_BLOCK = `
     - DO NOT use Bash for commands producing >20 lines of output.
     - DO NOT use Read for analysis (use execute_file). Read IS correct for files you intend to Edit.
     - DO NOT use WebFetch (use mcp__context-mode__fetch_and_index instead).
+    - DO NOT run git in sandbox tools (batch_execute, execute) — no .git directory exists there.
     - Bash is ONLY for git/mkdir/rm/mv/navigation.
   </forbidden_actions>
 


### PR DESCRIPTION
## Summary

- **Intent-aware Read guidance**: Replace the blanket "don't use Read for large files" rule with context-sensitive guidance. When the intent is to edit a file, Read is the correct tool (Edit requires file content in context). When the intent is analysis, `execute_file` is preferred. This prevents the agent from reading files twice — once with `execute_file` then again with `Read` before editing.

- **Git command denial in sandbox tools**: The MCP sandbox (`execute`, `batch_execute`) has no `.git` directory, so git commands fail with a confusing "not a git repository" error. Add detection that denies the call with a clear message redirecting to Bash, saving a wasted tool call.

Both changes update the shared `routing-block.mjs` module so guidance is consistent across `sessionstart.mjs` and `pretooluse.mjs` injection points.

## Test plan

- [ ] Verify that editing a file after `execute_file` analysis no longer triggers a redundant Read nudge
- [ ] Verify that running `git status` in `execute`/`batch_execute` is denied with a message pointing to Bash
- [ ] Verify that `sessionstart` routing block includes updated `forbidden_actions` and `READ_GUIDANCE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)