### PR TITLE
refactor: auto ABI protection for hooks via ensure-deps.mjs

### DIFF
--- a/hooks/ensure-deps.mjs
+++ b/hooks/ensure-deps.mjs
@@ -8,13 +8,22 @@
  * hook that needs native modules. Fast path: existsSync check (~0.1ms).
  * Slow path: npm install (first run only, ~5-30s).
  *
+ * Also handles ABI compatibility (#148, #203): when the current Node.js
+ * version differs from the one better-sqlite3 was compiled against,
+ * automatically swaps in a cached binary or rebuilds. This protects
+ * both the MCP server AND hooks from ABI mismatch crashes when users
+ * have multiple Node versions via mise/volta/fnm/nvm.
+ *
+ * @see https://github.com/mksglu/context-mode/issues/148
  * @see https://github.com/mksglu/context-mode/issues/172
+ * @see https://github.com/mksglu/context-mode/issues/203
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, copyFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
@@ -35,5 +44,60 @@ export function ensureDeps() {
   }
 }
 
+/**
+ * ABI-aware native binary caching for better-sqlite3 (#148, #203).
+ *
+ * Users with mise/asdf/volta/fnm may run sessions with different Node
+ * versions. Each ABI needs its own compiled binary — cache them
+ * side-by-side so switching Node versions doesn't require a rebuild
+ * every time.
+ *
+ * Flow:
+ *   1. Check if ABI-specific cache exists → swap in
+ *   2. Probe-load better-sqlite3 → if OK, cache current binary
+ *   3. If ABI mismatch → npm rebuild, then cache the new binary
+ */
+export function ensureNativeCompat(pluginRoot) {
+  try {
+    const abi = process.versions.modules;
+    const nativeDir = resolve(pluginRoot, "node_modules", "better-sqlite3", "build", "Release");
+    const binaryPath = resolve(nativeDir, "better_sqlite3.node");
+    const abiCachePath = resolve(nativeDir, `better_sqlite3.abi${abi}.node`);
+
+    if (!existsSync(nativeDir)) return;
+
+    // Fast path: cached binary for this ABI already exists
+    if (existsSync(abiCachePath)) {
+      copyFileSync(abiCachePath, binaryPath);
+      return;
+    }
+
+    if (!existsSync(binaryPath)) return;
+
+    // Probe: try loading better-sqlite3 with current Node
+    try {
+      const req = createRequire(resolve(pluginRoot, "package.json"));
+      req("better-sqlite3");
+      // Load succeeded — cache the working binary for this ABI
+      copyFileSync(binaryPath, abiCachePath);
+    } catch (probeErr) {
+      if (probeErr?.message?.includes("NODE_MODULE_VERSION")) {
+        // ABI mismatch — rebuild for current Node version
+        execSync("npm rebuild better-sqlite3", {
+          cwd: pluginRoot,
+          stdio: "pipe",
+          timeout: 60000,
+        });
+        if (existsSync(binaryPath)) {
+          copyFileSync(binaryPath, abiCachePath);
+        }
+      }
+    }
+  } catch {
+    /* best effort — caller will report the error on first DB access */
+  }
+}
+
 // Auto-run on import (like suppress-stderr.mjs)
 ensureDeps();
+ensureNativeCompat(root);

--- a/start.mjs
+++ b/start.mjs
@@ -1,53 +1,10 @@
 #!/usr/bin/env node
 import "./hooks/reexec-node.mjs";
 import { execSync } from "node:child_process";
-import { existsSync, copyFileSync, chmodSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { existsSync, chmodSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
-import { createRequire } from "node:module";
-
-/**
- * ABI-aware native binary caching for better-sqlite3 (#148).
- * Users with mise/asdf may run concurrent sessions with different Node versions.
- * Each ABI needs its own compiled binary — cache them side-by-side.
- */
-function ensureNativeCompat(pluginRoot) {
-  try {
-    const abi = process.versions.modules;
-    const nativeDir = resolve(pluginRoot, "node_modules", "better-sqlite3", "build", "Release");
-    const binaryPath = resolve(nativeDir, "better_sqlite3.node");
-    const abiCachePath = resolve(nativeDir, `better_sqlite3.abi${abi}.node`);
-
-    if (!existsSync(nativeDir)) return;
-
-    if (existsSync(abiCachePath)) {
-      copyFileSync(abiCachePath, binaryPath);
-      return;
-    }
-
-    if (!existsSync(binaryPath)) return;
-
-    try {
-      const req = createRequire(resolve(pluginRoot, "package.json"));
-      req("better-sqlite3");
-      copyFileSync(binaryPath, abiCachePath);
-    } catch (probeErr) {
-      if (probeErr?.message?.includes("NODE_MODULE_VERSION")) {
-        execSync("npm rebuild better-sqlite3", {
-          cwd: pluginRoot,
-          stdio: "pipe",
-          timeout: 60000,
-        });
-        if (existsSync(binaryPath)) {
-          copyFileSync(binaryPath, abiCachePath);
-        }
-      }
-    }
-  } catch {
-    /* best effort — server will report the error on first DB access */
-  }
-}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const originalCwd = process.cwd();
@@ -116,9 +73,10 @@ if (cacheMatch) {
   }
 }
 
-// Ensure native dependencies are available (shared with hooks via ensure-deps.mjs)
-import { ensureDeps } from "./hooks/ensure-deps.mjs";
-// ensure-deps handles better-sqlite3; also install pure-JS deps used by server
+// Ensure native dependencies + ABI compatibility (shared with hooks via ensure-deps.mjs)
+// ensure-deps handles better-sqlite3 install + ABI cache/rebuild automatically (#148, #203)
+import "./hooks/ensure-deps.mjs";
+// Also install pure-JS deps used by server
 for (const pkg of ["turndown", "turndown-plugin-gfm", "@mixmark-io/domino"]) {
   if (!existsSync(resolve(__dirname, "node_modules", pkg))) {
     try {
@@ -130,11 +88,6 @@ for (const pkg of ["turndown", "turndown-plugin-gfm", "@mixmark-io/domino"]) {
     } catch { /* best effort */ }
   }
 }
-
-// Ensure better-sqlite3 native binary matches current Node.js ABI (#148)
-// Users with mise/asdf may run concurrent sessions with different Node versions.
-// Each ABI needs its own compiled binary — cache them side-by-side.
-ensureNativeCompat(__dirname);
 
 // Self-heal: create CLI shim if cli.bundle.mjs is missing (marketplace installs)
 if (!existsSync(resolve(__dirname, "cli.bundle.mjs")) && existsSync(resolve(__dirname, "build", "cli.js"))) {


### PR DESCRIPTION
## Summary
- Moves `ensureNativeCompat` from `start.mjs` into `hooks/ensure-deps.mjs`
- All hooks now automatically get ABI cache/rebuild protection — no env var needed
- `start.mjs` simplified — uses shared `ensure-deps.mjs` instead of inline function
- `CONTEXT_MODE_NODE` (from #214) stays as an escape hatch for edge cases

## Why
The previous `CONTEXT_MODE_NODE` env var approach had poor DX — users have to manually set it and remember it exists. The real fix is automatic: `ensure-deps.mjs` already runs on every hook import, so adding ABI compat there makes it zero-config.

## Test Plan
- [x] All 12 adapter tests pass
- [x] All hook tests pass
- [x] TypeScript compiles with 0 errors

Follow-up to #214, related to #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)