### PR TITLE
fix(lifecycle): remove stdin listeners causing spurious MCP -32000 errors

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,8 +1,11 @@
 /**
  * lifecycle — Process lifecycle guard for MCP server.
  *
- * Detects parent process death, stdin close, and OS signals to prevent
+ * Detects parent process death (ppid polling) and OS signals to prevent
  * orphaned MCP server processes consuming 100% CPU (issue #103).
+ *
+ * Stdin close is NOT used as a shutdown signal — the MCP stdio transport
+ * owns stdin and transient pipe events cause spurious -32000 errors (#236).
  *
  * Cross-platform: macOS, Linux, Windows.
  */
@@ -10,7 +13,7 @@
 export interface LifecycleGuardOptions {
   /** Interval in ms to check parent liveness. Default: 30_000 */
   checkIntervalMs?: number;
-  /** Called when parent death or stdin close is detected. */
+  /** Called when parent death or OS signal is detected. */
   onShutdown: () => void;
   /** Injectable parent-alive check (for testing). Default: ppid-based check. */
   isParentAlive?: () => boolean;
@@ -54,14 +57,6 @@ export function startLifecycleGuard(opts: LifecycleGuardOptions): () => void {
   }, interval);
   timer.unref();
 
-  // P0: Stdin close — parent pipe broken
-  // Must resume stdin to receive close/end events (Node starts paused)
-  const onStdinClose = () => shutdown();
-  process.stdin.resume();
-  process.stdin.on("end", onStdinClose);
-  process.stdin.on("close", onStdinClose);
-  process.stdin.on("error", onStdinClose);
-
   // P0: OS signals — terminal close, kill, ctrl+c
   const signals: NodeJS.Signals[] = ["SIGTERM", "SIGINT"];
   if (process.platform !== "win32") signals.push("SIGHUP");
@@ -70,9 +65,6 @@ export function startLifecycleGuard(opts: LifecycleGuardOptions): () => void {
   return () => {
     stopped = true;
     clearInterval(timer);
-    process.stdin.removeListener("end", onStdinClose);
-    process.stdin.removeListener("close", onStdinClose);
-    process.stdin.removeListener("error", onStdinClose);
     for (const sig of signals) process.removeListener(sig, shutdown);
   };
 }

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -128,18 +128,31 @@ describe("Lifecycle Guard", () => {
 const isWindows = process.platform === "win32";
 
 describe.skipIf(isWindows)("Lifecycle Guard — Integration (real process)", () => {
-  test("child exits when stdin is closed", async () => {
+  test("child does NOT exit when stdin is closed (#236)", async () => {
     const { child, ready } = spawnGuardChild(42);
 
     await ready;
     child.stdin!.end();
 
-    const code = await new Promise<number | null>((resolve) => {
-      child.on("close", resolve);
-      setTimeout(() => { child.kill("SIGKILL"); resolve(null); }, 5000);
-    });
+    let exited = false;
+    let exitCode: number | null = null;
+    child.on("close", (code) => { exited = true; exitCode = code; });
 
-    assert.equal(code, 42, "Child should exit with code 42 when stdin closes");
+    // Give the guard 500ms — if stdin-close still triggered shutdown, it
+    // would have fired by now (previous implementation exited within ~1ms).
+    await new Promise((r) => setTimeout(r, 500));
+
+    assert.equal(exited, false, `Child must stay alive after stdin.end(); exited with code ${exitCode}`);
+    assert.equal(child.killed, false, "Child.killed should still be false");
+
+    // Clean up: SIGTERM the still-alive child so the test runner doesn't leak.
+    const closed = new Promise<number | null>((resolve) => {
+      if (exited) return resolve(exitCode);
+      child.on("close", resolve);
+      setTimeout(() => { child.kill("SIGKILL"); resolve(null); }, 3000);
+    });
+    child.kill("SIGTERM");
+    await closed;
   }, 10_000);
 
   test("child exits on SIGTERM", async () => {


### PR DESCRIPTION
## Summary

- Removes `process.stdin.resume()` and the `end`/`close`/`error` listeners from `src/lifecycle.ts` (the same diff as PR #237).
- Updates `tests/lifecycle.test.ts` so the integration test asserts the new contract — stdin close must NOT trigger the lifecycle guard.
- Supersedes #237 (same production-code fix, plus the test update that kept it from landing).

## Why

The lifecycle guard and the MCP stdio transport both own `process.stdin`. Any transient pipe event fired `onStdinClose` → `gracefulShutdown()` → `process.exit(0)` immediately, tearing in-flight JSON-RPC responses mid-flight and producing `MCP error -32000: Connection closed`. `ppid` polling every 30s plus `SIGTERM`/`SIGINT`/`SIGHUP` are enough to preserve the orphan protection from #103 without these false positives.

## What changed

- `src/lifecycle.ts` — stdin listeners + `resume()` removed; matching `removeListener` calls removed from the cleanup closure; JSDoc updated (both the file header and the `LifecycleGuardOptions.onShutdown` field comment).
- `tests/lifecycle.test.ts` — positive test (`child exits when stdin is closed`) replaced with a negative one (`child does NOT exit when stdin is closed (#236)`). All other unit tests and the SIGTERM integration test are untouched.

## Why #237 is superseded

PR #237 by @ponythewhite carried the exact production-code diff but did not update the integration test, which still asserted the old contract (`exit code === 42` on stdin close). CI went red on Ubuntu + macOS (Windows skips the integration block for unrelated POSIX-signal reasons). The author has been inactive for 6+ days. This PR keeps their production change verbatim and adds the test update so CI is green.

## Test plan

- `bunx vitest run tests/lifecycle.test.ts` — 7 tests pass locally (5 unit + 2 integration: negative stdin, SIGTERM).
- Full `vitest run` — hook/session tests already fail on pristine `upstream/main` (pre-existing, unrelated to this fix); no *new* regressions introduced.
- Manual smoke test: bundled server built with `bun run build && bun run bundle`, spawned with stdio piped, stdin closed mid-session. The lifecycle guard no longer calls `process.exit(0)` — the server now winds down via `StdioServerTransport`'s normal EOF handling (clean exit, no `-32000` framing corruption).
- CI on Ubuntu, macOS, and Windows must go green for this PR.

## Credit

Co-authored with @ponythewhite whose PR #237 carried the original diff.

Closes #236