### PR TITLE
fix(gemini-cli): emit SessionStart as structured JSON, not plaintext (#299)

### DIFF
--- a/hooks/gemini-cli/sessionstart.mjs
+++ b/hooks/gemini-cli/sessionstart.mjs
@@ -118,5 +118,13 @@ try {
   } catch { /* ignore logging failure */ }
 }
 
-const output = `SessionStart:compact hook success: Success\nSessionStart hook additional context: \n${additionalContext}`;
-process.stdout.write(output);
+// Emit structured JSON rather than plain text so Gemini CLI treats the
+// routing block as hook metadata instead of user-visible output (#299).
+// Matches the format already used by Claude Code and VS Code Copilot
+// SessionStart hooks.
+console.log(JSON.stringify({
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext,
+  },
+}));

--- a/tests/hooks/gemini-hooks.test.ts
+++ b/tests/hooks/gemini-hooks.test.ts
@@ -13,8 +13,10 @@ import { fileURLToPath } from "node:url";
 import { mkdtempSync, rmSync, existsSync, unlinkSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir, homedir } from "node:os";
+import { resolve } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..", "..");
 const HOOKS_DIR = join(__dirname, "..", "..", "hooks", "gemini-cli");
 
 interface HookResult {
@@ -169,6 +171,41 @@ describe("Gemini CLI hooks", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("SessionStart");
+    });
+
+    // Regression for #299 — the earlier plain-text output was rendered
+    // verbatim in Gemini CLI, spilling the full routing block (~10 KB) as
+    // user-visible startup noise. Structured JSON is treated as hook metadata.
+    test("sessionstart outputs structured JSON (hidden from user in Gemini CLI)", () => {
+      const result = runHook("sessionstart.mjs", {
+        source: "startup",
+        session_id: "test-gemini-json-shape",
+      }, geminiEnv());
+
+      expect(result.exitCode).toBe(0);
+
+      // stdout must parse as JSON — no leading plaintext banner
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.hookSpecificOutput).toBeDefined();
+      expect(parsed.hookSpecificOutput.hookEventName).toBe("SessionStart");
+      expect(typeof parsed.hookSpecificOutput.additionalContext).toBe("string");
+      expect(parsed.hookSpecificOutput.additionalContext).toContain("context-mode");
+
+      // The old plaintext markers must not leak through — they are exactly
+      // what rendered as visible noise in Gemini CLI before the fix.
+      expect(result.stdout).not.toContain("SessionStart:compact hook success");
+      expect(result.stdout).not.toContain("SessionStart hook additional context:");
+    });
+
+    test("sessionstart source uses JSON.stringify, not plaintext output (#299)", () => {
+      // Mirrors the vscode-copilot sessionstart source check — enforces the
+      // plaintext path cannot be reintroduced without breaking this test.
+      const hookSrc = readFileSync(resolve(ROOT, "hooks/gemini-cli/sessionstart.mjs"), "utf-8");
+      expect(hookSrc).toContain("JSON.stringify");
+      expect(hookSrc).toContain("hookSpecificOutput");
+      expect(hookSrc).toContain("hookEventName");
+      expect(hookSrc).toContain('"SessionStart"');
+      expect(hookSrc).not.toContain("SessionStart:compact hook success");
     });
   });
 


### PR DESCRIPTION
## What

`hooks/gemini-cli/sessionstart.mjs` concatenated the full ~10 KB routing block into a plain-text string prefixed with `"SessionStart:compact hook success: Success"` and wrote it to stdout. Gemini CLI surfaces that text verbatim in the UI, which is exactly the startup noise reported in #299 (\"the message is too verbose\").

The Ora Studio and VS Code Copilot SessionStart hooks already use structured JSON (`{ hookSpecificOutput: { hookEventName, additionalContext } }`) and are rendered as hook metadata rather than user-visible output. This PR brings the Gemini hook in line — no new config flag needed, hidden by default as the reporter suggested.

Fixes #299.

## Why just this

An in-repo source contract for the VS Code Copilot hook already exists (`tests/hooks/vscode-hooks.test.ts:279`) that forbids `\"SessionStart:compact hook success\"` in that hook's source and requires JSON.stringify. The Gemini hook is the one remaining SessionStart hook that hadn't been migrated. No config / new env var / new feature flag was considered necessary — the issue is effectively a missed parity cleanup.

No code path other than the final stdout emission changes, so session-lifecycle behavior (startup / compact / resume / clear) is untouched.

## Changes

**`hooks/gemini-cli/sessionstart.mjs`**
- Replace the final two lines (`const output = ...; process.stdout.write(output);`) with the same `console.log(JSON.stringify({ hookSpecificOutput: { hookEventName: \"SessionStart\", additionalContext } }))` form Ora Studio / VS Code Copilot already use.

**`tests/hooks/gemini-hooks.test.ts`** — two regression cases added to the existing `sessionstart.mjs` describe block (per CONTRIBUTING's \"add to existing domain file\" rule):

- `sessionstart outputs structured JSON (hidden from user in Gemini CLI)` — parses stdout as JSON, asserts `hookSpecificOutput.hookEventName === \"SessionStart\"` and that `additionalContext` is a string containing \"context-mode\". Also asserts the old plaintext markers (`\"SessionStart:compact hook success\"`, `\"SessionStart hook additional context:\"`) are not present.
- `sessionstart source uses JSON.stringify, not plaintext output (#299)` — reads the hook source and pins the JSON path in place (symmetric with the existing vscode-copilot source check at `tests/hooks/vscode-hooks.test.ts:279`).

## Test plan

- [x] `npx vitest run tests/hooks/gemini-hooks.test.ts` → 13/13 pass (2 new, 11 existing)
- [x] `npm test` → 1597 pass, 23 skipped, **0 failures**
- [x] `npm run typecheck` → clean

## Output quality (before / after)

Before — Gemini CLI user sees on session start:
```
ℹ SessionStart:compact hook success: Success
  SessionStart hook additional context: 
  <context_window_protection>
    <priority_instructions>
      Raw tool output floods your context window. You MUST use context-mode MCP tools...
    </priority_instructions>
    ... (~10 KB of XML routing instructions) ...
```

After:
```
(nothing visible — the routing block is still delivered, but as hook metadata)
```

The routing block is still injected into the agent's context on every session start — nothing changes semantically. Only the Gemini CLI UI rendering changes.

Generated by Ora Studio
Vibe coded by ousamabenyounes