### PR TITLE
fix: use relative path in .mcp.json to silence CLAUDE_PLUGIN_ROOT warning

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "context-mode": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/start.mjs"]
+      "args": ["./start.mjs"]
     }
   }
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "71.5k+",
+  "message": "71.7k+",
   "color": "brightgreen",
   "npm": "61.2k+",
-  "marketplace": "10.2k+"
+  "marketplace": "10.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "68.8k+",
+  "message": "70.5k+",
   "color": "brightgreen",
-  "npm": "58.4k+",
+  "npm": "60.1k+",
   "marketplace": "10.3k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "70.5k+",
+  "message": "71.6k+",
   "color": "brightgreen",
-  "npm": "60.1k+",
+  "npm": "61.2k+",
   "marketplace": "10.3k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "66.4k+",
+  "message": "68.8k+",
   "color": "brightgreen",
-  "npm": "56.1k+",
+  "npm": "58.4k+",
   "marketplace": "10.3k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "73k+",
+  "message": "73.8k+",
   "color": "brightgreen",
-  "npm": "62.2k+",
+  "npm": "63k+",
   "marketplace": "10.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "73.8k+",
+  "message": "74.6k+",
   "color": "brightgreen",
-  "npm": "63k+",
+  "npm": "63.8k+",
   "marketplace": "10.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -4,5 +4,5 @@
   "message": "74.6k+",
   "color": "brightgreen",
   "npm": "63.8k+",
-  "marketplace": "10.8k+"
+  "marketplace": "10.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "74.6k+",
+  "message": "75.1k+",
   "color": "brightgreen",
-  "npm": "63.8k+",
+  "npm": "64.4k+",
   "marketplace": "10.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "71.7k+",
+  "message": "72.7k+",
   "color": "brightgreen",
-  "npm": "61.2k+",
+  "npm": "62.2k+",
   "marketplace": "10.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "72.7k+",
+  "message": "73k+",
   "color": "brightgreen",
   "npm": "62.2k+",
-  "marketplace": "10.5k+"
+  "marketplace": "10.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "71.6k+",
+  "message": "71.5k+",
   "color": "brightgreen",
   "npm": "61.2k+",
-  "marketplace": "10.3k+"
+  "marketplace": "10.2k+"
 }

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -142,10 +142,25 @@ describe(".mcp.json — MCP server config", () => {
     expect(upgradeSrc).toContain('resolve(pluginRoot, ".mcp.json")');
   });
 
-  it("template .mcp.json keeps ${CLAUDE_PLUGIN_ROOT} for marketplace compatibility", () => {
+  it("plugin manifest keeps ${CLAUDE_PLUGIN_ROOT} for marketplace compatibility", () => {
+    // Marketplace installs read .claude-plugin/plugin.json, not repo-root
+    // .mcp.json. The plugin manifest is the one that must retain the
+    // ${CLAUDE_PLUGIN_ROOT} placeholder so installed plugins resolve their
+    // bundled server path. Repo-root .mcp.json is for contributors opening
+    // the repo as a regular project and uses a relative path to avoid the
+    // "Missing environment variable: CLAUDE_PLUGIN_ROOT" warning.
+    const plugin = JSON.parse(
+      readFileSync(resolve(ROOT, ".claude-plugin", "plugin.json"), "utf-8"),
+    );
+    const args = plugin.mcpServers["context-mode"].args;
+    expect(args[0]).toContain("CLAUDE_PLUGIN_ROOT");
+  });
+
+  it("repo-root .mcp.json uses relative path to silence CLAUDE_PLUGIN_ROOT warning", () => {
     const mcp = JSON.parse(readFileSync(resolve(ROOT, ".mcp.json"), "utf-8"));
     const args = mcp.mcpServers["context-mode"].args;
-    expect(args[0]).toContain("CLAUDE_PLUGIN_ROOT");
+    expect(args[0]).not.toContain("CLAUDE_PLUGIN_ROOT");
+    expect(args[0]).toMatch(/^\.\/|^start\.mjs$/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace `${CLAUDE_PLUGIN_ROOT}/start.mjs` with `./start.mjs` in repo-root `.mcp.json`.
- Silences the warning Claude Code prints when the repo is opened as a regular project (not as an installed plugin).
- Plugin install path is unchanged — it still reads `.claude-plugin/plugin.json`.

## Why

`${CLAUDE_PLUGIN_ROOT}` is only defined when Claude Code loads the repo as an installed plugin. Opening the repo as a normal project leaves the var undefined, so every session starts with:

```
[Warning] [context-mode] mcpServers.context-mode: Missing environment variables: CLAUDE_PLUGIN_ROOT
```

A relative path resolves correctly when Claude Code spawns the MCP server from the project root. Plugin-mode continues to use `.claude-plugin/plugin.json`, which is unchanged.

## Pros / Cons

**Pros**
- Removes the startup warning for contributors.
- No behavior change for installed-plugin users.
- Single-line change.

**Cons**
- Depends on Claude Code spawning the MCP server with the project root as cwd. If that assumption ever breaks, the relative path would too — but so would most `.mcp.json` files in the wild.

## Test plan

- [ ] Fresh clone opened in Claude Code shows no `CLAUDE_PLUGIN_ROOT` warning.
- [ ] `/context-mode:ctx-doctor` still passes on a normal plugin install.
- [ ] `node ./start.mjs` starts successfully from the repo root.

Closes #252