### PR TITLE
Fix: Support openclaw.json in OpenClaw installer

### DIFF
--- a/scripts/install-openclaw-plugin.sh
+++ b/scripts/install-openclaw-plugin.sh
@@ -17,14 +17,20 @@ if [ ! -d "$OPENCLAW_STATE_DIR" ]; then
   echo "✗ OPENCLAW_STATE_DIR ($OPENCLAW_STATE_DIR) does not exist. Is OpenClaw installed?" >&2
   exit 1
 fi
-if [ ! -f "$OPENCLAW_STATE_DIR/runtime/openclaw.runtime.json" ]; then
-  echo "✗ $OPENCLAW_STATE_DIR/runtime/openclaw.runtime.json not found." >&2
+
+# Support both runtime/openclaw.runtime.json and openclaw.json
+if [ -f "$OPENCLAW_STATE_DIR/runtime/openclaw.runtime.json" ]; then
+  RUNTIME_JSON="$OPENCLAW_STATE_DIR/runtime/openclaw.runtime.json"
+elif [ -f "$OPENCLAW_STATE_DIR/openclaw.json" ]; then
+  RUNTIME_JSON="$OPENCLAW_STATE_DIR/openclaw.json"
+  echo "→ Using openclaw.json instead of runtime/openclaw.runtime.json"
+else
+  echo "✗ Neither $OPENCLAW_STATE_DIR/runtime/openclaw.runtime.json nor $OPENCLAW_STATE_DIR/openclaw.json found." >&2
   echo "  Start OpenClaw once first, then re-run this script." >&2
   exit 1
 fi
 
 EXT_DIR="$OPENCLAW_STATE_DIR/extensions/context-mode"
-RUNTIME_JSON="$OPENCLAW_STATE_DIR/runtime/openclaw.runtime.json"
 
 echo "→ context-mode plugin installer"
 echo "  plugin root : $PLUGIN_ROOT"


### PR DESCRIPTION
## Problem

The OpenClaw installer script (`scripts/install-openclaw-plugin.sh`) fails because it expects `runtime/openclaw.runtime.json` but OpenClaw v2026.3.28 only creates `openclaw.json` as its configuration file.

## Solution

Modified the preflight check to support both:
1. `runtime/openclaw.runtime.json` (existing behavior)
2. `openclaw.json` (OpenClaw's current default)

## Changes

- Updated `scripts/install-openclaw-plugin.sh` to check for both file locations
- Added a fallback message when `openclaw.json` is used
- Maintained backward compatibility with existing installs

## Testing

Verified the fix works with:
- OpenClaw v2026.3.28
- Node.js v24.14.0
- Docker container environment

## Notes

The fix is minimal and only affects the installer script's file detection logic. No other functionality is changed.