### PR TITLE
fix: strip UTF-8 BOM from stdin before JSON.parse in hooks

### DIFF
--- a/hooks/core/stdin.mjs
+++ b/hooks/core/stdin.mjs
@@ -12,7 +12,7 @@ export function readStdin() {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => { data += chunk; });
-    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("end", () => resolve(data.replace(/^\uFEFF/, "")));
     process.stdin.on("error", reject);
     process.stdin.resume();
   });

--- a/hooks/session-helpers.mjs
+++ b/hooks/session-helpers.mjs
@@ -86,7 +86,7 @@ export function readStdin() {
     let data = "";
     process.stdin.setEncoding("utf-8");
     process.stdin.on("data", (chunk) => { data += chunk; });
-    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("end", () => resolve(data.replace(/^\uFEFF/, "")));
     process.stdin.on("error", reject);
     process.stdin.resume();
   });

--- a/tests/hooks/cursor-hooks.test.ts
+++ b/tests/hooks/cursor-hooks.test.ts
@@ -34,6 +34,21 @@ function runHook(hookFile: string, input: Record<string, unknown>, env?: Record<
   };
 }
 
+function runHookWithBOM(hookFile: string, input: Record<string, unknown>, env?: Record<string, string>): HookResult {
+  const result = spawnSync("node", [join(HOOKS_DIR, hookFile)], {
+    input: "\uFEFF" + JSON.stringify(input),
+    encoding: "utf-8",
+    timeout: 10000,
+    env: { ...process.env, ...env },
+  });
+
+  return {
+    exitCode: result.status ?? 1,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
+  };
+}
+
 describe("Cursor hooks", () => {
   let tempDir: string;
   let dbPath: string;
@@ -234,6 +249,45 @@ describe("Cursor hooks", () => {
       expect(startResult.exitCode).toBe(0);
       const payload = JSON.parse(startResult.stdout) as Record<string, unknown>;
       expect(String(payload.additional_context)).toContain("session_knowledge");
+    });
+  });
+
+  describe("UTF-8 BOM handling", () => {
+    test("pretooluse.mjs parses BOM-prefixed stdin without error", () => {
+      const result = runHookWithBOM("pretooluse.mjs", {
+        tool_name: "Write",
+        tool_input: { file_path: `${tempDir}/test.md`, content: "hello" },
+        conversation_id: "cursor-bom-test-1",
+        workspace_roots: [tempDir],
+      }, {});
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("{\"agent_message\":\"\"}");
+    });
+
+    test("posttooluse.mjs parses BOM-prefixed stdin without error", () => {
+      const result = runHookWithBOM("posttooluse.mjs", {
+        tool_name: "Shell",
+        tool_input: { command: "echo ok" },
+        tool_output: "ok",
+        conversation_id: "cursor-bom-test-2",
+        cwd: tempDir,
+      }, cursorEnv());
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("{\"additional_context\":\"\"}");
+    });
+
+    test("sessionstart.mjs parses BOM-prefixed stdin without error", () => {
+      const result = runHookWithBOM("sessionstart.mjs", {
+        source: "startup",
+        conversation_id: "cursor-bom-test-3",
+        cwd: tempDir,
+      }, cursorEnv());
+
+      expect(result.exitCode).toBe(0);
+      const payload = JSON.parse(result.stdout) as Record<string, unknown>;
+      expect(String(payload.additional_context)).toContain("context-mode");
     });
   });
 });

--- a/tests/hooks/integration.test.ts
+++ b/tests/hooks/integration.test.ts
@@ -57,6 +57,20 @@ function runHook(input: Record<string, unknown>, env?: Record<string, string>): 
   };
 }
 
+function runHookWithBOM(input: Record<string, unknown>, env?: Record<string, string>): HookResult {
+  const result = spawnSync("node", [HOOK_PATH], {
+    input: "\uFEFF" + JSON.stringify(input),
+    encoding: "utf-8",
+    timeout: 5000,
+    env: { ...process.env, ...env },
+  });
+  return {
+    exitCode: result.status ?? 1,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
+  };
+}
+
 /** Assert hook redirects Bash command to an echo message via updatedInput */
 function assertRedirect(result: HookResult, substringInEcho: string) {
   assert.equal(result.exitCode, 0, `Expected exit 0, got ${result.exitCode}`);
@@ -818,5 +832,23 @@ describe("Routing instructions — hookless platform gate", () => {
     }
 
     expect(existsSync(resolve(projectDir, "AGENTS.md"))).toBe(false);
+  });
+});
+
+describe("UTF-8 BOM handling (core/stdin.mjs path)", () => {
+  test("pretooluse.mjs parses BOM-prefixed stdin without error", () => {
+    const result = runHookWithBOM({
+      tool_name: "Glob",
+      tool_input: { pattern: "**/*.ts" },
+    });
+    assertPassthrough(result);
+  });
+
+  test("pretooluse.mjs handles BOM-prefixed Bash input correctly", () => {
+    const result = runHookWithBOM({
+      tool_name: "Bash",
+      tool_input: { command: "curl -s http://example.com" },
+    });
+    assertRedirect(result, "context-mode");
   });
 });


### PR DESCRIPTION
## What

Strip leading UTF-8 BOM (`U+FEFF`) from stdin in both `readStdin()` implementations before returning the string to callers.

## Why

On Windows, Cursor pipes hook stdin with a leading UTF-8 BOM. `JSON.parse()` rejects BOM at position 0, crashing every hook (`preToolUse`, `postToolUse`, `sessionStart`) with:

