### PR TITLE
feat: multi-LLM installer (Claude Code, Gemini CLI, OpenCode, Codex, VS Code)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,222 @@
+# context-mode Installation
+
+Multi-LLM CLI installer supporting Claude Code, Gemini CLI, OpenCode, Codex, and VS Code Copilot.
+
+## Quick Install
+
+```bash
+npx context-mode-install
+```
+
+## Supported Runtimes
+
+| Runtime | Flag | Config Directory |
+|---------|------|------------------|
+| Claude Code | `-c, --claude` | `~/.claude/` |
+| Gemini CLI | `-g, --gemini` | `~/.gemini/` |
+| OpenCode | `-o, --opencode` | `~/.config/opencode/` |
+| Codex | `-x, --codex` | `~/.codex/` |
+| VS Code Copilot | `-v, --vscode` | `~/.vscode/copilot/` |
+
+## Install Options
+
+### Single Runtime
+
+```bash
+# Claude Code (default)
+npx context-mode-install
+npx context-mode-install --claude
+
+# Gemini CLI
+npx context-mode-install --gemini
+
+# OpenCode
+npx context-mode-install --opencode
+
+# Codex
+npx context-mode-install --codex
+
+# VS Code Copilot
+npx context-mode-install --vscode
+```
+
+### Multiple Runtimes
+
+```bash
+# Claude Code + Gemini CLI
+npx context-mode-install --claude --gemini
+
+# Claude Code + OpenCode + Codex
+npx context-mode-install -c -o -x
+```
+
+### All Runtimes
+
+```bash
+npx context-mode-install --all
+```
+
+### Global vs Local
+
+```bash
+# Global install (default) - all projects
+npx context-mode-install --claude --global
+
+# Local install - current project only
+npx context-mode-install --claude --local
+```
+
+### Custom Account Directory
+
+```bash
+npx context-mode-install --claude --account ~/.custom-account
+```
+
+### Combined Options
+
+```bash
+# All runtimes, global
+npx context-mode-install --all --global
+
+# Specific runtimes, local
+npx context-mode-install --gemini --opencode --local
+
+# Custom directory
+npx context-mode-install -c -g -A ~/.multi-llm
+```
+
+## Command Reference
+
+### Runtime Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--claude` | `-c` | Install to Claude Code |
+| `--gemini` | `-g` | Install to Gemini CLI |
+| `--opencode` | `-o` | Install to OpenCode |
+| `--codex` | `-x` | Install to Codex |
+| `--vscode` | `-v` | Install to VS Code Copilot |
+| `--all` | `-a` | Install to all runtimes |
+
+### Location Flags
+
+| Flag | Description |
+|------|-------------|
+| `--global` | Install globally (default) |
+| `--local` | Install locally (current project) |
+| `--account <path>` | Custom account directory |
+
+### Other Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--marketplace <name>` | `-m` | Marketplace to install |
+| `--help` | `-h` | Show help |
+
+## GSD Comparison
+
+| Feature | GSD | context-mode |
+|---------|-----|--------------|
+| Claude Code | ✓ | ✓ |
+| Gemini CLI | ✓ | ✓ |
+| OpenCode | ✓ | ✓ |
+| Codex | ✓ | ✓ |
+| VS Code Copilot | - | ✓ |
+| `--all` flag | ✓ | ✓ |
+| Global/Local | ✓ | ✓ |
+| Install-time conversion | ✓ | - |
+
+## Manual Installation
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/mksglu/context-mode.git \
+  ~/.claude/plugins/cache/context-mode/context-mode/1.0.5
+```
+
+### 2. Install dependencies
+
+```bash
+cd ~/.claude/plugins/cache/context-mode/context-mode/1.0.5
+npm install
+npm run build
+```
+
+### 3. Register the plugin
+
+Edit `~/.claude/plugins/installed_plugins.json`:
+
+```json
+{
+  "version": 2,
+  "plugins": {
+    "context-mode@context-mode": [{
+      "scope": "user",
+      "installPath": "/Users/YOUR_USERNAME/.claude/plugins/cache/context-mode/context-mode/1.0.5",
+      "version": "1.0.5",
+      "installedAt": "2026-03-06T00:00:00.000Z"
+    }]
+  }
+}
+```
+
+### 4. Enable in settings
+
+Edit `~/.claude/.claude.json`:
+
+```json
+{
+  "enabledPlugins": {
+    "context-mode@context-mode": true
+  }
+}
+```
+
+## Verification
+
+After installation:
+
+```bash
+# Check plugin registry
+cat ~/.claude/plugins/installed_plugins.json
+
+# Check enabled plugins
+grep -A2 'enabledPlugins' ~/.claude/.claude.json
+```
+
+Restart your CLI to activate the plugin.
+
+## Uninstall
+
+```bash
+rm -rf ~/.claude/plugins/cache/context-mode
+rm -rf ~/.claude/plugins/marketplaces/context-mode
+```
+
+Edit `~/.claude/plugins/installed_plugins.json` and `~/.claude/.claude.json` to remove context-mode entries.
+
+## Troubleshooting
+
+**Plugin not showing up:**
+1. Restart the CLI completely
+2. Check that `installed_plugins.json` paths are correct
+3. Verify `enabledPlugins` in the settings file
+
+**Build failures:**
+1. Ensure Node.js and npm are installed
+2. Run `npm install` and `npm run build` manually in the plugin directory
+
+**Permission errors:**
+1. Try with `sudo` for global installs
+2. Or use `--local` for project-level installation
+
+## Related Issues
+
+- https://github.com/anthropics/claude-code/issues/9719
+- https://github.com/anthropics/claude-code/issues/14485
+
+## References
+
+- GSD Multi-LLM: https://github.com/gsd-build/get-shit-done
+- GSD NPM: https://www.npmjs.com/package/get-shit-done-cc

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ https://github.com/user-attachments/assets/07013dbf-07c0-4ef1-974a-33ea1207637b
 
 ## Install
 
+### Quick Install (All Platforms)
+
+```bash
+npx context-mode-install
+```
+
+Supports: Claude Code, Gemini CLI, OpenCode, Codex, VS Code Copilot.  
+See [INSTALL.md](./INSTALL.md) for all options.
+
+---
+
 <details open>
 <summary><strong>Claude Code</strong></summary>
 
@@ -26,6 +37,7 @@ https://github.com/user-attachments/assets/07013dbf-07c0-4ef1-974a-33ea1207637b
 ```bash
 /plugin marketplace add mksglu/context-mode
 /plugin install context-mode@context-mode
