### PR TITLE
feat: optimize installation for Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,13 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
 
 **Install:**
 
-1. Install the package into Pi:
+1. Install context-mode globally:
+
+   ```bash
+   npm install -g context-mode
+   ```
+
+2. Install the package into Pi:
 
    ```bash
    pi install npm:context-mode
@@ -652,9 +658,7 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
    }
    ```
 
-   context-mode now ships a Pi package manifest, so Pi can load the bundled extension from npm directly — no clone or local build step required.
-
-2. Add to `~/.pi/agent/mcp.json` (or `.pi/mcp.json` for project-level):
+3. Add to `~/.pi/agent/mcp.json` (or `.pi/mcp.json` for project-level):
 
    ```json
    {
@@ -666,9 +670,7 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
    }
    ```
 
-   This works after `pi install npm:context-mode` because Pi installs npm packages globally and the `context-mode` CLI is available on `PATH`.
-
-3. Restart Pi.
+4. Restart Pi.
 
 **Verify:** In a Pi session, type `ctx stats`. Context-mode tools should appear and respond.
 

--- a/README.md
+++ b/README.md
@@ -638,14 +638,21 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
 
 **Install:**
 
-1. Clone the extension:
+1. Install the package into Pi:
 
    ```bash
-   git clone https://github.com/mksglu/context-mode.git ~/.pi/extensions/context-mode
-   cd ~/.pi/extensions/context-mode
-   npm install
-   npm run build
+   pi install npm:context-mode
    ```
+
+   Alternative — add it manually to `~/.pi/agent/settings.json` (or `.pi/settings.json` for project-level):
+
+   ```json
+   {
+     "packages": ["npm:context-mode"]
+   }
+   ```
+
+   context-mode now ships a Pi package manifest, so Pi can load the bundled extension from npm directly — no clone or local build step required.
 
 2. Add to `~/.pi/agent/mcp.json` (or `.pi/mcp.json` for project-level):
 
@@ -653,14 +660,13 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
    {
      "mcpServers": {
        "context-mode": {
-         "command": "node",
-         "args": ["/home/youruser/.pi/extensions/context-mode/node_modules/context-mode/start.mjs"]
+         "command": "context-mode"
        }
      }
    }
    ```
 
-   > **Note:** JSON does not expand `~`. Replace `/home/youruser` with your actual home directory (run `echo $HOME` to find it).
+   This works after `pi install npm:context-mode` because Pi installs npm packages globally and the `context-mode` CLI is available on `PATH`.
 
 3. Restart Pi.
 

--- a/package.json
+++ b/package.json
@@ -19,13 +19,22 @@
     "sandbox",
     "code-execution",
     "fts5",
-    "bm25"
+    "bm25",
+    "pi-package"
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/mksglu/context-mode"
   },
   "homepage": "https://github.com/mksglu/context-mode#readme",
+  "pi": {
+    "extensions": [
+      "./build/pi-extension.js"
+    ],
+    "skills": [
+      "./skills"
+    ]
+  },
   "openclaw": {
     "extensions": [
       "./build/openclaw-plugin.js"


### PR DESCRIPTION
## Summary
- add a Pi package manifest to context-mode
- document Pi installation via `npm install -g context-mode`, `pi install npm:context-mode`, and `packages`
- simplify Pi MCP configuration to use `command: "context-mode"`

## Testing
- verified npm tarball includes `build/pi-extension.js`, `skills/`, and `start.mjs`
- verified local Pi can load the package from the repo root via the Pi package manifest
- verified `mcp.json` works with `command: "context-mode"`
- verified the Pi `/ctx-stats` output fix is present after rebasing onto latest `main`
