### PR TITLE
fix: emit empty hookSpecificOutput in PostToolUse to prevent false hook error

### DIFF
--- a/hooks/posttooluse.mjs
+++ b/hooks/posttooluse.mjs
@@ -53,4 +53,5 @@ try {
   // PostToolUse must never block the session — silent fallback
 }
 
-// PostToolUse hooks don't need hookSpecificOutput
+// Emit empty hookSpecificOutput so Claude Code doesn't show false "hook error" (CC #41868).
+process.stdout.write(JSON.stringify({ hookSpecificOutput: {} }) + "\n");


### PR DESCRIPTION
## Problem

PostToolUse hook exits 0 but outputs nothing to stdout. Claude Code interprets empty stdout as a hook failure and displays "hook error" on every tool call — including `TaskUpdate`, `TaskCreate`, and other internal tools that fire due to the `matcher: ""` catch-all.

References: anthropics/claude-code#41868, anthropics/claude-code#35587

## Fix

Output empty `{"hookSpecificOutput":{}}` at the end of `posttooluse.mjs`. This tells Claude Code the hook completed successfully without any modifications.

## Test results

| Tool | Before (exit/stdout) | After (exit/stdout) | Status |
|------|---------------------|---------------------|--------|
| TaskUpdate | 0 / (empty) | 0 / `{"hookSpecificOutput":{}}` | FIXED |
| Bash | 0 / (empty) | 0 / `{"hookSpecificOutput":{}}` | FIXED |
| Agent | 0 / (empty) | 0 / `{"hookSpecificOutput":{}}` | FIXED |
| Read | 0 / (empty) | 0 / `{"hookSpecificOutput":{}}` | FIXED |
| {} (invalid) | 0 / (empty) | 0 / `{"hookSpecificOutput":{}}` | FIXED |

PreToolUse regression check: no change (still returns additionalContext as before).

Full test reports: https://gist.github.com/murataslan1/e0290cb0862f57fff4a0e2936b6a77d8

Closes #229