```
SyntaxError: Unexpected token '', "{"convers"... is not valid JSON
```

This makes context-mode completely unusable on Cursor for Windows users.

## How

Added `.replace(/^\uFEFF/, "")` to the resolve callback of both `readStdin()` functions. The `^` anchor ensures only a leading BOM is stripped — mid-string `\uFEFF` inside JSON string values is never touched. On platforms that don't send a BOM, the regex is a no-op.

Changed files:
- `hooks/core/stdin.mjs` — used by Claude Code, VS Code Copilot, Kiro, Gemini CLI pretooluse hooks
- `hooks/session-helpers.mjs` — used by Cursor, session, posttooluse, precompact hooks

## Affected platforms

- [x] Claude Code
- [x] Gemini CLI
- [x] VS Code Copilot
- [x] OpenCode
- [x] Codex CLI
- [x] All platforms / core MCP server

Both `readStdin()` implementations are patched. The fix is defensive — it's a no-op on platforms that don't send a BOM, but protects all platforms if they ever do.

## TDD (required)

### RED (failing test)

Tests written first, run without the fix applied:

```
× tests/hooks/cursor-hooks.test.ts > Cursor hooks > UTF-8 BOM handling > pretooluse.mjs parses BOM-prefixed stdin without error 83ms
✓ tests/hooks/cursor-hooks.test.ts > Cursor hooks > UTF-8 BOM handling > posttooluse.mjs parses BOM-prefixed stdin without error 77ms
✓ tests/hooks/cursor-hooks.test.ts > Cursor hooks > UTF-8 BOM handling > sessionstart.mjs parses BOM-prefixed stdin without error 90ms
× tests/hooks/integration.test.ts > UTF-8 BOM handling (core/stdin.mjs path) > pretooluse.mjs parses BOM-prefixed stdin without error 76ms
× tests/hooks/integration.test.ts > UTF-8 BOM handling (core/stdin.mjs path) > pretooluse.mjs handles BOM-prefixed Bash input correctly 77ms
```

3 of 5 BOM tests fail (the 2 Cursor session hooks that pass have try/catch wrappers around JSON.parse in their hook scripts, masking the error — but the pretooluse path crashes).

### GREEN (passing test)

After applying the fix:

```
✓ tests/hooks/cursor-hooks.test.ts > Cursor hooks > UTF-8 BOM handling > pretooluse.mjs parses BOM-prefixed stdin without error 86ms
✓ tests/hooks/cursor-hooks.test.ts > Cursor hooks > UTF-8 BOM handling > posttooluse.mjs parses BOM-prefixed stdin without error 79ms
✓ tests/hooks/cursor-hooks.test.ts > Cursor hooks > UTF-8 BOM handling > sessionstart.mjs parses BOM-prefixed stdin without error 85ms
✓ tests/hooks/integration.test.ts > UTF-8 BOM handling (core/stdin.mjs path) > pretooluse.mjs parses BOM-prefixed stdin without error 70ms
✓ tests/hooks/integration.test.ts > UTF-8 BOM handling (core/stdin.mjs path) > pretooluse.mjs handles BOM-prefixed Bash input correctly 69ms
```

All 5 pass.

## Cross-platform verification

- [x] I've considered whether my change involves platform-specific behavior (file paths, stdin/stdout, child processes, shell commands, line endings)
- [x] I've asked an AI assistant (Claude, etc.) to review my code for cross-platform issues — especially around `node:fs`, `node:child_process`, and `node:path`

The fix is specifically for a Windows/Cursor stdin encoding issue. The `^\uFEFF` regex is a no-op on macOS/Linux where stdin does not carry a BOM.

## Adapter checklist

- [x] Hook scripts work on all affected platforms (`hooks/*.mjs`, `hooks/gemini-cli/`, `hooks/vscode-copilot/`)
- [ ] Routing instruction files updated if tool names or behavior changed (`configs/*/`) — N/A, no tool name or behavior changes
- [x] Adapter tests pass (`tests/adapters/`)
- [ ] `writeRoutingInstructions()` still works for all adapters — N/A, not affected

## Test plan

- [x] Tests added to **existing** test files (do NOT create new test files — see CONTRIBUTING.md)
- [x] `npm test` passes (no new failures introduced)
- [x] `npm run typecheck` passes
- [ ] `/context-mode:ctx-doctor` — N/A, hook-only change, no MCP server changes
- [ ] Tested in a live session with my local MCP server — Verified by piping BOM-prefixed JSON to the hook script directly

### Test output

```
Tests  6 failed | 57 passed (63)
```

All 6 failures are pre-existing on `main` (Security Policy tests fail on Windows due to HOME path differences; end-to-end flow test has a session_knowledge assertion issue). Zero new failures introduced.

### Before/After comparison

**Before (no fix):** Cursor hook crashes on every tool call with `SyntaxError: Unexpected token '﻿'`
**After (with fix):** Hook returns valid JSON response `{"agent_message":""}` and processes normally.

## Checklist

- [x] I've checked existing PRs to make sure this isn't a duplicate
- [x] I'm targeting the `main` branch
- [x] I've run the full test suite locally
- [x] Tests came first (TDD: red then green)
- [x] No breaking changes to existing tool interfaces
- [x] I've compared output quality before and after my change
- [ ] CI passes on all 3 platforms (Ubuntu, macOS, Windows) — to be verified by CI