### PR TITLE
fix: respect CLAUDE_CONFIG_DIR in hooks for multi-profile setups

### DIFF
--- a/hooks/precompact.mjs
+++ b/hooks/precompact.mjs
@@ -19,7 +19,10 @@ import { fileURLToPath } from "node:url";
 // Resolve absolute path for imports
 const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
 const { loadSessionDB, loadSnapshot } = createSessionLoaders(HOOK_DIR);
-const DEBUG_LOG = join(homedir(), ".claude", "context-mode", "precompact-debug.log");
+const _claudeConfigDir = process.env.CLAUDE_CONFIG_DIR
+  ? process.env.CLAUDE_CONFIG_DIR.replace(/^~/, homedir())
+  : join(homedir(), ".claude");
+const DEBUG_LOG = join(_claudeConfigDir, "context-mode", "precompact-debug.log");
 
 try {
   const raw = await readStdin();

--- a/hooks/pretooluse.mjs
+++ b/hooks/pretooluse.mjs
@@ -73,7 +73,8 @@ try {
 
     // 2. Update installed_plugins.json → point to correct version dir
     //    Skip if not present (e.g. CI / non-Claude-Code environments)
-    const ipPath = resolve(homedir(), ".claude", "plugins", "installed_plugins.json");
+    const configBase = process.env.CLAUDE_CONFIG_DIR ? resolve(process.env.CLAUDE_CONFIG_DIR.replace(/^~/, homedir())) : resolve(homedir(), ".claude");
+    const ipPath = resolve(configBase, "plugins", "installed_plugins.json");
     if (existsSync(ipPath)) {
       const ip = JSON.parse(readFileSync(ipPath, "utf-8"));
       for (const [key, entries] of Object.entries(ip.plugins || {})) {
@@ -90,7 +91,7 @@ try {
     // 3. Update hook paths + matcher in settings.json for ALL hook types (#187)
     //    Previously only fixed PreToolUse — SessionStart, PostToolUse, PreCompact,
     //    UserPromptSubmit paths remained stale after marketplace auto-update.
-    const settingsPath = resolve(homedir(), ".claude", "settings.json");
+    const settingsPath = resolve(configBase, "settings.json");
     try {
       const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
       const allHooks = settings.hooks || {};

--- a/hooks/session-helpers.mjs
+++ b/hooks/session-helpers.mjs
@@ -43,6 +43,19 @@ function getWorktreeSuffix() {
   return "";
 }
 
+/**
+ * Resolve the Claude Code config directory.
+ * Respects CLAUDE_CONFIG_DIR env var for multi-profile setups,
+ * falls back to ~/.claude.
+ */
+function getClaudeConfigDir() {
+  if (process.env.CLAUDE_CONFIG_DIR) {
+    const dir = process.env.CLAUDE_CONFIG_DIR.replace(/^~/, homedir());
+    return dir;
+  }
+  return join(homedir(), ".claude");
+}
+
 /** Claude Code platform options (default). */
 const CLAUDE_OPTS = {
   configDir: ".claude",
@@ -147,7 +160,8 @@ export function getSessionId(input, opts = CLAUDE_OPTS) {
 export function getSessionDBPath(opts = CLAUDE_OPTS) {
   const projectDir = getProjectDir(opts);
   const hash = createHash("sha256").update(projectDir).digest("hex").slice(0, 16);
-  const dir = join(homedir(), opts.configDir, "context-mode", "sessions");
+  const base = opts === CLAUDE_OPTS ? getClaudeConfigDir() : join(homedir(), opts.configDir);
+  const dir = join(base, "context-mode", "sessions");
   mkdirSync(dir, { recursive: true });
   return join(dir, `${hash}${getWorktreeSuffix()}.db`);
 }
@@ -160,7 +174,8 @@ export function getSessionDBPath(opts = CLAUDE_OPTS) {
 export function getSessionEventsPath(opts = CLAUDE_OPTS) {
   const projectDir = getProjectDir(opts);
   const hash = createHash("sha256").update(projectDir).digest("hex").slice(0, 16);
-  const dir = join(homedir(), opts.configDir, "context-mode", "sessions");
+  const base = opts === CLAUDE_OPTS ? getClaudeConfigDir() : join(homedir(), opts.configDir);
+  const dir = join(base, "context-mode", "sessions");
   mkdirSync(dir, { recursive: true });
   return join(dir, `${hash}${getWorktreeSuffix()}-events.md`);
 }
@@ -173,8 +188,11 @@ export function getSessionEventsPath(opts = CLAUDE_OPTS) {
 export function getCleanupFlagPath(opts = CLAUDE_OPTS) {
   const projectDir = getProjectDir(opts);
   const hash = createHash("sha256").update(projectDir).digest("hex").slice(0, 16);
-  const dir = join(homedir(), opts.configDir, "context-mode", "sessions");
+  const base = opts === CLAUDE_OPTS ? getClaudeConfigDir() : join(homedir(), opts.configDir);
+  const dir = join(base, "context-mode", "sessions");
   mkdirSync(dir, { recursive: true });
   return join(dir, `${hash}${getWorktreeSuffix()}.cleanup`);
 }
+
+export { getClaudeConfigDir };
 

--- a/hooks/sessionstart.mjs
+++ b/hooks/sessionstart.mjs
@@ -92,8 +92,11 @@ try {
     const sessionId = getSessionId(input);
     const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
     db.ensureSession(sessionId, projectDir);
+    const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR
+      ? process.env.CLAUDE_CONFIG_DIR.replace(/^~/, homedir())
+      : join(homedir(), ".claude");
     const claudeMdPaths = [
-      join(homedir(), ".claude", "CLAUDE.md"),
+      join(claudeConfigDir, "CLAUDE.md"),
       join(projectDir, "CLAUDE.md"),
       join(projectDir, ".claude", "CLAUDE.md"),
     ];
@@ -140,8 +143,11 @@ try {
     const { appendFileSync } = await import("node:fs");
     const { join: pjoin } = await import("node:path");
     const { homedir } = await import("node:os");
+    const debugConfigDir = process.env.CLAUDE_CONFIG_DIR
+      ? process.env.CLAUDE_CONFIG_DIR.replace(/^~/, homedir())
+      : pjoin(homedir(), ".claude");
     appendFileSync(
-      pjoin(homedir(), ".claude", "context-mode", "sessionstart-debug.log"),
+      pjoin(debugConfigDir, "context-mode", "sessionstart-debug.log"),
       `[${new Date().toISOString()}] ${err?.message || err}\n${err?.stack || ""}\n`,
     );
   } catch { /* ignore logging failure */ }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "82.2k+",
+  "message": "83.1k+",
   "color": "brightgreen",
   "npm": "71.2k+",
-  "marketplace": "11k+"
+  "marketplace": "11.8k+"
 }


### PR DESCRIPTION
## Summary

Fixes #289

Hooks hardcoded `~/.claude` paths via `join(homedir(), ".claude", ...)`, ignoring the `CLAUDE_CONFIG_DIR` environment variable. This broke multi-profile setups where users launch Claude Code with different config directories:

```bash
alias cc="CLAUDE_CONFIG_DIR=~/.claude-personal claude"
alias ccw="CLAUDE_CONFIG_DIR=~/.claude-work claude"
```

All path resolution now checks `process.env.CLAUDE_CONFIG_DIR` first, falling back to `~/.claude` when unset. No behavior change for single-profile users.

## Changes

- **`session-helpers.mjs`**: Added `getClaudeConfigDir()` helper. Updated `getSessionDBPath()`, `getSessionEventsPath()`, `getCleanupFlagPath()` to use it for Claude opts.
- **`pretooluse.mjs`**: Self-heal block now resolves `configBase` from env var for `settings.json` and `installed_plugins.json` paths.
- **`sessionstart.mjs`**: CLAUDE.md discovery and debug log path respect the env var.
- **`precompact.mjs`**: Debug log path respects the env var.

## Test plan

- [ ] Set `CLAUDE_CONFIG_DIR=~/.claude-test` and verify session DB is created under `~/.claude-test/context-mode/sessions/`
- [ ] Verify default behavior (no env var set) still uses `~/.claude/`
- [ ] Verify self-heal in pretooluse reads correct `settings.json` and `installed_plugins.json`
- [ ] Verify CLAUDE.md is read from the correct config directory on session start