### PR TITLE
fix: use node:https in fetchLatestVersion to avoid Windows UV_HANDLE_…

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import * as p from "@clack/prompts";
 import color from "picocolors";
 import { execSync } from "node:child_process";
 import { readFileSync, cpSync, accessSync, existsSync, readdirSync, rmSync, closeSync, openSync, constants } from "node:fs";
+import { request as httpsRequest } from "node:https";
 import { resolve, dirname, join } from "node:path";
 import { tmpdir, devNull } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -122,14 +123,30 @@ function getLocalVersion(): string {
 }
 
 async function fetchLatestVersion(): Promise<string> {
-  try {
-    const resp = await fetch("https://registry.npmjs.org/context-mode/latest");
-    if (!resp.ok) return "unknown";
-    const data = (await resp.json()) as { version?: string };
-    return data.version ?? "unknown";
-  } catch {
-    return "unknown";
-  }
+  // Use node:https instead of global fetch to avoid a Windows libuv assertion
+  // (UV_HANDLE_CLOSING) caused by undici's connection-pool background threads
+  // racing with process.exit() teardown on Node.js v24+.
+  return new Promise((resolve) => {
+    const req = httpsRequest(
+      "https://registry.npmjs.org/context-mode/latest",
+      { headers: { Connection: "close" } },
+      (res) => {
+        let raw = "";
+        res.on("data", (chunk: Buffer) => { raw += chunk; });
+        res.on("end", () => {
+          try {
+            const data = JSON.parse(raw) as { version?: string };
+            resolve(data.version ?? "unknown");
+          } catch {
+            resolve("unknown");
+          }
+        });
+      },
+    );
+    req.on("error", () => resolve("unknown"));
+    req.setTimeout(5000, () => { req.destroy(); resolve("unknown"); });
+    req.end();
+  });
 }
 
 /* -------------------------------------------------------


### PR DESCRIPTION
…CLOSING crash

On Windows with Node.js v24+, calling process.exit() after using the global fetch() API causes a libuv assertion failure:

  Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c

The root cause is undici's connection-pool background threads racing with libuv handle teardown during process.exit(). Replace global fetch() with node:https.request() using Connection: close, which shuts down cleanly.

Fixes: context-mode doctor crash on Windows (Node.js v24+)

## What

<!-- Brief description of the change -->

## Why

<!-- What problem does this solve? Link to issue if applicable: Fixes #000 -->

## What

Replace global `fetch()` with `node:https.request()` in `fetchLatestVersion()` to prevent a Windows-only libuv assertion crash when running `context-mode doctor`.

## Why

On **Windows with Node.js v24+**, running `context-mode doctor` always exits with a native assertion failure after completing successfully:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

The process exits with code `-1073740791` (exit code 1 in shell), even though all diagnostics pass. This makes doctor unusable in CI and scripted setups because any caller treating non-zero exit as failure will report a broken install.

**Root cause:** `doctor()` calls `fetchLatestVersion()` which uses the global `fetch()` API backed by undici. Undici maintains a connection pool with background worker threads. When `process.exit()` is called immediately after `await fetchLatestVersion()` resolves, libuv teardown races with undici's thread cleanup, triggering the assertion in `async.c`.

## How

Replace `fetch()` with `node:https.request()` using `Connection: close`, which prevents connection keep-alive and allows the socket to close cleanly before `process.exit()` runs:

```ts
// Before — triggers UV_HANDLE_CLOSING assertion on Windows + Node.js v24+
async function fetchLatestVersion(): Promise<string> {
  try {
    const resp = await fetch("https://registry.npmjs.org/context-mode/latest");
    if (!resp.ok) return "unknown";
    const data = (await resp.json()) as { version?: string };
    return data.version ?? "unknown";
  } catch {
    return "unknown";
  }
}

// After — clean teardown, no assertion
import { request as httpsRequest } from "node:https";

async function fetchLatestVersion(): Promise<string> {
  return new Promise((resolve) => {
    const req = httpsRequest(
      "https://registry.npmjs.org/context-mode/latest",
      { headers: { Connection: "close" } },
      (res) => {
        let raw = "";
        res.on("data", (chunk: Buffer) => { raw += chunk; });
        res.on("end", () => {
          try {
            const data = JSON.parse(raw) as { version?: string };
            resolve(data.version ?? "unknown");
          } catch {
            resolve("unknown");
          }
        });
      },
    );
    req.on("error", () => resolve("unknown"));
    req.setTimeout(5000, () => { req.destroy(); resolve("unknown"); });
    req.end();
  });
}
```

`node:https` is a Node.js built-in and introduces no new dependencies. The 5 second timeout ensures the function never hangs. Behaviour is identical on macOS and Linux.

## Affected platforms

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] VS Code Copilot
- [ ] OpenCode
- [ ] Codex CLI
- [x] All platforms / core MCP server

## TDD (required)

### RED (failing test)

Running `context-mode doctor` with the original `fetch()`-based implementation on Windows (Node.js v24.12.0):

```
◆  FTS5 / better-sqlite3: PASS — native module works
◇  Checking versions...
▲  npm (MCP): WARN — local v1.0.7, latest v1.0.6
●  VS Code Copilot: not installed — using standalone MCP mode
└  Diagnostics complete!

Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76

exit: -1073740791 (code 1)
```

The diagnostics all pass but the process crashes during teardown.

### GREEN (passing test)

After replacing with `node:https.request()`:

```
◆  FTS5 / better-sqlite3: PASS — native module works
◇  Checking versions...
◆  npm (MCP): PASS — v1.0.7
●  VS Code Copilot: not installed — using standalone MCP mode
└  Diagnostics complete!

exit: 0
```

No assertion. Clean exit.

## Cross-platform verification

- [x] I've considered whether my change involves platform-specific behavior (file paths, stdin/stdout, child processes, shell commands, line endings)
- [x] I've asked an AI assistant (Claude, etc.) to review my code for cross-platform issues — especially around `node:fs`, `node:child_process`, and `node:path`

`node:https.request()` is a Node.js built-in available on all platforms. `Connection: close` is a standard HTTP/1.1 header. The implementation was tested on Windows and is functionally identical to the original `fetch()` approach on all platforms.

## Adapter checklist

Not applicable — this change only affects `src/cli.ts` (`doctor` command internals).

## Test plan

- [x] `npm test` passes (746 tests)
- [x] `npm run typecheck` passes
- [x] `context-mode doctor` — all checks PASS, exit code 0 on Windows (Node.js v24.12.0)
- [x] Tested in a live session with local MCP server

### Test output

```
Tests  746 passed | 10 skipped (756)
Duration  39.93s
```

### Before/After comparison

| | Before | After |
|---|---|---|
| `doctor` exit code (Windows) | `-1073740791` (crash) | `0` (clean) |
| Assertion failure | `UV_HANDLE_CLOSING in async.c` | None |
| Usable in CI | ❌ False negative on every run | ✅ Reliable exit code |
| macOS / Linux | ✅ No change | ✅ No change |

## Local development setup

- [x] Symlinked plugin cache to my local clone
- [x] Updated `settings.json` hook path to my local clone
- [x] Deleted `server.bundle.mjs` so `start.mjs` uses `build/server.js`
- [x] Killed cached MCP server, verified local server is running
- [x] Bumped version in `package.json` and confirmed with `context-mode doctor`

## Checklist

- [x] I've checked [existing PRs](https://github.com/mksglu/context-mode/pulls) to make sure this isn't a duplicate
- [x] I'm targeting the `next` branch
- [x] I've run the full test suite locally
- [x] Tests came first (TDD: red then green)
- [x] No breaking changes to existing tool interfaces
- [x] CI passes on all 3 platforms (Ubuntu, macOS, Windows)
