### PR TITLE
fix(tests): reset guidance throttle between core-routing tests

### DIFF
--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 
 // Dynamic import for .mjs module
 let routePreToolUse: (
@@ -12,6 +12,7 @@ let routePreToolUse: (
   additionalContext?: string;
 } | null;
 
+let resetGuidanceThrottle: () => void;
 let ROUTING_BLOCK: string;
 let READ_GUIDANCE: string;
 let GREP_GUIDANCE: string;
@@ -19,11 +20,19 @@ let GREP_GUIDANCE: string;
 beforeAll(async () => {
   const mod = await import("../../hooks/core/routing.mjs");
   routePreToolUse = mod.routePreToolUse;
+  resetGuidanceThrottle = mod.resetGuidanceThrottle;
 
   const constants = await import("../../hooks/routing-block.mjs");
   ROUTING_BLOCK = constants.ROUTING_BLOCK;
   READ_GUIDANCE = constants.READ_GUIDANCE;
   GREP_GUIDANCE = constants.GREP_GUIDANCE;
+});
+
+// Reset throttle state between tests so each test evaluates routing
+// independently — without this, only the first test per tool type
+// receives guidance (the rest get null due to once-per-session throttle).
+beforeEach(() => {
+  if (typeof resetGuidanceThrottle === "function") resetGuidanceThrottle();
 });
 
 describe("routePreToolUse", () => {


### PR DESCRIPTION
## Summary

- The v1.0.21 guidance throttle (#113) causes 3 test failures in `core-routing.test.ts` because throttle state leaks between tests within the same vitest file
- Tests expecting `context` action for Bash only succeed on the first call per type — subsequent tests get `null` due to once-per-session throttle
- Adds `beforeEach(() => resetGuidanceThrottle())` to reset state between tests, matching the pattern already used in `guidance-throttle.test.ts`

## Failing tests (before fix)

```
FAIL  core-routing.test.ts > Bash tool > allows mkdir with BASH_GUIDANCE context
      expected null not to be null (line 89)

FAIL  core-routing.test.ts > Bash tool > allows npm install with BASH_GUIDANCE context
      expected null not to be null (line 95)

FAIL  core-routing.test.ts > Bash tool > does not false-positive on gradle in quoted text
      expected null not to be null (line 138)
```

## Test plan

- [x] All 28 core-routing tests pass after fix
- [x] Full test suite: no new failures introduced (6 pre-existing failures unrelated to this change)


🤖 Generated with [Claude Code](https://claude.com/claude-code)