### PR TITLE
fix: kill process group on Unix to prevent orphaned children

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -14,14 +14,17 @@ import type { ExecResult } from "./types.js";
 
 const isWin = process.platform === "win32";
 
-/** Kill process tree — on Windows, proc.kill() only kills the shell, not children. */
+/** Kill process tree — on Windows uses taskkill /T; on Unix kills the process group. */
 function killTree(proc: ReturnType<typeof spawn>): void {
   if (isWin && proc.pid) {
     try {
       execSync(`taskkill /F /T /PID ${proc.pid}`, { stdio: "pipe" });
     } catch { /* already dead */ }
-  } else {
-    proc.kill("SIGKILL");
+  } else if (proc.pid) {
+    try {
+      // Kill entire process group (negative PID) to prevent orphaned children
+      process.kill(-proc.pid, "SIGKILL");
+    } catch { /* already dead */ }
   }
 }
 
@@ -66,7 +69,8 @@ export class PolyglotExecutor {
   cleanupBackgrounded(): void {
     for (const pid of this.#backgroundedPids) {
       try {
-        process.kill(pid, "SIGTERM");
+        // Kill process group on Unix to catch all children
+        process.kill(isWin ? pid : -pid, "SIGTERM");
       } catch { /* already dead */ }
     }
     this.#backgroundedPids.clear();
@@ -218,6 +222,8 @@ export class PolyglotExecutor {
         stdio: ["ignore", "pipe", "pipe"],
         env: this.#buildSafeEnv(cwd),
         shell: needsShell,
+        // On Unix, create a new process group so killTree can kill all children
+        detached: !isWin,
       });
 
       let timedOut = false;

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -635,6 +635,58 @@ describe("Timeout Handling", () => {
     assert.equal(r.timedOut, true);
   });
 
+  test("JS: infinite loop leaves no orphaned process after kill", async () => {
+    // Spawn a process that writes its PID then loops forever
+    const r = await executor.execute({
+      language: "javascript",
+      code: `process.stdout.write(String(process.pid)); while(true) {}`,
+      timeout: 1000,
+    });
+    assert.equal(r.timedOut, true);
+    const pid = parseInt(r.stdout.trim(), 10);
+    assert.ok(pid > 0, `Expected valid PID in stdout, got: "${r.stdout}"`);
+    // Give OS a moment to reap
+    await new Promise(r => setTimeout(r, 200));
+    let alive = false;
+    try {
+      process.kill(pid, 0); // signal 0 = check if alive
+      alive = true;
+    } catch { /* ESRCH = not found = good */ }
+    assert.equal(alive, false, `Process ${pid} should be dead after timeout kill`);
+  }, 10_000);
+
+  test("JS: child processes are killed with parent (no orphans)", async () => {
+    // Parent spawns a child that writes its PID to stderr, then both loop
+    const code = `
+      const { fork } = require("child_process");
+      if (process.env.__CHILD__) {
+        process.stderr.write(String(process.pid));
+        while(true) {}
+      } else {
+        process.stdout.write(String(process.pid));
+        const env = { ...process.env, __CHILD__: "1" };
+        fork(process.argv[1], { env });
+        while(true) {}
+      }
+    `;
+    const r = await executor.execute({
+      language: "javascript",
+      code,
+      timeout: 1500,
+    });
+    assert.equal(r.timedOut, true);
+    const parentPid = parseInt(r.stdout.trim(), 10);
+    const childPid = parseInt(r.stderr.trim(), 10);
+    assert.ok(parentPid > 0, `Expected parent PID, got: "${r.stdout}"`);
+    assert.ok(childPid > 0, `Expected child PID, got: "${r.stderr}"`);
+    await new Promise(r => setTimeout(r, 200));
+    for (const pid of [parentPid, childPid]) {
+      let alive = false;
+      try { process.kill(pid, 0); alive = true; } catch {}
+      assert.equal(alive, false, `Process ${pid} should be dead after group kill`);
+    }
+  }, 10_000);
+
   test("Shell: sleep times out", async () => {
     const r = await executor.execute({
       language: "shell",


### PR DESCRIPTION
## Summary
- Spawned processes now use `detached: true` on Unix, giving each its own process group
- `killTree()` sends SIGKILL to `-pid` (entire group) instead of just the single process
- `cleanupBackgrounded()` also kills process groups instead of individual PIDs
- Prevents `while(true) {}` loops (and their children) from surviving as orphaned processes consuming 100% CPU

## Root cause
On Unix, `proc.kill("SIGKILL")` only kills the immediate process. If the runtime (e.g. bun) forks internally, the child survives and gets reparented to PID 1. Two such orphans were found consuming 92% CPU each, running for 90+ minutes.

## Test plan
- [x] Added test: infinite loop process is dead after timeout kill
- [x] Added test: child processes spawned by parent are killed with the group
- [x] All 6 timeout tests pass
- [x] All 16 stream-cap tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)