### PR TITLE
perf(search): periodic FTS5 optimize to defragment indexes

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -298,6 +298,12 @@ export class ContentStore {
   #stmtStats!: PreparedStatement;
   #stmtSourceMeta!: PreparedStatement;
 
+  // FTS5 optimization: track inserts and optimize periodically to defragment
+  // the index. FTS5 b-trees fragment over many insert/delete cycles, degrading
+  // search performance. SQLite's built-in 'optimize' merges b-tree segments.
+  #insertCount = 0;
+  static readonly OPTIMIZE_EVERY = 50;
+
   constructor(dbPath?: string) {
     const Database = loadDatabase();
     this.#dbPath =
@@ -728,6 +734,15 @@ export class ContentStore {
     const sourceId = transaction();
     if (text) this.#extractAndStoreVocabulary(text);
 
+    // Periodically optimize FTS5 indexes to merge b-tree segments.
+    // Fragmentation accumulates over insert/delete cycles (dedup re-indexes
+    // every source on update). The 'optimize' command merges segments into
+    // a single b-tree, improving search latency for long-running sessions.
+    this.#insertCount++;
+    if (this.#insertCount % ContentStore.OPTIMIZE_EVERY === 0) {
+      this.#optimizeFTS();
+    }
+
     return {
       sourceId,
       label,
@@ -1099,7 +1114,16 @@ export class ContentStore {
     }
   }
 
+  /** Merge FTS5 b-tree segments for both porter and trigram indexes. */
+  #optimizeFTS(): void {
+    try {
+      this.#db.exec("INSERT INTO chunks(chunks) VALUES('optimize')");
+      this.#db.exec("INSERT INTO chunks_trigram(chunks_trigram) VALUES('optimize')");
+    } catch { /* best effort — don't block indexing */ }
+  }
+
   close(): void {
+    this.#optimizeFTS(); // defragment before close
     closeDB(this.#db); // WAL checkpoint before close — important for persistent DBs
   }
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1460,3 +1460,44 @@ describe("ContentStore — corrupt DB recovery", () => {
     expect(() => new ContentStore(tmpdir())).toThrow();
   });
 });
+
+// ═══════════════════════════════════════════════════════════
+// FTS5 Periodic Optimization
+// ═══════════════════════════════════════════════════════════
+
+describe("FTS5 periodic optimize", () => {
+  test("search works correctly after OPTIMIZE_EVERY inserts", () => {
+    const dbPath = join(tmpdir(), `ctx-optimize-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    const store = new ContentStore(dbPath);
+
+    // Insert enough sources to trigger at least one optimize cycle
+    for (let i = 0; i < ContentStore.OPTIMIZE_EVERY + 5; i++) {
+      store.indexPlainText(`Document number ${i} about testing optimization`, `source-${i}`);
+    }
+
+    // Search should still work correctly after optimization ran
+    const results = store.search("testing optimization");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].content).toContain("testing optimization");
+
+    store.cleanup();
+  });
+
+  test("close() does not throw even after many inserts", () => {
+    const dbPath = join(tmpdir(), `ctx-optimize-close-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    const store = new ContentStore(dbPath);
+
+    for (let i = 0; i < 10; i++) {
+      store.indexPlainText(`Content ${i}`, `src-${i}`);
+    }
+
+    // close() calls #optimizeFTS — should not throw
+    expect(() => store.close()).not.toThrow();
+  });
+
+  test("OPTIMIZE_EVERY is a reasonable value", () => {
+    // Guard against accidentally setting it too low (perf) or too high (no benefit)
+    expect(ContentStore.OPTIMIZE_EVERY).toBeGreaterThanOrEqual(20);
+    expect(ContentStore.OPTIMIZE_EVERY).toBeLessThanOrEqual(200);
+  });
+});


### PR DESCRIPTION
## Summary

- Runs SQLite's built-in FTS5 `optimize` command every 50 inserts and on `close()`
- Merges fragmented b-tree segments in both porter and trigram indexes
- Improves search latency for long-running sessions where sources are re-indexed frequently

## Why this matters

Every `indexPlainText`/`index` call deletes then re-inserts chunks (dedup logic from #67). This creates b-tree fragmentation in FTS5 — more segments to scan per query. SQLite's `optimize` merges them into a single segment, reducing I/O per search.

## Design decisions

- **Every 50 inserts**: balances optimize cost (~1-2ms) vs accumulated fragmentation. Too frequent wastes time; too rare lets fragmentation build up.
- **Also on `close()`**: ensures the index is clean when persistent DBs are reopened.
- **Best-effort**: `#optimizeFTS` catches all errors silently — optimization is a performance hint, never a correctness requirement.
- **No new dependencies, no schema changes**.
- **`OPTIMIZE_EVERY` is a public static** for testability and future tuning.

## Test plan

- [x] 3 new tests in `tests/store.test.ts` (search correctness after optimize, close() safety, constant bounds)
- [x] All 96 store tests pass
- [x] All 100 search tests pass (no regression)
- [ ] CI validation on Windows/Linux/macOS