### PR TITLE
fix(windows): use forks pool on Windows to prevent ACCESS_VIOLATION crash

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
     testTimeout: 30_000,
-    pool: "threads",
+    pool: process.platform === "win32" ? "forks" : "threads",
   },
 });


### PR DESCRIPTION
## What

Switch vitest pool to `forks` on Windows (`process.platform === 'win32'`). No change on Linux/macOS (keeps `threads`).

## Why

`pool: 'threads'` causes a non-deterministic `STATUS_ACCESS_VIOLATION (0xC0000005)` crash on Windows when `executor.test.ts` and `stream-cap.test.ts` run concurrently — both files spawn and kill many child processes. Windows worker threads share a job object handle table; heavy subprocess churn from multiple threads simultaneously causes a race condition in the native layer.

The crash is preexisting on `upstream/next` (confirmed in CI) and is flaky: ~60% failure rate locally.

## How

One-line change in `vitest.config.ts`:
```ts
pool: process.platform === 'win32' ? 'forks' : 'threads',
```

`forks` spawns isolated child processes per test file — no shared handle table, no race. Linux/macOS keep `threads` for speed.

## Affected platforms

- [x] All platforms / core MCP server (Windows fix, no production code changed)

## TDD (required)

No new test needed — the fix is validated by running the existing suite:

### RED (failing test)

```
# Before fix — pool: 'threads'
Run 1: EXIT 0 ✓
Run 2: EXIT -1073741819 (ACCESS_VIOLATION) ✗
Run 3: EXIT -1073741819 (ACCESS_VIOLATION) ✗
Run 4: EXIT 0 ✓
Run 5: EXIT -1073741819 (ACCESS_VIOLATION) ✗
# 3/5 crash
```

### GREEN (passing test)

```
# After fix — pool: forks on Windows
Run 1: 785 passed | 10 skipped — EXIT 0 ✓
Run 2: 785 passed | 10 skipped — EXIT 0 ✓
Run 3: 785 passed | 10 skipped — EXIT 0 ✓
Run 4: 785 passed | 10 skipped — EXIT 0 ✓
Run 5: 785 passed | 10 skipped — EXIT 0 ✓
# 5/5 pass
```

## Cross-platform verification

- Windows: 5/5 runs pass locally (Node v24, Windows 11)
- Linux/macOS: unchanged (`threads` pool kept)

## Windows impact

This PR fixes Windows. Zero impact on Linux/macOS behavior.

## Checklist

- [x] I've checked existing PRs to make sure this isn't a duplicate
- [x] I'm targeting the `next` branch
- [x] I've run the full test suite locally
- [x] No breaking changes to existing tool interfaces
- [x] CI passes on all 3 platforms (Ubuntu, macOS, Windows)
