### PR TITLE
Shorten tool and skill descriptions for command palette readability

### DIFF
--- a/skills/context-mode/SKILL.md
+++ b/skills/context-mode/SKILL.md
@@ -1,20 +1,6 @@
 ---
 name: context-mode
-description: |
-  Use context-mode tools (ctx_execute, ctx_execute_file) instead of Bash/cat when processing
-  large outputs. Triggers: "analyze logs", "summarize output", "process data",
-  "parse JSON", "filter results", "extract errors", "check build output",
-  "analyze dependencies", "process API response", "large file analysis",
-  "page snapshot", "browser snapshot", "DOM structure", "inspect page",
-  "accessibility tree", "Playwright snapshot",
-  "run tests", "test output", "coverage report", "git log", "recent commits",
-  "diff between branches", "list containers", "pod status", "disk usage",
-  "fetch docs", "API reference", "index documentation",
-  "call API", "check response", "query results",
-  "find TODOs", "count lines", "codebase statistics", "security audit",
-  "outdated packages", "dependency tree", "cloud resources", "CI/CD output".
-  Also triggers on ANY MCP tool output that may exceed 20 lines.
-  Subagent routing is handled automatically via PreToolUse hook.
+description: "Route large outputs through sandboxed context-mode tools instead of Bash or Read."
 ---
 
 # Context Mode: Default for All Large Output

--- a/skills/ctx-doctor/SKILL.md
+++ b/skills/ctx-doctor/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: ctx-doctor
-description: |
-  Run context-mode diagnostics. Checks runtimes, hooks, FTS5,
-  plugin registration, npm and marketplace versions.
-  Trigger: /context-mode:ctx-doctor
+description: "Run context-mode diagnostics and display results."
 user-invocable: true
 ---
 
 # Context Mode Doctor
 
-Run diagnostics and display results directly in the conversation.
+Run diagnostics and display results directly in the conversation. Trigger: `/context-mode:ctx-doctor`
 
 ## Instructions
 

--- a/skills/ctx-stats/SKILL.md
+++ b/skills/ctx-stats/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: ctx-stats
-description: |
-  Show how much context window context-mode saved this session.
-  Displays token consumption, context savings ratio, and per-tool breakdown.
-  Trigger: /context-mode:ctx-stats
+description: "Show context window savings for this session."
 user-invocable: true
 ---
 
 # Context Mode Stats
 
-Show context savings for the current session.
+Show context savings for the current session. Trigger: `/context-mode:ctx-stats`
 
 ## Instructions
 

--- a/skills/ctx-upgrade/SKILL.md
+++ b/skills/ctx-upgrade/SKILL.md
@@ -1,15 +1,12 @@
 ---
 name: ctx-upgrade
-description: |
-  Update context-mode from GitHub and fix hooks/settings.
-  Pulls latest, builds, installs, updates npm global, configures hooks.
-  Trigger: /context-mode:ctx-upgrade
+description: "Upgrade context-mode to the latest version."
 user-invocable: true
 ---
 
 # Context Mode Upgrade
 
