### PR TITLE
fix(claude-code): skip settings.json hook registration when plugin hooks.json exists

### DIFF
--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -48,6 +48,7 @@ import type {
 import {
   HOOK_TYPES,
   HOOK_SCRIPTS,
+  REQUIRED_HOOKS,
   PRE_TOOL_USE_MATCHER_PATTERN,
   isContextModeHook,
   isAnyContextModeHook,
@@ -531,6 +532,23 @@ export class ClaudeCodeAdapter implements HookAdapter {
       if (removed > 0) {
         hooks[hookType] = filtered;
         changes.push(`Removed ${removed} stale ${hookType} hook(s)`);
+      }
+    }
+
+    // If plugin hooks.json already covers all required hooks, skip settings.json
+    // registration entirely (Issue #198). Plugin installs don't need settings.json
+    // entries — hooks.json with ${CLAUDE_PLUGIN_ROOT} is the source of truth.
+    const pluginHooks = this.readPluginHooks(pluginRoot);
+    if (pluginHooks) {
+      const allCovered = REQUIRED_HOOKS.every((ht) =>
+        this.checkHookType(undefined, pluginHooks, ht),
+      );
+      if (allCovered) {
+        // Still write cleaned settings (stale removal) but don't add new entries
+        settings.hooks = hooks;
+        this.writeSettings(settings);
+        changes.push("Skipped settings.json registration — plugin hooks.json is sufficient");
+        return changes;
       }
     }
 

--- a/tests/adapters/claude-code.test.ts
+++ b/tests/adapters/claude-code.test.ts
@@ -455,6 +455,82 @@ describe("ClaudeCodeAdapter", () => {
       expect(changes.some((c: string) => c.includes("stale"))).toBe(false);
     });
 
+    it("skips settings.json registration when plugin hooks.json already has all required hooks", () => {
+      // Plugin hooks.json has both PreToolUse and SessionStart
+      mkdirSync(join(pluginRoot, ".claude-plugin", "hooks"), { recursive: true });
+      writeFileSync(
+        join(pluginRoot, ".claude-plugin", "hooks", "hooks.json"),
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [{
+              matcher: "Bash",
+              hooks: [{ type: "command", command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.mjs" }],
+            }],
+            SessionStart: [{
+              matcher: "",
+              hooks: [{ type: "command", command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/sessionstart.mjs" }],
+            }],
+          },
+        }),
+      );
+
+      // settings.json starts empty
+      writeFileSync(join(tempDir, "settings.json"), JSON.stringify({}));
+
+      const changes = adapter.configureAllHooks(pluginRoot);
+
+      // Should NOT have written hook entries to settings.json
+      const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
+      expect(settings.hooks?.PreToolUse).toBeUndefined();
+      expect(settings.hooks?.SessionStart).toBeUndefined();
+      // Should report that plugin hooks are sufficient
+      expect(changes.some((c: string) => c.includes("plugin hooks.json"))).toBe(true);
+    });
+
+    it("still cleans stale entries even when plugin hooks.json is present", () => {
+      const staleRoot = "/tmp/non-existent-old-version-dir";
+
+      // Plugin hooks.json has all required hooks
+      mkdirSync(join(pluginRoot, "hooks", "hooks_dir"), { recursive: true });
+      writeFileSync(
+        join(pluginRoot, "hooks", "hooks.json"),
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [{
+              matcher: "Bash",
+              hooks: [{ type: "command", command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.mjs" }],
+            }],
+            SessionStart: [{
+              matcher: "",
+              hooks: [{ type: "command", command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/sessionstart.mjs" }],
+            }],
+          },
+        }),
+      );
+
+      // settings.json has stale entries
+      writeFileSync(
+        join(tempDir, "settings.json"),
+        JSON.stringify({
+          hooks: {
+            SessionStart: [{
+              matcher: "",
+              hooks: [{ type: "command", command: `node "${staleRoot}/hooks/sessionstart.mjs"` }],
+            }],
+          },
+        }),
+      );
+
+      const changes = adapter.configureAllHooks(pluginRoot);
+
+      // Should clean stale entries
+      expect(changes).toContain("Removed 1 stale SessionStart hook(s)");
+      // Should NOT re-register in settings.json
+      const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
+      const sessionHooks = settings.hooks?.SessionStart;
+      expect(!sessionHooks || sessionHooks.length === 0).toBe(true);
+    });
+
     it("registers fresh hooks with correct pluginRoot paths after cleanup", () => {
       const staleRoot = "/tmp/old-version";
       writeFileSync(


### PR DESCRIPTION
## Summary
- Marketplace plugin installs already register hooks via `hooks.json` with portable `${CLAUDE_PLUGIN_ROOT}` paths
- `configureAllHooks` was writing duplicate entries to `~/.claude/settings.json`, causing user confusion
- Now checks if plugin `hooks.json` covers all required hooks and skips `settings.json` registration when it does
- Stale entry cleanup still runs regardless

## Test Plan
- [x] Added test: skips settings.json registration when plugin hooks.json has all required hooks
- [x] Added test: still cleans stale entries even when plugin hooks.json is present
- [x] All 12 adapter tests pass (286/286)
- [x] TypeScript compiles with 0 errors

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)