### PR TITLE
perf(search): skip fuzzy correction on stopwords and cache cleanup statements

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -298,6 +298,11 @@ export class ContentStore {
   #stmtStats!: PreparedStatement;
   #stmtSourceMeta!: PreparedStatement;
 
+  // Cleanup path
+  #stmtCleanupChunks!: PreparedStatement;
+  #stmtCleanupChunksTrigram!: PreparedStatement;
+  #stmtCleanupSources!: PreparedStatement;
+
   // FTS5 optimization: track inserts and optimize periodically to defragment
   // the index. FTS5 b-trees fragment over many insert/delete cycles, degrading
   // search performance. SQLite's built-in 'optimize' merges b-tree segments.
@@ -614,6 +619,17 @@ export class ContentStore {
         (SELECT COUNT(*) FROM chunks) AS chunks,
         (SELECT COUNT(*) FROM chunks WHERE content_type = 'code') AS codeChunks
     `);
+
+    // Cleanup path — cached to avoid recompiling SQL on each periodic call
+    this.#stmtCleanupChunks = this.#db.prepare(
+      "DELETE FROM chunks WHERE source_id IN (SELECT id FROM sources WHERE datetime(indexed_at) < datetime('now', '-' || ? || ' days'))",
+    );
+    this.#stmtCleanupChunksTrigram = this.#db.prepare(
+      "DELETE FROM chunks_trigram WHERE source_id IN (SELECT id FROM sources WHERE datetime(indexed_at) < datetime('now', '-' || ? || ' days'))",
+    );
+    this.#stmtCleanupSources = this.#db.prepare(
+      "DELETE FROM sources WHERE datetime(indexed_at) < datetime('now', '-' || ? || ' days')",
+    );
   }
 
   // ── Index ──
@@ -968,11 +984,13 @@ export class ContentStore {
     }
 
     // Step 2: Fuzzy correction → RRF re-run
+    // Skip stopwords — they'll be filtered by sanitizeQuery anyway, and each
+    // fuzzyCorrect call hits the vocab DB + runs levenshtein comparisons.
     const words = query
       .toLowerCase()
       .trim()
       .split(/\s+/)
-      .filter((w) => w.length >= 3);
+      .filter((w) => w.length >= 3 && !STOPWORDS.has(w));
     const original = words.join(" ");
     const correctedWords = words.map((w) => this.fuzzyCorrect(w) ?? w);
     const correctedQuery = correctedWords.join(" ");
@@ -1095,19 +1113,10 @@ export class ContentStore {
    * Returns count of deleted sources.
    */
   cleanupStaleSources(maxAgeDays: number): number {
-    const deleteChunks = this.#db.prepare(
-      "DELETE FROM chunks WHERE source_id IN (SELECT id FROM sources WHERE datetime(indexed_at) < datetime('now', '-' || ? || ' days'))",
-    );
-    const deleteChunksTrigram = this.#db.prepare(
-      "DELETE FROM chunks_trigram WHERE source_id IN (SELECT id FROM sources WHERE datetime(indexed_at) < datetime('now', '-' || ? || ' days'))",
-    );
-    const deleteSources = this.#db.prepare(
-      "DELETE FROM sources WHERE datetime(indexed_at) < datetime('now', '-' || ? || ' days')",
-    );
     const cleanup = this.#db.transaction((days: number) => {
-      deleteChunks.run(days);
-      deleteChunksTrigram.run(days);
-      return deleteSources.run(days);
+      this.#stmtCleanupChunks.run(days);
+      this.#stmtCleanupChunksTrigram.run(days);
+      return this.#stmtCleanupSources.run(days);
     });
     const info = cleanup(maxAgeDays);
     return info.changes;

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1512,3 +1512,59 @@ describe("FTS5 periodic optimize", () => {
     expect(ContentStore.OPTIMIZE_EVERY).toBeLessThanOrEqual(200);
   });
 });
+
+describe("Fuzzy correction skips stopwords", () => {
+  test("searchWithFallback does not fuzzy-correct stopwords", () => {
+    const store = createStore();
+    // Index content with a typo-like word "databse" that fuzzy should correct
+    store.index({
+      content:
+        "# Database Guide\n\nThe database handles all persistent storage.\n\n# Unrelated\n\nNothing relevant here.",
+      source: "fuzzy-stopwords",
+    });
+
+    // "update" is a stopword, "databse" is a typo for "database"
+    // Fuzzy correction should only run on "databse", not waste cycles on "update"
+    const results = store.searchWithFallback("update databse", 2);
+    // Should still find results via fuzzy correction of "databse" → "database"
+    // (or via RRF direct match since "database" stems match)
+    assert.ok(results.length > 0, "Should return results");
+    assert.ok(
+      results[0].content.toLowerCase().includes("database"),
+      `Should match 'database', got: ${results[0].title}`,
+    );
+    store.close();
+  });
+});
+
+describe("cleanupStaleSources uses cached prepared statements", () => {
+  test("cleanupStaleSources works correctly with cached statements", () => {
+    const store = createStore();
+    store.index({ content: "# Old\n\nOld content.", source: "old-source" });
+    store.index({ content: "# New\n\nNew content.", source: "new-source" });
+
+    const statsBefore = store.getStats();
+    assert.equal(statsBefore.sources, 2, "Should have 2 sources");
+
+    // Cleanup with 0 days should remove everything
+    const cleaned = store.cleanupStaleSources(0);
+    assert.ok(cleaned >= 0, "Should not throw with cached statements");
+
+    store.close();
+  });
+
+  test("cleanupStaleSources can be called multiple times", () => {
+    const store = createStore();
+    store.index({ content: "# Test\n\nContent.", source: "multi-call" });
+
+    // Multiple calls should reuse cached statements without error
+    store.cleanupStaleSources(30);
+    store.cleanupStaleSources(30);
+    store.cleanupStaleSources(30);
+
+    // Still functional after multiple cleanup calls
+    const stats = store.getStats();
+    assert.equal(stats.sources, 1, "Source should still exist (not older than 30 days)");
+    store.close();
+  });
+});


### PR DESCRIPTION
## Summary

- **Fuzzy correction skips stopwords** — `searchWithFallback` was running `fuzzyCorrect()` on every word including stopwords like `update`, `test`, `fix`. Each call queries the vocab DB + runs levenshtein comparisons, wasted on words that get filtered from the FTS5 query anyway.
- **Cache cleanup prepared statements** — `cleanupStaleSources()` was the only method creating 3 new prepared statements per call. All other methods in ContentStore cache theirs in the constructor. Now consistent.

## Test plan

- [x] Fuzzy correction still works on meaningful misspelled terms
- [x] `cleanupStaleSources` works correctly with cached statements
- [x] `cleanupStaleSources` can be called multiple times (reuse)
- [x] Full store test suite — 0 regressions