### PR TITLE
fix(hooks): clean stale hook paths from settings during upgrade

### DIFF
--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -114,3 +114,34 @@ export function buildHookCommand(hookType: HookType, pluginRoot?: string): strin
   }
   return `context-mode hook claude-code ${hookType.toLowerCase()}`;
 }
+
+/**
+ * Extract the hook script file path from a command string.
+ * Returns the path if the command uses the `node "/path/to/hook.mjs"` format,
+ * or null if it uses the CLI dispatcher format (which is path-independent).
+ *
+ * Handles both quoted and unquoted paths, and both forward/back slashes.
+ */
+export function extractHookScriptPath(command: string): string | null {
+  // Match: node "/path/to/hooks/scriptname.mjs" or node /path/to/hooks/scriptname.mjs
+  const match = command.match(/node\s+"?([^"]+\.mjs)"?/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Check if a hook entry is a context-mode hook (any hook type).
+ * Broader than `isContextModeHook` — matches any context-mode script name
+ * without requiring a specific hookType.
+ */
+export function isAnyContextModeHook(
+  entry: { hooks?: Array<{ command?: string }> },
+): boolean {
+  const scriptNames = Object.values(HOOK_SCRIPTS);
+  return (
+    entry.hooks?.some((h) =>
+      h.command != null &&
+      (scriptNames.some((s) => h.command!.includes(s)) ||
+        h.command.includes("context-mode hook")),
+    ) ?? false
+  );
+}

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -21,6 +21,7 @@ import {
   mkdirSync,
   copyFileSync,
   accessSync,
+  existsSync,
   readdirSync,
   chmodSync,
   constants,
@@ -49,6 +50,8 @@ import {
   HOOK_SCRIPTS,
   PRE_TOOL_USE_MATCHER_PATTERN,
   isContextModeHook,
+  isAnyContextModeHook,
+  extractHookScriptPath,
   buildHookCommand,
   type HookType,
 } from "./hooks.js";
@@ -497,6 +500,41 @@ export class ClaudeCodeAdapter implements HookAdapter {
     const hooks = (settings.hooks ?? {}) as Record<string, unknown>;
     const changes: string[] = [];
 
+    // Remove stale context-mode hook entries across ALL hook types (fixes #187).
+    // After a marketplace auto-update or version change, settings.json may contain
+    // hardcoded paths pointing to deleted version directories (e.g., .../0.9.17/hooks/...).
+    // Clean these before registering fresh entries to prevent SessionStart errors.
+    for (const hookType of Object.keys(hooks)) {
+      const entries = hooks[hookType];
+      if (!Array.isArray(entries)) continue;
+
+      const filtered = entries.filter((entry: Record<string, unknown>) => {
+        const typedEntry = entry as { hooks?: Array<{ command?: string }> };
+        if (!isAnyContextModeHook(typedEntry)) return true; // preserve non-context-mode hooks
+
+        // Keep CLI dispatcher entries (path-independent, never stale)
+        const commands = typedEntry.hooks ?? [];
+        const hasOnlyDispatcherCommands = commands.every(
+          (h) => !h.command || !extractHookScriptPath(h.command),
+        );
+        if (hasOnlyDispatcherCommands) return true;
+
+        // For node path commands, check if the referenced script file exists
+        return commands.every((h) => {
+          const scriptPath = h.command ? extractHookScriptPath(h.command) : null;
+          if (!scriptPath) return true; // not a path-based command
+          return existsSync(scriptPath);
+        });
+      });
+
+      const removed = entries.length - filtered.length;
+      if (removed > 0) {
+        hooks[hookType] = filtered;
+        changes.push(`Removed ${removed} stale ${hookType} hook(s)`);
+      }
+    }
+
+    // Register fresh hooks for required hook types
     const hookTypes: HookType[] = [
       HOOK_TYPES.PRE_TOOL_USE,
       HOOK_TYPES.SESSION_START,

--- a/tests/adapters/claude-code.test.ts
+++ b/tests/adapters/claude-code.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createHash } from "node:crypto";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { ClaudeCodeAdapter } from "../../src/adapters/claude-code/index.js";
 
 describe("ClaudeCodeAdapter", () => {
@@ -312,6 +312,164 @@ describe("ClaudeCodeAdapter", () => {
       const sessionStart = results.find((r) => r.check === "SessionStart hook");
       expect(preToolUse?.status).toBe("pass");
       expect(sessionStart?.status).toBe("pass");
+    });
+  });
+
+  // ── configureAllHooks — stale hook cleanup (Issue #187) ──
+
+  describe("configureAllHooks", () => {
+    let tempDir: string;
+    let pluginRoot: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "claude-hooks-test-"));
+      pluginRoot = mkdtempSync(join(tmpdir(), "plugin-root-hooks-"));
+      // Create hook scripts in the pluginRoot so they're "valid"
+      mkdirSync(join(pluginRoot, "hooks"), { recursive: true });
+      writeFileSync(join(pluginRoot, "hooks", "pretooluse.mjs"), "");
+      writeFileSync(join(pluginRoot, "hooks", "sessionstart.mjs"), "");
+      Object.defineProperty(adapter, "getSettingsPath", {
+        value: () => join(tempDir, "settings.json"),
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+      rmSync(pluginRoot, { recursive: true, force: true });
+    });
+
+    it("removes stale hook entries pointing to non-existent paths", () => {
+      const staleRoot = "/tmp/non-existent-old-version-dir";
+      writeFileSync(
+        join(tempDir, "settings.json"),
+        JSON.stringify({
+          hooks: {
+            SessionStart: [{
+              matcher: "",
+              hooks: [{ type: "command", command: `node "${staleRoot}/hooks/sessionstart.mjs"` }],
+            }],
+            PreToolUse: [{
+              matcher: "Bash",
+              hooks: [{ type: "command", command: `node "${staleRoot}/hooks/pretooluse.mjs"` }],
+            }],
+          },
+        }),
+      );
+
+      const changes = adapter.configureAllHooks(pluginRoot);
+      expect(changes).toContain("Removed 1 stale SessionStart hook(s)");
+      expect(changes).toContain("Removed 1 stale PreToolUse hook(s)");
+    });
+
+    it("preserves non-context-mode hooks from other plugins", () => {
+      const staleRoot = "/tmp/non-existent-old-version-dir";
+      const otherPluginHook = {
+        matcher: "Bash",
+        hooks: [{ type: "command", command: "node /some/other-plugin/hooks/check.mjs" }],
+      };
+      writeFileSync(
+        join(tempDir, "settings.json"),
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [
+              otherPluginHook,
+              {
+                matcher: "Bash",
+                hooks: [{ type: "command", command: `node "${staleRoot}/hooks/pretooluse.mjs"` }],
+              },
+            ],
+          },
+        }),
+      );
+
+      adapter.configureAllHooks(pluginRoot);
+
+      const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
+      const preToolUseEntries = settings.hooks.PreToolUse;
+      // Should have the other plugin's hook + the fresh context-mode hook
+      expect(preToolUseEntries.length).toBe(2);
+      expect(preToolUseEntries[0]).toEqual(otherPluginHook);
+    });
+
+    it("handles multiple stale versions from upgrade chains", () => {
+      writeFileSync(
+        join(tempDir, "settings.json"),
+        JSON.stringify({
+          hooks: {
+            SessionStart: [
+              {
+                matcher: "",
+                hooks: [{ type: "command", command: 'node "/old/path/0.9.17/hooks/sessionstart.mjs"' }],
+              },
+              {
+                matcher: "",
+                hooks: [{ type: "command", command: 'node "/old/path/1.0.50/hooks/sessionstart.mjs"' }],
+              },
+            ],
+          },
+        }),
+      );
+
+      const changes = adapter.configureAllHooks(pluginRoot);
+      expect(changes).toContain("Removed 2 stale SessionStart hook(s)");
+    });
+
+    it("preserves CLI dispatcher format hooks (path-independent)", () => {
+      writeFileSync(
+        join(tempDir, "settings.json"),
+        JSON.stringify({
+          hooks: {
+            SessionStart: [{
+              matcher: "",
+              hooks: [{ type: "command", command: "context-mode hook claude-code sessionstart" }],
+            }],
+          },
+        }),
+      );
+
+      adapter.configureAllHooks(pluginRoot);
+
+      const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
+      // Should have the dispatcher entry updated (or kept) + fresh entry
+      const sessionStartEntries = settings.hooks.SessionStart;
+      expect(sessionStartEntries.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("works correctly on fresh install with no existing hooks", () => {
+      writeFileSync(join(tempDir, "settings.json"), JSON.stringify({}));
+
+      const changes = adapter.configureAllHooks(pluginRoot);
+
+      const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
+      expect(settings.hooks.PreToolUse).toHaveLength(1);
+      expect(settings.hooks.SessionStart).toHaveLength(1);
+      expect(changes.some((c: string) => c.includes("stale"))).toBe(false);
+    });
+
+    it("registers fresh hooks with correct pluginRoot paths after cleanup", () => {
+      const staleRoot = "/tmp/old-version";
+      writeFileSync(
+        join(tempDir, "settings.json"),
+        JSON.stringify({
+          hooks: {
+            SessionStart: [{
+              matcher: "",
+              hooks: [{ type: "command", command: `node "${staleRoot}/hooks/sessionstart.mjs"` }],
+            }],
+          },
+        }),
+      );
+
+      adapter.configureAllHooks(pluginRoot);
+
+      const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
+      const sessionHooks = settings.hooks.SessionStart;
+      expect(sessionHooks).toHaveLength(1);
+      // The fresh entry should point to the new pluginRoot (path may use \ on Windows)
+      const command = sessionHooks[0].hooks[0].command;
+      expect(command).toContain(pluginRoot);
+      expect(command).toContain("sessionstart.mjs");
     });
   });
 


### PR DESCRIPTION
## What

Remove stale context-mode hook entries from `~/.claude/settings.json` during the upgrade process, preventing `SessionStart:startup hook error` after version changes.

## Why

Fixes #187 — After upgrading context-mode (e.g., 0.9.17 → 1.0.53), hook paths in `settings.json` still reference the old version directory. The old directory is deleted during upgrade, but the hardcoded paths like `.../0.9.17/hooks/sessionstart.mjs` remain in settings, causing hook errors on every session start.

This happens because:
- `hooks.json` uses `${CLAUDE_PLUGIN_ROOT}` (dynamically resolved) ✅
- `configureAllHooks()` writes hardcoded absolute paths to `settings.json` ❌
- Marketplace auto-updates create new version directories and delete old ones, but `configureAllHooks()` is only called via CLI upgrade — not during marketplace updates

## How

Modified `configureAllHooks()` in `src/adapters/claude-code/index.ts` to scan and remove stale hook entries **before** registering fresh ones:

1. **Added `extractHookScriptPath()`** — extracts the file path from `node "/path/to/hook.mjs"` commands
2. **Added `isAnyContextModeHook()`** — detects context-mode hooks across all hook types without requiring a specific hookType
3. **Added stale cleanup loop** — iterates all hook types in `settings.hooks`, identifies context-mode entries with non-existent file paths, removes them

Safety guarantees:
- **Non-context-mode hooks are never touched** (other plugins preserved)
- **CLI dispatcher format preserved** (`context-mode hook claude-code ...` is path-independent, never stale)
- **Handles multi-version upgrade chains** (cleans 0.9.17, 1.0.50, etc. — not just the previous version)
- **Cross-platform** — tested on Windows with backslash paths

## Testing

Added 6 test cases to `tests/adapters/claude-code.test.ts`:

| Test | Verifies |
|------|----------|
| Removes stale entries pointing to non-existent paths | Core fix for #187 |
| Preserves non-context-mode hooks from other plugins | No collateral damage |
| Handles multiple stale versions from upgrade chains | 0.9.17 → 1.0.50 → 1.0.53 |
| Preserves CLI dispatcher format hooks | Path-independent hooks kept |
| Works correctly on fresh install | No errors with empty settings |
| Registers fresh hooks with correct pluginRoot after cleanup | End-to-end upgrade path |

```
✓ tests/adapters/claude-code.test.ts (32 tests) — all pass
✓ npm run typecheck — clean
✓ Diff: 228 lines across 3 files
```

## Files Changed

| File | Change |
|------|--------|
| `src/adapters/claude-code/hooks.ts` | Added `extractHookScriptPath()` and `isAnyContextModeHook()` helpers |
| `src/adapters/claude-code/index.ts` | Added stale cleanup loop at top of `configureAllHooks()` |
| `tests/adapters/claude-code.test.ts` | Added 6 test cases for stale hook cleanup |