+npx context-mode-install --claude
 ```
 
 **Step 2 — Restart Claude Code.**
@@ -58,9 +70,10 @@ This gives you the 6 sandbox tools but without automatic routing. The model can 
 <details>
 <summary><strong>Gemini CLI</strong> <sup>(Beta)</sup></summary>
 
-**Step 1 — Install globally:**
+**Step 1 — Install:**
 
 ```bash
+npx context-mode-install --gemini
 npm install -g context-mode
 ```
 
@@ -114,9 +127,10 @@ Full hook config including PreCompress: [`configs/gemini-cli/settings.json`](con
 <details>
 <summary><strong>VS Code Copilot</strong> <sup>(Beta)</sup></summary>
 
-**Step 1 — Install globally:**
+**Step 1 — Install:**
 
 ```bash
+npx context-mode-install --vscode
 npm install -g context-mode
 ```
 
@@ -161,9 +175,10 @@ Full hook config including PreCompact: [`configs/vscode-copilot/hooks.json`](con
 <details>
 <summary><strong>OpenCode</strong> <sup>(Beta)</sup></summary>
 
-**Step 1 — Install globally:**
+**Step 1 — Install:**
 
 ```bash
+npx context-mode-install --opencode
 npm install -g context-mode
 ```
 
@@ -195,9 +210,10 @@ The `mcp` entry gives you the 6 sandbox tools. The `plugin` entry enables hooks 
 <details>
 <summary><strong>Codex CLI</strong> <sup>(Beta)</sup></summary>
 
-**Step 1 — Install globally:**
+**Step 1 — Install:**
 
 ```bash
