### PR TITLE
test(executor): cover background mode, cleanupBackgrounded, hardCapBytes

### DIFF
--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -1453,6 +1453,75 @@ describe("Temp Cleanup Resilience", () => {
   });
 });
 
+describe("Background Mode", () => {
+  test("background: true returns partial output with backgrounded flag", async () => {
+    const bgExecutor = new PolyglotExecutor({ runtimes });
+    const r = await bgExecutor.execute({
+      language: "javascript",
+      code: `console.log("started"); setInterval(() => {}, 1000);`,
+      timeout: 500,
+      background: true,
+    });
+    assert.equal(r.backgrounded, true, "Should be marked as backgrounded");
+    assert.equal(r.timedOut, true, "Background detach fires on timeout");
+    assert.equal(r.exitCode, 0, "Backgrounded processes return exitCode 0");
+    assert.ok(r.stdout.includes("started"), "Should capture output before detach");
+    bgExecutor.cleanupBackgrounded();
+  }, 10_000);
+
+  test("cleanupBackgrounded kills detached process", async () => {
+    const bgExecutor = new PolyglotExecutor({ runtimes });
+    const r = await bgExecutor.execute({
+      language: "javascript",
+      code: `process.stdout.write(String(process.pid)); setInterval(() => {}, 1000);`,
+      timeout: 500,
+      background: true,
+    });
+    const pid = parseInt(r.stdout.trim(), 10);
+    assert.ok(pid > 0, `Expected valid PID, got: "${r.stdout}"`);
+
+    let alive = false;
+    try { process.kill(pid, 0); alive = true; } catch { /* ESRCH */ }
+    assert.equal(alive, true, "Process should be alive before cleanup");
+
+    bgExecutor.cleanupBackgrounded();
+    await new Promise((r) => setTimeout(r, 300));
+
+    alive = false;
+    try { process.kill(pid, 0); alive = true; } catch { /* ESRCH */ }
+    assert.equal(alive, false, `Process ${pid} should be dead after cleanup`);
+  }, 10_000);
+});
+
+describe("hardCapBytes Enforcement", () => {
+  test("kills process when combined output exceeds byte cap", async () => {
+    const cappedExecutor = new PolyglotExecutor({
+      runtimes,
+      hardCapBytes: 1024,
+    });
+    const r = await cappedExecutor.execute({
+      language: "javascript",
+      code: `for (let i = 0; i < 10000; i++) console.log("x".repeat(100));`,
+      timeout: 10_000,
+    });
+    assert.ok(r.stderr.includes("output capped at"), "Should indicate cap was hit");
+    assert.notEqual(r.exitCode, 0, "Process should be killed (non-zero exit)");
+  }, 15_000);
+
+  test("stderr contributes to byte cap", async () => {
+    const cappedExecutor = new PolyglotExecutor({
+      runtimes,
+      hardCapBytes: 1024,
+    });
+    const r = await cappedExecutor.execute({
+      language: "javascript",
+      code: `for (let i = 0; i < 10000; i++) console.error("e".repeat(100));`,
+      timeout: 10_000,
+    });
+    assert.ok(r.stderr.includes("output capped at"), "stderr should trigger cap");
+  }, 15_000);
+});
+
 describe("Windows Shell Support", () => {
   test("shell runtime is always a non-empty string", async () => {
     assert.ok(


### PR DESCRIPTION
## Summary

Three untested paths in `PolyglotExecutor` that now have regression coverage:

| Path | What it does | Test |
|---|---|---|
| `background: true` | Detaches process on timeout, returns partial output with `backgrounded: true` | Verifies flag, exitCode 0, and stdout captured before detach |
| `cleanupBackgrounded()` | Kills all detached PIDs via SIGTERM | Backgrounds a process, verifies it's alive, calls cleanup, verifies it's dead |
| `hardCapBytes` | Stream-level byte cap kills process when stdout+stderr exceeds limit | Creates 1KB-capped executor, generates ~1MB output, verifies cap message in stderr |

4 new tests, 69 lines added. No runtime changes.

## Verification

```
npx vitest run tests/executor.test.ts
 Test Files  1 passed (1)
      Tests  97 passed (97)
```

## Test plan

- [x] All 97 executor tests pass (93 existing + 4 new)
- [x] Background process properly cleaned up after test (no zombies)
- [x] Both stdout and stderr paths trigger hardCapBytes