### PR TITLE
Update README with npm build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
    git clone https://github.com/mksglu/context-mode.git ~/.pi/extensions/context-mode
    cd ~/.pi/extensions/context-mode
    npm install
+   npm run build
    ```
 
 2. Add to `~/.pi/settings/mcp.json` (or `.pi/settings/mcp.json` for project-level):


### PR DESCRIPTION
## What
Add build step to for pi agent extension installation instructions

## Why
Without the build stesp. the context mode extension for pi would fail to load with error unable to find module `../../../build/pi-extension.js`

## How
Added the build step to ensure that the build folder is genrated and the `pi-extension.js` is present in the specified path

## Affected platforms

<!-- Check all platforms affected by this change -->

- [X] PI Agent

## TDD (required)

Every PR must include tests. We follow **red-green-refactor**:

1. **RED** — Write a failing test that describes the behavior you want. Paste the failure output below.
2. **GREEN** — Write the minimum code to make that test pass. Paste the passing output below.
3. **Refactor** — Clean up while keeping tests green.

### RED (failing test)

Pi editor with context-mode extension fails to loads ith below mentioned error.  The extension is installed based  on instruction provided in the README.md file. The readme.md instrcution is missing essential step to run npm build.
The following is the error displayed
```
Extension issues]
  ~/.pi/extensions/context-mode/.pi/extensions/context-mode/index.ts
    Failed to load extension: Cannot find module '../../../build/pi-extension.js'
Require stack:
- ~/.pi/extensions/context-mode/.pi/extensions/context-mode/index.ts
```

### GREEN (passing test)
Pi editor with context-mode extension installed by  following the instruction provided in the README.md file loads withot an error.
```
```

</details>
