### PR TITLE
ci(windows): cache GOCACHE and raise Go test timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,25 @@ jobs:
           go-version: "stable"
           cache: false
 
+      # Cache GOCACHE across runs so the inline Go snippets tests execute
+      # do not pay the cold-compile cost every run (Windows is ~30s).
+      - name: Resolve Go cache paths
+        id: go-cache-paths
+        shell: bash
+        run: |
+          echo "gocache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "gomodcache=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Go build + module cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.gocache }}
+            ${{ steps.go-cache-paths.outputs.gomodcache }}
+          key: go-${{ matrix.os }}-v1
+          restore-keys: |
+            go-${{ matrix.os }}-
+
       - uses: erlef/setup-beam@v1
         if: runner.os != 'Windows'
         with:

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -464,6 +464,10 @@ puts JSON.generate({ count: data[:users].length })
 });
 
 describe.runIf(runtimes.go)("Go Execution", () => {
+  // Windows runners with a cold GOCACHE can take 30s+ on the first compile.
+  // Bumped to 90s so cold-cache CI runs do not flake.
+  const GO_TEST_TIMEOUT = 90_000;
+
   test("Go: hello world", async () => {
     const r = await executor.execute({
       language: "go",
@@ -471,7 +475,7 @@ describe.runIf(runtimes.go)("Go Execution", () => {
     });
     assert.equal(r.exitCode, 0);
     assert.ok(r.stdout.includes("hello from go"));
-  });
+  }, GO_TEST_TIMEOUT);
 
   test("Go: loops + slices", async () => {
     const r = await executor.execute({
@@ -487,7 +491,7 @@ describe.runIf(runtimes.go)("Go Execution", () => {
     });
     assert.equal(r.exitCode, 0);
     assert.ok(r.stdout.includes("sum: 15"));
-  });
+  }, GO_TEST_TIMEOUT);
 });
 
 describe.runIf(runtimes.php)("PHP Execution", () => {


### PR DESCRIPTION
## Summary
- Windows CI fails intermittently with `Test timed out in 30000ms` on `tests/executor.test.ts > Go Execution > Go: hello world` — cold GOCACHE on the Windows runner blows past vitest's default 30s.
- Cache GOCACHE + GOMODCACHE across runs via `actions/cache`, keyed per matrix OS. Paths resolved with `go env` so it works on all three OSes.
- Raise the two Go execution tests to a 90s timeout as a safety net for fresh caches / new runner images.

## Test plan
- [ ] CI green on ubuntu / macos / windows
- [ ] Re-run Windows job with cache hit — Go tests complete well under 90s
- [ ] Cold-cache run (key miss) — still passes via the raised timeout