### PR TITLE
fix(ctx_search): return early with clear error when index is empty

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -951,6 +951,20 @@ server.registerTool(
   async (params) => {
     try {
       const store = getStore();
+
+      // Guard: refuse to search when the index is empty — the result would
+      // always be empty, and surfacing ctx_search to the model in this state
+      // leads to hallucinated "no results" answers in new sessions.
+      if (store.getStats().chunks === 0) {
+        return trackResponse("ctx_search", {
+          content: [{
+            type: "text" as const,
+            text: "No indexed content found. Use ctx_batch_execute or ctx_index to index content before searching.",
+          }],
+          isError: true,
+        });
+      }
+
       const raw = params as Record<string, unknown>;
 
       // Normalize: accept both query (string) and queries (array)


### PR DESCRIPTION
## Problem

When `ctx_search` is called in a new session where no content has been indexed yet, it silently returns empty results. This causes the model to give misleading or hallucinated answers instead of directing the user to index content first.

**Root cause**: `ctx_search` had no guard against an empty index. A new session always starts with 0 chunks, so any search call would return `"No results found."` — which the model may misinterpret as a valid (but empty) answer.

## Solution

Added an early-return guard at the top of the `ctx_search` handler that checks `store.getStats().chunks === 0` before executing the search. When the index is empty, it returns an `isError: true` response with an actionable message:

> "No indexed content found. Use ctx_batch_execute or ctx_index to index content before searching."

## Changes

- `src/server.ts`: 14-line guard added to `ctx_search` handler

## Future work

A stronger fix would dynamically remove `ctx_search` from the `tools/list` MCP response when the index is empty, so the tool is never visible to the model in that state. This would require overriding the `McpServer` tool list handler and is left as a follow-up.

## Testing

Verified manually: calling `ctx_search` on a fresh session (no prior `ctx_batch_execute`) now returns the error message immediately instead of an empty result.