### PR TITLE
Add Windows notes for script execution and path handling

### DIFF
--- a/configs/codex/AGENTS.md
+++ b/configs/codex/AGENTS.md
@@ -56,3 +56,22 @@ Search results can flood context. Use `ctx_execute(language: "shell", code: "gre
 | `ctx stats` | Call the `stats` MCP tool and display the full output verbatim |
 | `ctx doctor` | Call the `doctor` MCP tool, run the returned shell command, display as checklist |
 | `ctx upgrade` | Call the `upgrade` MCP tool, run the returned shell command, display as checklist |
+
+## Windows notes
+ 
+**PowerShell cmdlets in shell scripts** — The sandbox executes scripts via bash. PowerShell
+cmdlets (`Format-List`, `Format-Table`, `Get-Culture`, etc.) do not exist in bash and will fail
+with `command not found`. Wrap them with `pwsh -NoProfile -Command "..."` instead.
+ 
+**Relative paths** — The sandbox CWD is a temp directory, not your project root. Always convert
+any user-supplied path to an absolute path before passing it to `rg`, `grep`, or `find`.
+Ask the user to confirm the absolute path if it is not already known.
+ 
+**Windows drive letter paths** — The sandbox runs Git Bash / MSYS2, not WSL. Drive letters must
+use the MSYS2 convention, NOT the WSL convention:
+`X:\path` → `/x/path` (lowercase letter, no `/mnt/` prefix).
+Never emit `/mnt/<letter>/` prefixes regardless of which drive the project is on.
+ 
+**Always quote paths** — If a path contains spaces, bash splits it into separate arguments.
+Always wrap every path in double quotes: `rg "symbol" "$REPO_ROOT/some dir/Source"`.
+This applies to all tools: `rg`, `grep`, `find`, `ls`, etc.


### PR DESCRIPTION
## What

Add Windows-specific notes to `AGENTS.md` covering:

* PowerShell cmdlet usage in bash-based sandbox environments
* Absolute path requirements for file operations
* MSYS2-style drive letter path conventions
* Mandatory quoting for paths with spaces

---

## Why

The sandbox executes commands using **bash (MSYS2/Git Bash)** rather than PowerShell or WSL.

Without explicit guidance, contributors frequently:

* Use PowerShell cmdlets directly → `command not found`
* Use relative paths → resolve to incorrect temp directories
* Use WSL-style `/mnt/c/...` paths → incompatible with MSYS2
* Omit quotes → path splitting bugs on Windows

These issues lead to **non-portable scripts and frequent execution failures**, especially in Codex CLI and similar environments.

---

## How

Updated `AGENTS.md` by adding a **Windows notes section** that:

1. Clarifies that sandbox shell is bash, not PowerShell
2. Enforces explicit wrapping for PowerShell commands via `pwsh`
3. Defines MSYS2 path conversion rules:

   * `C:\foo\bar` → `/c/foo/bar`
4. Requires absolute paths for all filesystem operations
5. Enforces quoting of all paths to avoid argument splitting

The goal is to make Windows behavior **explicit, deterministic, and cross-platform safe**.

---

## Affected platforms

* [ ] Claude Code
* [ ] Gemini CLI
* [ ] VS Code Copilot
* [ ] OpenCode
* [x] Codex CLI
* [x] All platforms / core MCP server

---

## TDD (required)

### RED (failing test)

```
Example failure cases before this change:

- Running PowerShell cmdlet in bash:
  Format-Table
  → command not found

- Using WSL path:
  rg "foo" /mnt/c/project
  → No such file or directory

- Using relative path:
  rg "foo" ./Source
  → incorrect results due to sandbox CWD

- Unquoted path:
  rg "foo" /c/My Project/Source
  → splits into invalid arguments
```

### GREEN (passing test)

```
After applying documented rules:

- pwsh -NoProfile -Command "Format-Table"
  → executes correctly

- rg "foo" "/c/project/Source"
  → resolves correctly

- rg "foo" "$ABSOLUTE_PATH"
  → consistent results

- rg "foo" "/c/My Project/Source"
  → no argument splitting
```

---

## Cross-platform verification

* [x] I've considered whether my change involves platform-specific behavior
* [x] I've asked an AI assistant to review cross-platform implications

---

## Adapter checklist

* [x] No changes to hooks or adapters
* [x] No routing logic changes
* [x] No impact on `writeRoutingInstructions()`

---

## Test plan

* [x] Documentation-only change (no runtime logic modified)
* [x] Verified examples manually in Windows (Git Bash / MSYS2)
* [x] No impact on existing test suite

### Test output

```
npm test
→ All existing tests pass (no changes required)
```

---

## Before/After comparison

**Before:**

* Frequent Windows execution errors
* Inconsistent path handling across environments
* Implicit assumptions about shell type

**After:**

* Deterministic Windows behavior
* Clear path + shell conventions
* Reduced cross-platform ambiguity

---

## Local development setup

* [x] Followed local dev workflow
* [x] Verified AGENTS.md changes reflected in local MCP session

---

## Checklist

* [x] Not a duplicate PR
* [x] Targeting `main` branch
* [x] No breaking changes
* [x] Output quality improved via clearer guidance
* [x] Cross-platform considerations addressed