+npx context-mode-install --codex
 npm install -g context-mode
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "context-mode",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-mode",
-      "version": "1.0.2",
+      "version": "1.0.5",
+      "hasInstallScript": true,
       "license": "Elastic-2.0",
       "dependencies": {
         "@clack/prompts": "^1.0.1",
@@ -19,7 +20,8 @@
         "zod": "^3.25.0"
       },
       "bin": {
-        "context-mode": "build/cli.js"
+        "context-mode": "build/cli.js",
+        "context-mode-install": "build/install-https.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "./plugin": "./build/opencode-plugin.js"
   },
   "bin": {
-    "context-mode": "./build/cli.js"
+    "context-mode": "./build/cli.js",
+    "context-mode-install": "./build/install-https.js"
   },
   "files": [
     "build",
@@ -44,15 +45,17 @@
     ".mcp.json",
     "start.mjs",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "INSTALL.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x build/cli.js",
+    "build": "tsc && chmod +x build/cli.js && chmod +x build/install-https.js",
     "bundle": "esbuild src/server.ts --bundle --platform=node --target=node18 --format=esm --outfile=server.bundle.mjs --external:better-sqlite3 --external:turndown --external:turndown-plugin-gfm --external:@mixmark-io/domino --minify",
     "prepublishOnly": "npm run build",
     "dev": "npx tsx src/server.ts",
     "setup": "npx tsx src/cli.ts setup",
     "doctor": "npx tsx src/cli.ts doctor",
+    "install": "npx tsx src/install-https.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/install-https.ts
+++ b/src/install-https.ts
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * context-mode-install - Installer for multiple LLM CLI platforms
+ * 
+ * Usage:
+ *   npx context-mode-install
+ *   npx context-mode-install --claude --global
+ *   npx context-mode-install --gemini --local
+ *   npx context-mode-install --opencode --all
+ *   npx context-mode-install --codex
+ *   npx context-mode-install --vscode
+ */
+
+import { execSync } from "node:child_process";
+import { mkdirSync, cpSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+
+const args = process.argv.slice(2);
+
+type Runtime = "claude" | "gemini" | "opencode" | "codex" | "vscode";
+type Location = "global" | "local";
+
+interface InstallOptions {
+  runtimes: Runtime[];
+  location?: Location;
+  account?: string;
+  marketplace?: string;
+  help?: boolean;
+  all?: boolean;
+}
+
+const RUNTIME_CONFIGS: Record<Runtime, { configDir: string; name: string }> = {
+  "claude": { configDir: ".claude", name: "Claude Code" },
+  "gemini": { configDir: ".gemini", name: "Gemini CLI" },
+  "opencode": { configDir: ".config/opencode", name: "OpenCode" },
+  "codex": { configDir: ".codex", name: "Codex" },
+  "vscode": { configDir: ".vscode/copilot", name: "VS Code Copilot" },
+};
+
+function parseArgs(args: string[]): InstallOptions {
+  const result: InstallOptions = { runtimes: [] };
+  
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--claude" || args[i] === "-c") {
+      result.runtimes.push("claude");
+    } else if (args[i] === "--gemini" || args[i] === "-g") {
+      result.runtimes.push("gemini");
+    } else if (args[i] === "--opencode" || args[i] === "-o") {
+      result.runtimes.push("opencode");
+    } else if (args[i] === "--codex" || args[i] === "-x") {
+      result.runtimes.push("codex");
+    } else if (args[i] === "--vscode" || args[i] === "-v") {
+      result.runtimes.push("vscode");
+    } else if (args[i] === "--all" || args[i] === "-a") {
+      result.all = true;
+    } else if (args[i] === "--global") {
+      result.location = "global";
+    } else if (args[i] === "--local") {
+      result.location = "local";
+    } else if (args[i] === "--account" || args[i] === "-A") {
+      result.account = args[++i];
+    } else if (args[i] === "--marketplace" || args[i] === "-m") {
+      result.marketplace = args[++i];
+    } else if (args[i] === "--help" || args[i] === "-h") {
+      result.help = true;
+    }
+  }
+  
+  // Default to claude if no runtime specified
+  if (result.runtimes.length === 0 && !result.all) {
+    result.runtimes = ["claude"];
+  }
+  
+  // Expand --all to all runtimes
+  if (result.all) {
+    result.runtimes = ["claude", "gemini", "opencode", "codex", "vscode"];
+  }
+  
+  return result;
+}
+
+function getInstallPath(runtime: Runtime, location: Location, customAccount?: string): string {
+  if (customAccount) {
+    return resolve(customAccount);
+  }
+  
+  const config = RUNTIME_CONFIGS[runtime];
+  
+  if (location === "local") {
+    return resolve(process.cwd(), config.configDir);
+  }
+  
+  return join(homedir(), config.configDir);
+}
+
+function installToRuntime(runtime: Runtime, marketplace: string, claudeAccount: string): boolean {
+  const marketplaceName = marketplace.split("/")[1] || "context-mode";
+  const config = RUNTIME_CONFIGS[runtime];
+  
+  console.log(`\n=== Installing to ${config.name} ===`);
+  console.log(`Location: ${claudeAccount}`);
+  
+  // Create directories
+  const pluginCacheDir = join(claudeAccount, "plugins", "cache", marketplaceName);
+  const pluginMarketplaceDir = join(claudeAccount, "plugins", "marketplaces");
+  mkdirSync(pluginCacheDir, { recursive: true });
+  mkdirSync(pluginMarketplaceDir, { recursive: true });
+  
+  // Clone via HTTPS
+  const tempDir = join(tmpdir(), `context-mode-install-${Date.now()}-${runtime}`);
+  const repoUrl = `https://github.com/${marketplace}.git`;
+  
+  console.log("1. Cloning repository...");
+  try {
+    execSync(`git clone --depth 1 ${repoUrl} "${tempDir}"`, { stdio: "pipe" });
+  } catch (e: any) {
+    console.error(`   Failed to clone: ${e.message}`);
+    return false;
+  }
+  
+  // Get version
+  let version = "unknown";
+  const pluginJsonPath = join(tempDir, ".claude-plugin", "plugin.json");
+  if (existsSync(pluginJsonPath)) {
+    const pluginJson = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
+    version = pluginJson.version || "unknown";
+  }
+  
+  console.log(`2. Version: ${version}`);
+  
+  // Copy to cache
+  const cacheVersionDir = join(pluginCacheDir, marketplaceName, version);
+  if (existsSync(cacheVersionDir)) {
+    console.log("3. Removing old version...");
+    rmSync(cacheVersionDir, { recursive: true, force: true });
+  }
+  
+  console.log("4. Copying to cache...");
+  mkdirSync(join(pluginCacheDir, marketplaceName), { recursive: true });
+  cpSync(tempDir, cacheVersionDir, { recursive: true });
+  
+  // Install dependencies
+  const packageJsonPath = join(cacheVersionDir, "package.json");
+  if (existsSync(packageJsonPath)) {
+    console.log("5. Installing dependencies...");
+    try {
+      execSync("npm install --no-audit --no-fund", { cwd: cacheVersionDir, stdio: "pipe" });
+      
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+      if (packageJson.scripts?.build) {
+        console.log("   Building plugin...");
+        execSync("npm run build", { cwd: cacheVersionDir, stdio: "pipe" });
+      }
+    } catch (e: any) {
+      console.warn("   Warning: Build/install failed, plugin may not work correctly");
+    }
+  }
+  
+  // Get plugin name
+  let pluginName = marketplaceName;
+  if (existsSync(pluginJsonPath)) {
+    const pluginJson = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
+    pluginName = pluginJson.name || marketplaceName;
+  }
+  
+  // Update installed_plugins.json
+  const installedPluginsFile = join(claudeAccount, "plugins", "installed_plugins.json");
+  const installTime = new Date().toISOString();
+  
+  console.log("6. Registering plugin...");
+  let installedPlugins: any = { version: 2, plugins: {} };
+  if (existsSync(installedPluginsFile)) {
+    installedPlugins = JSON.parse(readFileSync(installedPluginsFile, "utf-8"));
+  }
+  
+  if (!installedPlugins.plugins) {
+    installedPlugins.plugins = {};
+  }
+  
+  const pluginKey = `${pluginName}@${marketplaceName}`;
+  if (!installedPlugins.plugins[pluginKey]) {
+    installedPlugins.plugins[pluginKey] = [];
+  }
+  
+  installedPlugins.plugins[pluginKey].push({
+    scope: "user",
+    installPath: cacheVersionDir,
+    version: version,
+    installedAt: installTime
+  });
+  
+  writeFileSync(installedPluginsFile, JSON.stringify(installedPlugins, null, 2));
+  
+  // Update known_marketplaces.json
+  const knownMarketplacesFile = join(claudeAccount, "plugins", "known_marketplaces.json");
+  const knownMarketplaces = existsSync(knownMarketplacesFile)
+    ? JSON.parse(readFileSync(knownMarketplacesFile, "utf-8"))
+    : {};
+  
+  knownMarketplaces[marketplaceName] = {
+    source: {
+      source: "git",
+      url: repoUrl
+    },
+    installLocation: join(pluginMarketplaceDir, marketplaceName),
+    lastUpdated: installTime
+  };
+  writeFileSync(knownMarketplacesFile, JSON.stringify(knownMarketplaces, null, 2));
+  
+  // Enable plugin in settings (runtime-specific)
+  let settingsFile = join(claudeAccount, ".claude.json");
+  
+  // Try runtime-specific settings files
+  if (runtime === "opencode" && !existsSync(settingsFile)) {
+    settingsFile = join(claudeAccount, "opencode.json");
+  } else if (runtime === "gemini" && !existsSync(settingsFile)) {
+    settingsFile = join(claudeAccount, ".gemini.json");
+  } else if (runtime === "codex" && !existsSync(settingsFile)) {
+    settingsFile = join(claudeAccount, ".codex.json");
+  }
+  
+  if (existsSync(settingsFile)) {
+    console.log("7. Enabling plugin in settings...");
+    const settings = JSON.parse(readFileSync(settingsFile, "utf-8"));
+    settings.enabledPlugins = settings.enabledPlugins || {};
+    settings.enabledPlugins[pluginKey] = true;
+    writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
+  }
+  
+  // Cleanup
+  rmSync(tempDir, { recursive: true, force: true });
+  
+  console.log(`\n✓ Installed to ${config.name}`);
+  return true;
+}
+
+function main() {
+  const opts = parseArgs(args);
+  
+  if (opts.help) {
+    console.log(`
+context-mode-install - Installer for multiple LLM CLI platforms
+
+Usage:
+  npx context-mode-install [options]
+
+Runtimes:
+  -c, --claude      Install to Claude Code
+  -g, --gemini      Install to Gemini CLI
+  -o, --opencode    Install to OpenCode
+  -x, --codex       Install to Codex
+  -v, --vscode      Install to VS Code Copilot
+  -a, --all         Install to all supported runtimes
+
+Location:
+  --global          Install globally (default)
+  --local           Install locally (current project)
+  -A, --account     Custom account directory
+
+Other:
+  -m, --marketplace Marketplace to install (default: mksglu/context-mode)
+  -h, --help        Show this help message
+
+Examples:
+  npx context-mode-install                      # Interactive, Claude Code global
+  npx context-mode-install --claude --global    # Claude Code global
+  npx context-mode-install --gemini --local     # Gemini CLI local
+  npx context-mode-install --all --global       # All runtimes global
+  npx context-mode-install -c -g -o -A ~/.custom
+`.trim());
+    process.exit(0);
+  }
+  
+  const marketplace = opts.marketplace || "mksglu/context-mode";
+  const location = opts.location || "global";
+  
+  console.log("=== context-mode-install ===");
+  console.log(`Marketplace: ${marketplace}`);
+  console.log(`Runtimes: ${opts.runtimes.map(r => RUNTIME_CONFIGS[r].name).join(", ")}`);
+  console.log(`Location: ${location}`);
+  
+  let successCount = 0;
+  
+  for (const runtime of opts.runtimes) {
+    const installPath = getInstallPath(runtime, location, opts.account);
+    
+    try {
+      if (installToRuntime(runtime, marketplace, installPath)) {
+        successCount++;
+      }
+    } catch (e: any) {
+      console.error(`Failed to install to ${RUNTIME_CONFIGS[runtime].name}: ${e.message}`);
+    }
+  }
+  
+  console.log("\n=== Installation Complete ===");
+  console.log(`Successfully installed to ${successCount}/${opts.runtimes.length} runtime(s)`);
+  console.log("\nRestart your CLI to activate the plugin.");
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds `npx context-mode-install` command that installs to multiple LLM CLI platforms, patterned after GSD (get-shit-done-cc) multi-runtime distribution model.

## Changes

- **New installer**: `src/install-https.ts` - Multi-LLM installer script
- **New documentation**: `INSTALL.md` - Complete installation guide
- **Updated README**: Added `npx context-mode-install` to all platform sections
- **Package.json**: Added binary export for `context-mode-install`

## Supported Runtimes

| Runtime | Flag | Config Directory |
|---------|------|------------------|
| Claude Code | `-c, --claude` | `~/.claude/` |
| Gemini CLI | `-g, --gemini` | `~/.gemini/` |
| OpenCode | `-o, --opencode` | `~/.config/opencode/` |
| Codex | `-x, --codex` | `~/.codex/` |
| VS Code Copilot | `-v, --vscode` | `~/.vscode/copilot/` |

## Usage

```bash
# Default (Claude Code global)
npx context-mode-install

# All runtimes
npx context-mode-install --all

# Specific runtimes
npx context-mode-install --claude --gemini --opencode

# Local install
npx context-mode-install --local
```

## Related

- GSD Multi-LLM: https://github.com/gsd-build/get-shit-done
- GSD NPM: https://www.npmjs.com/package/get-shit-done-cc