### PR TITLE
fix(insight): terminate dashboard when Claude/MCP exits

### DIFF
--- a/insight/server.mjs
+++ b/insight/server.mjs
@@ -637,6 +637,19 @@ if (isBun) {
   server.listen(PORT, "127.0.0.1");
 }
 
+// Parent watchdog: exit when the MCP process that spawned us disappears.
+// Fallback for SIGKILL / crash paths where shutdown() cannot run.
+const PARENT_PID = Number(process.env.INSIGHT_PARENT_PID);
+if (Number.isFinite(PARENT_PID) && PARENT_PID > 0) {
+  setInterval(() => {
+    try {
+      process.kill(PARENT_PID, 0);
+    } catch {
+      process.exit(0);
+    }
+  }, 5000).unref();
+}
+
 console.log(`\n  context-mode Insight`);
 console.log(`  http://localhost:${PORT}`);
 console.log(`  Runtime: ${isBun ? "Bun" : "Node.js"}\n`);

--- a/skills/ctx-insight/SKILL.md
+++ b/skills/ctx-insight/SKILL.md
@@ -26,4 +26,4 @@ Open the personal analytics dashboard in the browser.
 4. Tell the user:
    - "Dashboard is running at http://localhost:4747"
    - "Refresh the page to see updated metrics"
-   - "To stop: kill the PID shown above, or close the terminal"
+   - "Dashboard stops automatically when Claude exits. To stop sooner: kill the PID shown above."

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createRequire } from "node:module";
 import { createHash } from "node:crypto";
 import { existsSync, unlinkSync, readdirSync, readFileSync, writeFileSync, rmSync, mkdirSync, cpSync, statSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execSync, type ChildProcess } from "node:child_process";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir, tmpdir } from "node:os";
@@ -115,6 +115,10 @@ function maybeIndexSessionEvents(store: ContentStore): void {
 // hardcoded configDir detection in tool handlers.
 
 let _detectedAdapter: HookAdapter | null = null;
+
+// Tracks the ctx_insight dashboard child so shutdown can terminate it.
+// See ctx_insight handler + shutdown() in main().
+let _insightChild: ChildProcess | null = null;
 
 /**
  * Get the platform-specific sessions directory from the detected adapter.
@@ -2191,7 +2195,15 @@ server.registerTool(
         // Port is free, proceed with spawn
       }
 
-      // Start server in background
+      // Kill any previous insight child this MCP spawned (e.g. re-invocation).
+      if (_insightChild && _insightChild.pid && !_insightChild.killed) {
+        try { _insightChild.kill("SIGTERM"); } catch { /* best effort */ }
+      }
+
+      // Start server in background. `detached: true` keeps MCP stdio free, but
+      // we track the handle and kill it in shutdown() so the dashboard does
+      // not orphan when Claude closes. The child also watches INSIGHT_PARENT_PID
+      // as a fallback for SIGKILL/crash paths.
       const { spawn } = await import("node:child_process");
       const child = spawn("node", [join(cacheDir, "server.mjs")], {
         cwd: cacheDir,
@@ -2200,12 +2212,14 @@ server.registerTool(
           PORT: String(port),
           INSIGHT_SESSION_DIR: getSessionDir(),
           INSIGHT_CONTENT_DIR: join(dirname(getSessionDir()), "content"),
+          INSIGHT_PARENT_PID: String(process.pid),
         },
         detached: true,
         stdio: "ignore",
       });
       child.on("error", () => {}); // prevent unhandled error crash
       child.unref();
+      _insightChild = child;
 
       // Wait for server to be ready
       await new Promise(r => setTimeout(r, 1500));
@@ -2279,6 +2293,10 @@ async function main() {
     try { unlinkSync(CM_FS_PRELOAD); } catch { /* best effort */ }
     // Remove MCP readiness sentinel (#230)
     try { unlinkSync(mcpSentinel); } catch { /* best effort */ }
+    // Stop ctx_insight dashboard so it does not outlive Claude.
+    if (_insightChild && _insightChild.pid && !_insightChild.killed) {
+      try { _insightChild.kill("SIGTERM"); } catch { /* best effort */ }
+    }
   };
   const gracefulShutdown = async () => {
     shutdown();

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "82.2k+",
+  "message": "83.1k+",
   "color": "brightgreen",
   "npm": "71.2k+",
-  "marketplace": "11k+"
+  "marketplace": "11.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "83.7k+",
+  "message": "85.1k+",
   "color": "brightgreen",
-  "npm": "71.2k+",
+  "npm": "72.6k+",
   "marketplace": "12.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "83.1k+",
+  "message": "83.7k+",
   "color": "brightgreen",
   "npm": "71.2k+",
-  "marketplace": "11.8k+"
+  "marketplace": "12.4k+"
 }


### PR DESCRIPTION
## Summary
- ctx_insight dashboard was spawned `detached: true` + `unref()` and never tracked, so it kept running after Claude closed
- Track the child in `_insightChild` and SIGTERM it from `shutdown()` (also kills prior child on re-invocation)
- Pass `INSIGHT_PARENT_PID` and add a 5s `process.kill(ppid, 0)` watchdog in `insight/server.mjs` for SIGKILL / crash / prior-session-orphan paths

## Why
User expectation: closing Claude should close the dashboard. Current behavior leaked a node process + bound port across sessions.

## Test plan
- [ ] Launch Claude, run `ctx_insight`, confirm dashboard up
- [ ] Exit Claude cleanly, confirm port 4747 free within ~1s
- [ ] `kill -9` the MCP process, confirm dashboard self-exits within ~5s (watchdog)
- [ ] Re-run `ctx_insight` in same session, confirm old child killed before new one spawns