### PR TITLE
fix: replace hardcoded username in Windows non-ASCII path test

### DIFF
--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -39,8 +39,9 @@ describe("Runtime Detection", () => {
     });
 
     test("Windows: shell execute works with non-ASCII (Chinese) project path", async () => {
-      const chineseDir = "C:\\Users\\NINGMEI\\AppData\\Local\\Temp\\测试目录";
       const { mkdirSync, rmSync } = await import("node:fs");
+      const { tmpdir } = await import("node:os");
+      const chineseDir = join(tmpdir(), "测试目录");
       try { mkdirSync(chineseDir, { recursive: true }); } catch {}
       const chineseExecutor = new PolyglotExecutor({ runtimes, projectRoot: chineseDir });
       const r = await chineseExecutor.execute({ language: "shell", code: 'echo "chinese path ok"' });


### PR DESCRIPTION
## What

Replace a hardcoded Windows username in the non-ASCII path test with `os.tmpdir()`.

## Why

The test for Windows non-ASCII (Chinese) project paths used:

```ts
const chineseDir = "C:\\Users\\NINGMEI\\AppData\\Local\\Temp\\测试目录";
```

This hardcodes a specific Windows username (`NINGMEI`). On any machine where that user does not exist, `mkdirSync` silently fails (ENOENT), the executor is created with a non-existent `projectRoot`, and `spawn` fails with `ENOENT` instead of producing the expected output.

Fixes the test failing on all Windows machines except the original author's.

## How

Replace the hardcoded path with `join(tmpdir(), "测试目录")` — this resolves to the actual temp directory of the current user on any Windows machine (e.g. `C:\Users\lukas\AppData\Local\Temp\测试目录`).

```ts
// Before
const chineseDir = "C:\\Users\\NINGMEI\\AppData\\Local\\Temp\\测试目录";

// After
const { tmpdir } = await import("node:os");
const chineseDir = join(tmpdir(), "测试目录");
```

## Affected platforms

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] VS Code Copilot
- [ ] OpenCode
- [ ] Codex CLI
- [x] All platforms / core MCP server

## TDD (required)

### RED (failing test)

The test already existed and was failing on this machine (different username):

```
FAIL  tests/executor.test.ts > Runtime Detection > Windows: shell execute works with non-ASCII (Chinese) project path

AssertionError: Failed with stderr: spawn C:\Program Files\Git\usr\bin\bash.exe ENOENT

 - Expected  - 1
 + Received  + 1

 - 0
 + 1

  at assert.equal (tests/executor.test.ts:47:7)

Tests  1 failed | 75 passed | 10 skipped (86)
```

### GREEN (passing test)

After replacing with `os.tmpdir()`:

```
✓ tests/executor.test.ts > Runtime Detection > Windows: shell execute works with non-ASCII (Chinese) project path  93ms

Tests  75 passed | 10 skipped (86)
```

## Cross-platform verification

- [x] I've considered whether my change involves platform-specific behavior (file paths, stdin/stdout, child processes, shell commands, line endings)
- [x] I've asked an AI assistant (Claude, etc.) to review my code for cross-platform issues — especially around `node:fs`, `node:child_process`, and `node:path`

`os.tmpdir()` returns the correct platform temp directory on all OSes:
- Windows: `C:\Users\<user>\AppData\Local\Temp`
- macOS/Linux: `/tmp` or `$TMPDIR`

The non-ASCII subdirectory `测试目录` is preserved to keep validating the original intent of the test.

## Adapter checklist

Not applicable — this change only affects the test file.

## Test plan

- [x] `npm test` passes (746 tests — Chinese path test now green)
- [x] `npm run typecheck` passes
- [x] `/context-mode:ctx-doctor` — all checks PASS on local build
- [x] Tested on Windows (Node.js v24.12.0, Git Bash shell)

### Test output

```
✓ tests/executor.test.ts > Runtime Detection > Windows: shell execute works with non-ASCII (Chinese) project path  93ms

Tests  746 passed | 10 skipped (756)
Duration  39.93s
```

### Before/After comparison

| | Before | After |
|---|---|---|
| Test result | FAIL (ENOENT — user NINGMEI not found) | PASS |
| Temp path used | `C:\Users\NINGMEI\AppData\Local\Temp\测试目录` | `C:\Users\lukas\AppData\Local\Temp\测试目录` |
| Portable | ❌ Only works on one specific machine | ✅ Works on any Windows machine |

## Local development setup

- [x] Symlinked plugin cache to my local clone
- [x] Updated `settings.json` hook path to my local clone
- [x] Deleted `server.bundle.mjs` so `start.mjs` uses `build/server.js`
- [x] Killed cached MCP server, verified local server is running
- [x] Bumped version in `package.json` and confirmed with `/context-mode:ctx-doctor`

## Checklist

- [x] I've checked [existing PRs](https://github.com/mksglu/context-mode/pulls) to make sure this isn't a duplicate
- [x] I'm targeting the `next` branch
- [x] I've run the full test suite locally
- [x] Tests came first (TDD: red then green)
- [x] No breaking changes to existing tool interfaces
- [x] CI passes on all 3 platforms (Ubuntu, macOS, Windows)