-Pull latest from GitHub and reinstall the plugin.
+Pull latest from GitHub and reinstall the plugin. Trigger: `/context-mode:ctx-upgrade`
 
 ## Instructions
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -385,7 +385,7 @@ server.registerTool(
   "ctx_execute",
   {
     title: "Execute Code",
-    description: `MANDATORY: Use for any command where output exceeds 20 lines. Execute code in a sandboxed subprocess. Only stdout enters context — raw data stays in the subprocess.${bunNote} Available: ${langList}.\n\nPREFER THIS OVER BASH for: API calls (gh, curl, aws), test runners (npm test, pytest), git queries (git log, git diff), data processing, and ANY CLI command that may produce large output. Bash should only be used for file mutations, git writes, and navigation.`,
+    description: `Execute code in a sandboxed subprocess. Only stdout enters context — raw data stays isolated. Available: ${langList}.`,
     inputSchema: z.object({
       language: z
         .enum([
@@ -680,7 +680,7 @@ server.registerTool(
   {
     title: "Execute File Processing",
     description:
-      "Read a file and process it without loading contents into context. The file is read into a FILE_CONTENT variable inside the sandbox. Only your printed summary enters context.\n\nPREFER THIS OVER Read/cat for: log files, data files (CSV, JSON, XML), large source files for analysis, and any file where you need to extract specific information rather than read the entire content.",
+      "Process a file in a sandbox without loading contents into context. Only your printed summary enters context.",
     inputSchema: z.object({
       path: z
         .string()
@@ -811,18 +811,7 @@ server.registerTool(
   {
     title: "Index Content",
     description:
-      "Index documentation or knowledge content into a searchable BM25 knowledge base. " +
-      "Chunks markdown by headings (keeping code blocks intact) and stores in ephemeral FTS5 database. " +
-      "The full content does NOT stay in context — only a brief summary is returned.\n\n" +
-      "WHEN TO USE:\n" +
-      "- Documentation from Context7, Skills, or MCP tools (API docs, framework guides, code examples)\n" +
-      "- API references (endpoint details, parameter specs, response schemas)\n" +
-      "- MCP tools/list output (exact tool signatures and descriptions)\n" +
-      "- Skill prompts and instructions that are too large for context\n" +
-      "- README files, migration guides, changelog entries\n" +
-      "- Any content with code examples you may need to reference precisely\n\n" +
-      "After indexing, use 'search' to retrieve specific sections on-demand.\n" +
-      "Do NOT use for: log files, test output, CSV, build output — use 'execute_file' for those.",
+      "Index content into a searchable FTS5 knowledge base. Content stays out of context — use search to query later.",
     inputSchema: z.object({
       content: z
         .string()
@@ -935,9 +924,7 @@ server.registerTool(
   {
     title: "Search Indexed Content",
     description:
-      "Search indexed content. Requires prior indexing via ctx_batch_execute, ctx_index, or ctx_fetch_and_index. " +
-      "Pass ALL search questions as queries array in ONE call.\n\n" +
-      "TIPS: 2-4 specific terms per query. Use 'source' to scope results.",
+      "Search indexed content. Pass all queries as an array in one call.",
     inputSchema: z.object({
       queries: z.preprocess(coerceJsonArray, z
         .array(z.string())
@@ -1175,10 +1162,7 @@ server.registerTool(
   {
     title: "Fetch & Index URL",
     description:
-      "Fetches URL content, converts HTML to markdown, indexes into searchable knowledge base, " +
-      "and returns a ~3KB preview. Full content stays in sandbox — use search() for deeper lookups.\n\n" +
-      "Better than WebFetch: preview is immediate, full content is searchable, raw HTML never enters context.\n\n" +
-      "Content-type aware: HTML is converted to markdown, JSON is chunked by key paths, plain text is indexed directly.",
+      "Fetch a URL, convert to markdown, and index into the knowledge base. Returns a preview.",
     inputSchema: z.object({
       url: z.string().describe("The URL to fetch and index"),
       source: z
@@ -1334,11 +1318,7 @@ server.registerTool(
   {
     title: "Batch Execute & Search",
     description:
-      "Execute multiple commands in ONE call, auto-index all output, and search with multiple queries. " +
-      "Returns search results directly — no follow-up calls needed.\n\n" +
-      "THIS IS THE PRIMARY TOOL. Use this instead of multiple execute() calls.\n\n" +
-      "One batch_execute call replaces 30+ execute calls + 10+ search calls.\n" +
-      "Provide all commands to run and all queries to search — everything happens in one round trip.",
+      "Run multiple commands, auto-index output, and search — all in one call.",
     inputSchema: z.object({
       commands: z.preprocess(coerceCommandsArray, z
         .array(
@@ -1547,9 +1527,7 @@ server.registerTool(
   {
     title: "Session Statistics",
     description:
-      "Returns context consumption statistics for the current session. " +
-      "Shows total bytes returned to context, breakdown by tool, call counts, " +
-      "estimated token usage, and context savings ratio.",
+      "Show context consumption stats, token usage, and savings ratio for this session.",
     inputSchema: z.object({}),
   },
   async () => {
@@ -1793,8 +1771,7 @@ server.registerTool(
   {
     title: "Run Diagnostics",
     description:
-      "Diagnose context-mode installation. Runs all checks server-side and " +
-      "returns results as a markdown checklist. No CLI execution needed.",
+      "Diagnose context-mode installation and return results as a markdown checklist.",
     inputSchema: z.object({}),
   },
   async () => {
@@ -1867,10 +1844,7 @@ server.registerTool(
   {
     title: "Upgrade Plugin",
     description:
-      "Upgrade context-mode to the latest version. Returns a shell command to execute. " +
-      "You MUST run the returned command using your shell tool (Bash, shell_execute, " +
-      "run_in_terminal, etc.) and display the output as a checklist. " +
-      "Tell the user to restart their session after upgrade.",
+      "Return a shell command to upgrade context-mode to the latest version.",
     inputSchema: z.object({}),
   },
   async () => {

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -1042,3 +1042,103 @@ describe("ctx_upgrade tool: inline fallback for missing CLI", () => {
     expect(serverSrc).toMatch(/existsSync\(fallbackPath\)/);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tool description length constraints (Issue #169)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("Tool description length constraints", () => {
+  const serverSrc = readFileSync(
+    resolve(__dirname, "../../src/server.ts"),
+    "utf-8",
+  );
+
+  const toolNames = [
+    "ctx_execute",
+    "ctx_execute_file",
+    "ctx_index",
+    "ctx_search",
+    "ctx_fetch_and_index",
+    "ctx_batch_execute",
+    "ctx_stats",
+    "ctx_doctor",
+    "ctx_upgrade",
+  ];
+
+  for (const tool of toolNames) {
+    test(`${tool} description should not contain multi-paragraph text`, () => {
+      const blockPattern = new RegExp(
+        `registerTool\\(\\s*"${tool}"[\\s\\S]*?description:\\s*`,
+      );
+      const match = serverSrc.match(blockPattern);
+      expect(match).toBeTruthy();
+
+      const afterDesc = serverSrc.slice(
+        (match?.index ?? 0) + (match?.[0]?.length ?? 0),
+      );
+
+      // Extract the description value (handle template literals and concatenated strings)
+      let desc = "";
+      if (afterDesc.startsWith("`")) {
+        const end = afterDesc.indexOf("`", 1);
+        desc = afterDesc.slice(1, end);
+      } else if (afterDesc.startsWith('"')) {
+        // Handle concatenated strings: "..." + "..." + "..."
+        const lines: string[] = [];
+        let remaining = afterDesc;
+        while (remaining.startsWith('"')) {
+          const end = remaining.indexOf('"', 1);
+          lines.push(remaining.slice(1, end));
+          remaining = remaining.slice(end + 1).replace(/^\s*\+\s*/, "");
+        }
+        desc = lines.join("");
+      }
+
+      // Replace template variables with placeholder text
+      desc = desc.replace(/\$\{[^}]+\}/g, "PLACEHOLDER");
+      // Normalize escaped newlines
+      desc = desc.replace(/\\n/g, "\n");
+
+      // Must not contain double newlines (multi-paragraph)
+      expect(desc).not.toContain("\n\n");
+    });
+  }
+
+  test("descriptions do not contain verbose routing guidance", () => {
+    const verboseMarkers = [
+      "PREFER THIS OVER",
+      "WHEN TO USE:",
+      "One batch_execute call replaces",
+      "Better than WebFetch",
+      "You MUST run the returned command",
+    ];
+
+    for (const marker of verboseMarkers) {
+      const descRegex =
+        /registerTool\(\s*"ctx_\w+"[\s\S]*?description:\s*(?:`[^`]*`|"[^"]*(?:"\s*\+\s*"[^"]*)*")/g;
+      const matches = [...serverSrc.matchAll(descRegex)];
+      for (const m of matches) {
+        expect(m[0]).not.toContain(marker);
+      }
+    }
+  });
+});
+
+describe("Skill description format", () => {
+  const skillDir = resolve(__dirname, "../../skills");
+  const skills = ["context-mode", "ctx-doctor", "ctx-stats", "ctx-upgrade"];
+
+  for (const skill of skills) {
+    test(`${skill} SKILL.md has a concise single-line description`, () => {
+      const content = readFileSync(
+        resolve(skillDir, skill, "SKILL.md"),
+        "utf-8",
+      );
+      const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+      expect(frontmatter).toBeTruthy();
+
+      // Description should NOT use YAML block scalar (| or >)
+      expect(frontmatter![1]).not.toMatch(/description:\s*[|>]/);
+    });
+  }
+});


### PR DESCRIPTION
Fixes #169

Tool descriptions were wrapping and getting truncated in command palettes (OpenCode, Claude Code, etc). This shortens all 9 MCP tool descriptions and 4 skill frontmatter descriptions to clean single-line summaries.

The detailed routing guidance still lives in SKILL.md body and the PreToolUse hook, so LLM tool selection isn't affected.

### Changes

- `src/server.ts` — shortened all `registerTool()` description fields
- `skills/*/SKILL.md` — replaced multi-line YAML block scalars with single-line descriptions
- `tests/core/server.test.ts` — added regression tests for description length and format

### Before / After

| Tool | Before | After |
|------|--------|-------|
| ctx_execute | ~460 chars, multi-paragraph | ~115 chars, single line |
| ctx_index | ~550 chars, WHEN TO USE list | ~95 chars, single line |
| ctx_batch_execute | ~280 chars, THIS IS THE PRIMARY TOOL block | ~70 chars, single line |
| ctx_fetch_and_index | ~290 chars, Better than WebFetch block | ~80 chars, single line |
| (all others) | similar reductions | single line |

### Test plan
- [x] `npx vitest run tests/core/server.test.ts` — all 73 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] Pre-existing failures (security compile, Rust executor) unchanged