### PR TITLE
fix: prevent duplicate hook processes when hooks.json is present

### DIFF
--- a/hooks/pretooluse.mjs
+++ b/hooks/pretooluse.mjs
@@ -96,24 +96,46 @@ try {
       const allHooks = settings.hooks || {};
       let changed = false;
 
-      for (const hookType of Object.keys(allHooks)) {
-        const entries = allHooks[hookType];
-        if (!Array.isArray(entries)) continue;
-
-        for (const entry of entries) {
-          // Fix deprecated Task-only matcher (PreToolUse only)
-          if (hookType === "PreToolUse" && entry.matcher?.includes("Task") && !entry.matcher.includes("Agent")) {
-            entry.matcher = entry.matcher.replace("Task", "Agent|Task");
+      // If hooks.json is present, the plugin system owns hook registration.
+      // Remove any settings.json context-mode entries to prevent duplicate concurrent
+      // hook processes that cause "non-blocking hook error" on every tool call.
+      const hooksJsonPath = resolve(myRoot, "hooks", "hooks.json");
+      if (existsSync(hooksJsonPath)) {
+        for (const hookType of Object.keys(allHooks)) {
+          const entries = allHooks[hookType];
+          if (!Array.isArray(entries)) continue;
+          const filtered = entries.filter(
+            (entry) =>
+              !entry.hooks?.some(
+                (h) => h.command?.includes(".mjs") && h.command?.includes("context-mode"),
+              ),
+          );
+          if (filtered.length !== entries.length) {
+            allHooks[hookType] = filtered;
             changed = true;
           }
-          // Rewrite stale context-mode hook paths to point to current version
-          for (const h of (entry.hooks || [])) {
-            if (h.command && h.command.includes(".mjs") && h.command.includes("context-mode") && !h.command.includes(targetDir)) {
-              // Extract the script filename (e.g., sessionstart.mjs, pretooluse.mjs)
-              const scriptMatch = h.command.match(/([a-z]+\.mjs)\s*"?\s*$/);
-              if (scriptMatch) {
-                h.command = "node " + resolve(targetDir, "hooks", scriptMatch[1]);
-                changed = true;
+        }
+      } else {
+        // Legacy: hooks.json absent — rewrite stale paths to current version dir.
+        for (const hookType of Object.keys(allHooks)) {
+          const entries = allHooks[hookType];
+          if (!Array.isArray(entries)) continue;
+
+          for (const entry of entries) {
+            // Fix deprecated Task-only matcher (PreToolUse only)
+            if (hookType === "PreToolUse" && entry.matcher?.includes("Task") && !entry.matcher.includes("Agent")) {
+              entry.matcher = entry.matcher.replace("Task", "Agent|Task");
+              changed = true;
+            }
+            // Rewrite stale context-mode hook paths to point to current version
+            for (const h of (entry.hooks || [])) {
+              if (h.command && h.command.includes(".mjs") && h.command.includes("context-mode") && !h.command.includes(targetDir)) {
+                // Extract the script filename (e.g., sessionstart.mjs, pretooluse.mjs)
+                const scriptMatch = h.command.match(/([a-z]+\.mjs)\s*"?\s*$/);
+                if (scriptMatch) {
+                  h.command = "node " + resolve(targetDir, "hooks", scriptMatch[1]);
+                  changed = true;
+                }
               }
             }
           }

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -543,7 +543,22 @@ export class ClaudeCodeAdapter implements HookAdapter {
         this.checkHookType(undefined, pluginHooks, ht),
       );
       if (allCovered) {
-        // Still write cleaned settings (stale removal) but don't add new entries
+        // Remove ALL existing context-mode hooks from settings.json — hooks.json
+        // is the source of truth. Keeping them causes duplicate concurrent hook
+        // processes (one from settings.json, one from hooks.json), which triggers
+        // "non-blocking hook error" warnings on every tool call.
+        for (const hookType of Object.keys(hooks)) {
+          const entries = hooks[hookType];
+          if (!Array.isArray(entries)) continue;
+          const filtered = (entries as Array<Record<string, unknown>>).filter((entry) =>
+            !isAnyContextModeHook(entry as { hooks?: Array<{ command?: string }> }),
+          );
+          const removed = entries.length - filtered.length;
+          if (removed > 0) {
+            hooks[hookType] = filtered;
+            changes.push(`Removed ${removed} duplicate ${hookType} hook(s) — covered by plugin hooks.json`);
+          }
+        }
         settings.hooks = hooks;
         this.writeSettings(settings);
         changes.push("Skipped settings.json registration — plugin hooks.json is sufficient");

--- a/tests/adapters/claude-code.test.ts
+++ b/tests/adapters/claude-code.test.ts
@@ -560,6 +560,45 @@ describe("ClaudeCodeAdapter", () => {
       expect(command).toContain(pluginRoot);
       expect(command).toContain("sessionstart.mjs");
     });
+
+    it("removes existing valid context-mode hooks from settings.json when plugin hooks.json covers all required hooks", () => {
+      // Plugin hooks.json covers all required hooks (pluginRoot already has scripts from beforeEach)
+      writeFileSync(
+        join(pluginRoot, "hooks", "hooks.json"),
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.mjs" }] }],
+            SessionStart: [{ matcher: "", hooks: [{ type: "command", command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/sessionstart.mjs" }] }],
+          },
+        }),
+      );
+
+      // settings.json has VALID (non-stale) context-mode hooks — paths exist, so they won't be
+      // removed by the stale-path filter. But they duplicate what hooks.json already registers,
+      // causing two concurrent hook processes for every tool call (the root cause of #NNN).
+      writeFileSync(
+        join(tempDir, "settings.json"),
+        JSON.stringify({
+          hooks: {
+            PreToolUse: [{
+              matcher: "Bash|WebFetch|Read|Grep|Agent",
+              hooks: [{ type: "command", command: `node "${join(pluginRoot, "hooks", "pretooluse.mjs")}"` }],
+            }],
+            SessionStart: [{
+              matcher: "",
+              hooks: [{ type: "command", command: `node "${join(pluginRoot, "hooks", "sessionstart.mjs")}"` }],
+            }],
+          },
+        }),
+      );
+
+      adapter.configureAllHooks(pluginRoot);
+
+      // Valid duplicate hooks should be removed — hooks.json is the source of truth
+      const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
+      expect(settings.hooks?.PreToolUse ?? []).toHaveLength(0);
+      expect(settings.hooks?.SessionStart ?? []).toHaveLength(0);
+    });
   });
 
   // ── Hook matchers (#229, #241) ────────────────────────


### PR DESCRIPTION
## Root cause

When context-mode is installed via the Claude Code marketplace, two systems register hooks simultaneously:
1. **`hooks.json`** (plugin system) — registers hooks via `${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.mjs`
2. **`settings.json`** (self-heal + `configureAllHooks`) — also writes the same hooks as absolute paths

Both fire concurrently on every tool call. One process occasionally fails with:
```
PreToolUse:mcp__...__ctx_execute hook error
Failed with non-blocking status code: node:internal/modules/cjs/loader:1423
```

## Who is affected

**Affected:** Users who set up context-mode via the CLI (`ctx upgrade`) before the marketplace plugin system existed, then later also had the marketplace install active. The `ctx upgrade` command wrote hooks to `settings.json`; the marketplace install then also registered the same hooks via `hooks.json`. Both fire on every tool call.

**Not affected:** Fresh marketplace installs with no prior context-mode history. The self-heal step 3 only *updates* existing `settings.json` entries — it never creates new ones — so users with no prior entries have no duplicates to cause the problem.

In short: any **early adopter or power user** who transitioned from CLI setup to marketplace install is likely seeing this error on every `ctx_execute` / `ctx_batch_execute` call. It's non-blocking but noisy and confusing.

## Fixes

### `src/adapters/claude-code/index.ts` — `configureAllHooks`
When `hooks.json` covers all required hooks, remove any existing context-mode entries from `settings.json` rather than skipping silently. `hooks.json` is the source of truth.

### `hooks/pretooluse.mjs` — self-heal step 3
When `hooks.json` exists at the plugin root, remove all context-mode entries from `settings.json` instead of rewriting their paths. Previously this rewrite would re-create duplicates on every version upgrade, even after a manual cleanup.

## Test
Added a failing test first (TDD) in `tests/adapters/claude-code.test.ts`:
- `removes existing valid context-mode hooks from settings.json when plugin hooks.json covers all required hooks`

All 41 adapter tests pass. 2 pre-existing failures in executor/codex tests (Windows path-with-spaces, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)