### PR TITLE
fix(routing): scope guidance throttle by session, not process.ppid (#298)

### DIFF
--- a/hooks/codex/pretooluse.mjs
+++ b/hooks/codex/pretooluse.mjs
@@ -10,7 +10,7 @@ import "../suppress-stderr.mjs";
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readStdin, getInputProjectDir, CODEX_OPTS } from "../session-helpers.mjs";
+import { readStdin, getInputProjectDir, getSessionId, CODEX_OPTS } from "../session-helpers.mjs";
 import { routePreToolUse, initSecurity } from "../core/routing.mjs";
 import { formatDecision } from "../core/formatters.mjs";
 
@@ -23,7 +23,7 @@ const tool = input.tool_name ?? "";
 const toolInput = input.tool_input ?? {};
 const projectDir = getInputProjectDir(input, CODEX_OPTS);
 
-const decision = routePreToolUse(tool, toolInput, projectDir, "codex");
+const decision = routePreToolUse(tool, toolInput, projectDir, "codex", getSessionId(input, CODEX_OPTS));
 const response = formatDecision("codex", decision);
 const output = response ?? {
   hookSpecificOutput: { hookEventName: "PreToolUse" },

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -36,23 +36,41 @@ import { resolve } from "node:path";
 //   - In-memory Set for same-process (OpenCode ts-plugin, vitest)
 //   - File-based markers with O_EXCL for cross-process atomicity
 //     (Claude Code, Gemini, Cursor, VS Code Copilot)
-// Session scoped via process.ppid (= host PID, constant for session lifetime).
+//
+// Session identity is resolved in this order:
+//   1. sessionId passed in by the caller (stable across hook invocations)
+//   2. process.ppid fallback (works on macOS/Linux — host PID is stable)
+//
+// The ppid fallback is unreliable on Windows + Git Bash, where each hook
+// invocation spawns a fresh bash.exe with a different PID (#298). Callers
+// that have a stable session identifier (e.g. from the hook payload) should
+// pass it to routePreToolUse so the marker directory stays consistent across
+// invocations of the same logical session.
 const _guidanceShown = new Set();
-const _guidanceId = process.env.VITEST_WORKER_ID
-  ? `${process.ppid}-w${process.env.VITEST_WORKER_ID}`
-  : String(process.ppid);
-const _guidanceDir = resolve(tmpdir(), `context-mode-guidance-${_guidanceId}`);
 
-function guidanceOnce(type, content) {
+function defaultGuidanceId() {
+  return process.env.VITEST_WORKER_ID
+    ? `${process.ppid}-w${process.env.VITEST_WORKER_ID}`
+    : String(process.ppid);
+}
+
+function guidanceDirFor(sessionId) {
+  const id = sessionId ? `s-${sessionId}` : defaultGuidanceId();
+  return resolve(tmpdir(), `context-mode-guidance-${id}`);
+}
+
+function guidanceOnce(type, content, sessionId) {
   // Fast path: in-memory (same process)
   if (_guidanceShown.has(type)) return null;
 
-  // Ensure marker directory exists
-  try { mkdirSync(_guidanceDir, { recursive: true }); } catch {}
+  // Resolve marker directory for this session (stable even on Windows/Git Bash
+  // where process.ppid shifts every invocation — see #298).
+  const dir = guidanceDirFor(sessionId);
+  try { mkdirSync(dir, { recursive: true }); } catch {}
 
   // Atomic create-or-fail: O_CREAT | O_EXCL | O_WRONLY
   // First process to create the file wins; others get EEXIST.
-  const marker = resolve(_guidanceDir, type);
+  const marker = resolve(dir, type);
   try {
     const fd = openSync(marker, fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY);
     closeSync(fd);
@@ -66,9 +84,13 @@ function guidanceOnce(type, content) {
   return { action: "context", additionalContext: content };
 }
 
-export function resetGuidanceThrottle() {
+export function resetGuidanceThrottle(sessionId) {
   _guidanceShown.clear();
-  try { rmSync(_guidanceDir, { recursive: true, force: true }); } catch {}
+  // Clear ppid-based dir (legacy / fallback callers) and the sessionId dir if given
+  try { rmSync(guidanceDirFor(), { recursive: true, force: true }); } catch {}
+  if (sessionId) {
+    try { rmSync(guidanceDirFor(sessionId), { recursive: true, force: true }); } catch {}
+  }
 }
 
 /**
@@ -150,8 +172,11 @@ const TOOL_ALIASES = {
  * @param {object} toolInput - The tool input/parameters
  * @param {string} [projectDir] - Project directory for security policy lookup
  * @param {string} [platform="claude-code"] - Platform ID for tool name formatting
+ * @param {string} [sessionId] - Stable session identifier from hook payload. When
+ *   provided, the guidance throttle uses it to scope marker files across hook
+ *   invocations even when process.ppid shifts (Windows/Git Bash — see #298).
  */
-export function routePreToolUse(toolName, toolInput, projectDir, platform) {
+export function routePreToolUse(toolName, toolInput, projectDir, platform, sessionId) {
   // Build platform-specific tool namer (defaults to claude-code for backward compat)
   const t = createToolNamer(platform || "claude-code");
 
@@ -272,17 +297,17 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform) {
     }
 
     // allow all other Bash commands, but inject routing nudge (once per session)
-    return guidanceOnce("bash", bashGuidance);
+    return guidanceOnce("bash", bashGuidance, sessionId);
   }
 
   // ─── Read: nudge toward execute_file (once per session) ───
   if (canonical === "Read") {
-    return guidanceOnce("read", readGuidance);
+    return guidanceOnce("read", readGuidance, sessionId);
   }
 
   // ─── Grep: nudge toward execute (once per session) ───
   if (canonical === "Grep") {
-    return guidanceOnce("grep", grepGuidance);
+    return guidanceOnce("grep", grepGuidance, sessionId);
   }
 
   // ─── WebFetch: deny + redirect to sandbox ───

--- a/hooks/cursor/pretooluse.mjs
+++ b/hooks/cursor/pretooluse.mjs
@@ -6,7 +6,7 @@ import "../suppress-stderr.mjs";
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readStdin, getInputProjectDir, CURSOR_OPTS } from "../session-helpers.mjs";
+import { readStdin, getInputProjectDir, getSessionId, CURSOR_OPTS } from "../session-helpers.mjs";
 import { routePreToolUse, initSecurity } from "../core/routing.mjs";
 import { formatDecision } from "../core/formatters.mjs";
 
@@ -19,7 +19,7 @@ const tool = input.tool_name ?? "";
 const toolInput = input.tool_input ?? {};
 const projectDir = getInputProjectDir(input, CURSOR_OPTS);
 
-const decision = routePreToolUse(tool, toolInput, projectDir, "cursor");
+const decision = routePreToolUse(tool, toolInput, projectDir, "cursor", getSessionId(input, CURSOR_OPTS));
 const response = formatDecision("cursor", decision);
 // Cursor treats empty stdout as an invalid hook response,
 // so even passthrough decisions must emit a syntactically valid no-op payload.

--- a/hooks/gemini-cli/beforetool.mjs
+++ b/hooks/gemini-cli/beforetool.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { readStdin } from "../core/stdin.mjs";
 import { routePreToolUse, initSecurity } from "../core/routing.mjs";
 import { formatDecision } from "../core/formatters.mjs";
+import { getSessionId, GEMINI_OPTS } from "../session-helpers.mjs";
 
 const __hookDir = dirname(fileURLToPath(import.meta.url));
 await initSecurity(resolve(__hookDir, "..", "..", "build"));
@@ -19,7 +20,7 @@ const input = JSON.parse(raw);
 const tool = input.tool_name ?? "";
 const toolInput = input.tool_input ?? {};
 
-const decision = routePreToolUse(tool, toolInput, process.env.GEMINI_PROJECT_DIR || process.env.CLAUDE_PROJECT_DIR, "gemini-cli");
+const decision = routePreToolUse(tool, toolInput, process.env.GEMINI_PROJECT_DIR || process.env.CLAUDE_PROJECT_DIR, "gemini-cli", getSessionId(input, GEMINI_OPTS));
 const response = formatDecision("gemini-cli", decision);
 if (response !== null) {
   process.stdout.write(JSON.stringify(response) + "\n");

--- a/hooks/kiro/pretooluse.mjs
+++ b/hooks/kiro/pretooluse.mjs
@@ -13,6 +13,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readStdin } from "../core/stdin.mjs";
 import { routePreToolUse, initSecurity } from "../core/routing.mjs";
+import { getSessionId, KIRO_OPTS } from "../session-helpers.mjs";
 
 const __hookDir = dirname(fileURLToPath(import.meta.url));
 await initSecurity(resolve(__hookDir, "..", "..", "build"));
@@ -24,7 +25,7 @@ const tool = input.tool_name ?? "";
 const toolInput = input.tool_input ?? {};
 const projectDir = input.cwd ?? process.cwd();
 
-const decision = routePreToolUse(tool, toolInput, projectDir, "kiro");
+const decision = routePreToolUse(tool, toolInput, projectDir, "kiro", getSessionId(input, KIRO_OPTS));
 
 if (!decision) process.exit(0);
 

--- a/hooks/pretooluse.mjs
+++ b/hooks/pretooluse.mjs
@@ -18,6 +18,7 @@ import { homedir, tmpdir } from "node:os";
 import { readStdin } from "./core/stdin.mjs";
 import { routePreToolUse, initSecurity } from "./core/routing.mjs";
 import { formatDecision } from "./core/formatters.mjs";
+import { getSessionId } from "./session-helpers.mjs";
 
 // ─── Manual recursive copy (avoids cpSync libuv crash on non-ASCII paths, Windows + Node 24) ───
 function copyDirSync(src, dest) {
@@ -163,7 +164,7 @@ const tool = input.tool_name ?? "";
 const toolInput = input.tool_input ?? {};
 
 // ─── Route and format response ───
-const decision = routePreToolUse(tool, toolInput, process.env.CLAUDE_PROJECT_DIR, "claude-code");
+const decision = routePreToolUse(tool, toolInput, process.env.CLAUDE_PROJECT_DIR, "claude-code", getSessionId(input));
 const response = formatDecision("claude-code", decision);
 if (response !== null) {
   process.stdout.write(JSON.stringify(response) + "\n");

--- a/hooks/vscode-copilot/pretooluse.mjs
+++ b/hooks/vscode-copilot/pretooluse.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { readStdin } from "../core/stdin.mjs";
 import { routePreToolUse, initSecurity } from "../core/routing.mjs";
 import { formatDecision } from "../core/formatters.mjs";
+import { getSessionId, VSCODE_OPTS } from "../session-helpers.mjs";
 
 const __hookDir = dirname(fileURLToPath(import.meta.url));
 await initSecurity(resolve(__hookDir, "..", "..", "build"));
@@ -19,7 +20,7 @@ const input = JSON.parse(raw);
 const tool = input.tool_name ?? "";
 const toolInput = input.tool_input ?? {};
 
-const decision = routePreToolUse(tool, toolInput, process.env.VSCODE_CWD || process.env.CLAUDE_PROJECT_DIR, "vscode-copilot");
+const decision = routePreToolUse(tool, toolInput, process.env.VSCODE_CWD || process.env.CLAUDE_PROJECT_DIR, "vscode-copilot", getSessionId(input, VSCODE_OPTS));
 const response = formatDecision("vscode-copilot", decision);
 if (response !== null) {
   process.stdout.write(JSON.stringify(response) + "\n");

--- a/tests/guidance-throttle.test.ts
+++ b/tests/guidance-throttle.test.ts
@@ -121,4 +121,99 @@ describe("guidance throttle", () => {
     const r2 = routePreToolUse("Bash", { command: "pwd" }, PROJECT_DIR);
     expect(r2).toBeNull();
   });
+
+  // Regression coverage for #298 — Windows/Git Bash spawns a new bash.exe per
+  // hook invocation, so process.ppid differs every call. The legacy marker-dir
+  // naming (scoped to ppid) created a fresh directory each time and the
+  // throttle never fired. The sessionId parameter scopes the marker directory
+  // to a stable per-session identifier passed in from the hook payload.
+  describe("sessionId scoping (#298 — stable across shifting ppids)", () => {
+    const fs = require("node:fs");
+    const os = require("node:os");
+    const path = require("node:path");
+
+    const SESSION_A = "a1b2c3d4-session-alpha";
+    const SESSION_B = "e5f6a7b8-session-beta";
+
+    function sessionDir(sessionId: string) {
+      return path.resolve(os.tmpdir(), `context-mode-guidance-s-${sessionId}`);
+    }
+
+    function clearSessionDir(sessionId: string) {
+      try { fs.rmSync(sessionDir(sessionId), { recursive: true, force: true }); } catch {}
+    }
+
+    beforeEach(() => {
+      clearSessionDir(SESSION_A);
+      clearSessionDir(SESSION_B);
+    });
+
+    afterEach(() => {
+      clearSessionDir(SESSION_A);
+      clearSessionDir(SESSION_B);
+    });
+
+    it("second call with same sessionId is throttled even when in-memory Set is cleared", () => {
+      const r1 = routePreToolUse("Read", { file_path: "/tmp/a.ts" }, PROJECT_DIR, "claude-code", SESSION_A);
+      expect(r1?.action).toBe("context");
+
+      // Simulate a fresh Node.js process (as happens on every Windows Git Bash
+      // hook invocation): in-memory state is gone, but the on-disk marker must
+      // still block the second call.
+      resetGuidanceThrottle();
+
+      const r2 = routePreToolUse("Read", { file_path: "/tmp/b.ts" }, PROJECT_DIR, "claude-code", SESSION_A);
+      expect(r2).toBeNull();
+      // The marker must live under the session-scoped directory, not the ppid one
+      expect(fs.existsSync(path.resolve(sessionDir(SESSION_A), "read"))).toBe(true);
+    });
+
+    it("different sessionIds get independent throttles", () => {
+      const rA = routePreToolUse("Read", { file_path: "/tmp/a.ts" }, PROJECT_DIR, "claude-code", SESSION_A);
+      expect(rA?.action).toBe("context");
+
+      // Clear in-memory to ensure we're reading the file-based marker
+      resetGuidanceThrottle();
+
+      // Different session → fresh throttle → guidance fires again
+      const rB = routePreToolUse("Read", { file_path: "/tmp/b.ts" }, PROJECT_DIR, "claude-code", SESSION_B);
+      expect(rB?.action).toBe("context");
+    });
+
+    it("sessionId routing is immune to process.ppid changes", () => {
+      // Claim the ppid-based fallback marker so we can prove the sessionId path
+      // is independent of it. This mirrors what happens when a prior invocation
+      // ran with a different ppid and wrote a marker in the legacy dir.
+      const ppidSuffix = process.env.VITEST_WORKER_ID
+        ? `${process.ppid}-w${process.env.VITEST_WORKER_ID}`
+        : String(process.ppid);
+      const ppidDir = path.resolve(os.tmpdir(), `context-mode-guidance-${ppidSuffix}`);
+      try { fs.mkdirSync(ppidDir, { recursive: true }); } catch {}
+      try { fs.writeFileSync(path.resolve(ppidDir, "bash"), "", "utf-8"); } catch {}
+
+      // A sessionId-scoped call should NOT see the ppid marker — different namespace.
+      const r = routePreToolUse("Bash", { command: "ls" }, PROJECT_DIR, "claude-code", SESSION_A);
+      expect(r?.action).toBe("context");
+    });
+
+    it("resetGuidanceThrottle(sessionId) clears the session-scoped dir", () => {
+      const r1 = routePreToolUse("Grep", { pattern: "foo" }, PROJECT_DIR, "claude-code", SESSION_A);
+      expect(r1?.action).toBe("context");
+      expect(fs.existsSync(path.resolve(sessionDir(SESSION_A), "grep"))).toBe(true);
+
+      resetGuidanceThrottle(SESSION_A);
+
+      const r2 = routePreToolUse("Grep", { pattern: "bar" }, PROJECT_DIR, "claude-code", SESSION_A);
+      expect(r2?.action).toBe("context");
+    });
+
+    it("no sessionId passed → falls back to ppid-based behavior (backward compat)", () => {
+      // Legacy callers that haven't been updated yet must continue to work.
+      const r1 = routePreToolUse("Read", { file_path: "/tmp/a.ts" }, PROJECT_DIR);
+      expect(r1?.action).toBe("context");
+
+      const r2 = routePreToolUse("Read", { file_path: "/tmp/b.ts" }, PROJECT_DIR);
+      expect(r2).toBeNull();
+    });
+  });
 });

--- a/tests/hooks/integration.test.ts
+++ b/tests/hooks/integration.test.ts
@@ -29,16 +29,21 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const HOOK_PATH = join(__dirname, "..", "..", "hooks", "pretooluse.mjs");
 
 // Clean guidance throttle markers before each test so guidance fires fresh.
-// Subprocess hooks use process.ppid (= this test's pid) + VITEST_WORKER_ID.
+// Subprocess hooks scope markers two ways (#298): the legacy ppid-based dir
+// (kept as fallback when no sessionId is passed) and the sessionId-scoped dir
+// (derived from getSessionId which falls back to `pid-${process.ppid}` when
+// the hook payload has no session_id).
 const _wid = process.env.VITEST_WORKER_ID;
 const _guidanceSuffix = _wid ? `${process.pid}-w${_wid}` : String(process.pid);
 const _guidanceDir = resolve(tmpdir(), `context-mode-guidance-${_guidanceSuffix}`);
+const _sessionGuidanceDir = resolve(tmpdir(), `context-mode-guidance-s-pid-${process.pid}`);
 
 // MCP readiness sentinel — subprocess hooks check process.ppid (= this test's pid)
 const mcpSentinel = resolve(tmpdir(), `context-mode-mcp-ready-${process.pid}`);
 
 beforeEach(() => {
   try { rmSync(_guidanceDir, { recursive: true, force: true }); } catch {}
+  try { rmSync(_sessionGuidanceDir, { recursive: true, force: true }); } catch {}
   writeFileSync(mcpSentinel, String(process.pid));
 });
 

--- a/tests/hooks/vscode-hooks.test.ts
+++ b/tests/hooks/vscode-hooks.test.ts
@@ -116,13 +116,17 @@ describe("VS Code Copilot hooks", () => {
   const mcpSentinel = resolve(tmpdir(), `context-mode-mcp-ready-${process.pid}`);
 
   // Clean file-based guidance throttle markers between tests.
-  // Subprocess hooks use process.ppid (= this test's pid) for marker dir.
+  // Subprocess hooks use process.ppid (= this test's pid) for the legacy marker dir;
+  // the sessionId-scoped dir (#298) is derived from getSessionId() which falls back
+  // to `pid-${process.ppid}` when the hook input has no session_id.
   // VITEST_WORKER_ID is inherited by subprocesses, matching routing.mjs logic.
   beforeEach(() => {
     const wid = process.env.VITEST_WORKER_ID;
     const suffix = wid ? `${process.pid}-w${wid}` : String(process.pid);
-    const guidanceDir = resolve(tmpdir(), `context-mode-guidance-${suffix}`);
-    try { rmSync(guidanceDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    const legacyDir = resolve(tmpdir(), `context-mode-guidance-${suffix}`);
+    const sessionDir = resolve(tmpdir(), `context-mode-guidance-s-pid-${process.pid}`);
+    try { rmSync(legacyDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(sessionDir, { recursive: true, force: true }); } catch { /* best effort */ }
     writeFileSync(mcpSentinel, String(process.pid));
   });
 


### PR DESCRIPTION
## What

`guidanceOnce()` in `hooks/core/routing.mjs` scoped its on-disk marker directory by `process.ppid`. On Windows + Git Bash each hook invocation spawns a fresh `bash.exe` with a different PID, so the marker directory name changed every call, the throttle never fired, and Read/Bash/Grep guidance was injected on every tool use — 716 stale marker dirs in `/tmp` and ~10 KB of repetitive context noise per session, per #298.

This PR threads the stable `sessionId` from the hook payload through `routePreToolUse` and names the marker directory `context-mode-guidance-s-<sessionId>` instead. The legacy ppid-based path stays as a backward-compatible fallback for callers that don't pass a session identifier.

Fixes #298.

## Why sessionId, not just a patched ppid

- Every adapter hook (`claude-code`, `codex`, `cursor`, `gemini-cli`, `kiro`, `vscode-copilot`) already reads hook input and has `getSessionId(input, <PLATFORM_OPTS>)` available via `session-helpers.mjs`. It's derived from the hook payload's `transcript_path` / `conversation_id` / `sessionId` / `session_id` / env var, with a final `pid-${ppid}` fallback. That identifier is stable across hook invocations within the same logical session.
- Passing it through `routePreToolUse` is additive (optional 5th arg) — no behavior change for callers that don't pass one, and no need to rely on platform-specific env vars or extra syscalls.
- The alternatives from the issue (grandparent PID, writing a session marker from `sessionstart.mjs`) all required more moving parts to reach the same fix.

## Changes

**`hooks/core/routing.mjs`**
- `_guidanceId` is no longer pinned at module load — `guidanceDirFor(sessionId)` resolves the marker dir per call, using `s-<sessionId>` when one is passed, falling back to the ppid suffix otherwise.
- `guidanceOnce(type, content, sessionId?)` and `resetGuidanceThrottle(sessionId?)` accept the optional session id.
- `routePreToolUse(toolName, toolInput, projectDir, platform, sessionId?)` threads it into the three `guidanceOnce` call sites (Bash/Read/Grep).

**Six adapter hooks** now import the matching `*_OPTS` (or none for Ora Studio default) and pass `getSessionId(input, ...)` at the routing call site:
- `hooks/pretooluse.mjs` (claude-code)
- `hooks/codex/pretooluse.mjs`
- `hooks/cursor/pretooluse.mjs`
- `hooks/gemini-cli/beforetool.mjs`
- `hooks/kiro/pretooluse.mjs`
- `hooks/vscode-copilot/pretooluse.mjs`

**Scope note:** `src/openclaw-plugin.ts` and `src/opencode-plugin.ts` are intentionally not touched. Both run in-process across hook invocations, so `process.ppid` was never unstable for them and the ppid fallback stays correct.

## Coverage added (added to `tests/guidance-throttle.test.ts`, per CONTRIBUTING's "no new test files" rule)

5 regression cases in a new `describe("sessionId scoping (#298 — stable across shifting ppids)")`:

- `second call with same sessionId is throttled even when in-memory Set is cleared` — simulates the Windows Git Bash case (fresh process per hook) and asserts the on-disk marker still blocks the second call.
- `different sessionIds get independent throttles` — two sessions, same process, each fires its own guidance exactly once.
- `sessionId routing is immune to process.ppid changes` — plants a marker in the legacy ppid dir; the sessionId-scoped call ignores it.
- `resetGuidanceThrottle(sessionId)` clears the session-scoped dir.
- `no sessionId passed → falls back to ppid-based behavior (backward compat)` — the previously existing contract is preserved for in-process callers.

Subprocess-based tests (`tests/hooks/integration.test.ts`, `tests/hooks/vscode-hooks.test.ts`) now also clean `context-mode-guidance-s-pid-<testpid>` in their `beforeEach` so the new marker location doesn't leak between tests.

## Test plan

- [x] `npx vitest run tests/guidance-throttle.test.ts` → 13/13 pass (5 new + 8 existing)
- [x] `npx vitest run tests/hooks/integration.test.ts tests/hooks/vscode-hooks.test.ts tests/guidance-throttle.test.ts` → 67/67 pass
- [x] `npm test` → 1600 pass, 23 skipped, **0 failures** — including the subprocess JSON-parse cases in `integration.test.ts` that were flaking on `next`
- [x] `npm run typecheck` → clean

No runtime behavior changes for macOS/Linux users. The fix activates when a caller passes a session id — which all six adapter hooks now do.

Generated by Ora Studio
Vibe coded by ousamabenyounes