### PR TITLE
fix(lifecycle): shut down when grandparent reparents to init (#311)

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -10,6 +10,8 @@
  * Cross-platform: macOS, Linux, Windows.
  */
 
+import { execFileSync } from "node:child_process";
+
 export interface LifecycleGuardOptions {
   /** Interval in ms to check parent liveness. Default: 30_000 */
   checkIntervalMs?: number;
@@ -19,22 +21,70 @@ export interface LifecycleGuardOptions {
   isParentAlive?: () => boolean;
 }
 
-/**
- * Default parent liveness check.
- * Compares current ppid against the original — if it changed (reparented to
- * init/launchd/systemd), parent is dead. This is more reliable than
- * kill(ppid, 0) which succeeds for PID 1 on all platforms.
- *
- * On Windows, ppid becomes 0 when parent exits.
- */
-const originalPpid = process.ppid;
-
-function defaultIsParentAlive(): boolean {
+/** Read grandparent PID via `ps -o ppid= -p $PPID`. Returns NaN on failure or Windows. */
+function readGrandparentPpidImpl(): number {
+  if (process.platform === "win32") return NaN;
   const ppid = process.ppid;
-  if (ppid !== originalPpid) return false;
-  if (ppid === 0 || ppid === 1) return false;
-  return true;
+  if (!ppid || ppid <= 1) return NaN;
+  try {
+    const out = execFileSync("ps", ["-o", "ppid=", "-p", String(ppid)], {
+      encoding: "utf-8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const n = parseInt(out, 10);
+    return Number.isFinite(n) ? n : NaN;
+  } catch {
+    return NaN;
+  }
 }
+
+/** Injectable dependencies for {@link makeDefaultIsParentAlive}. */
+export interface IsParentAliveDeps {
+  /** Read the current ppid. Default: `() => process.ppid`. */
+  getPpid?: () => number;
+  /** Read the grandparent ppid. Default: ps-based POSIX probe, NaN on Windows. */
+  readGrandparentPpid?: () => number;
+}
+
+/**
+ * Build a parent-liveness check that handles the npm-exec wrapper case (#311).
+ *
+ * A plain ppid comparison misses Claude Code sessions launched via
+ * `start.mjs → npm exec → context-mode server`: when Claude Code dies,
+ * `start.mjs` reparents to init but `npm exec` stays alive, so the server's
+ * direct ppid never changes. We additionally check whether the grandparent
+ * process has been reparented to init (PID 1). When the original grandparent
+ * was already 1 (daemonized startup) the check is skipped, and on Windows
+ * where there's no cheap `ps` equivalent we also skip — so this change is
+ * strictly additive to the previous behavior.
+ *
+ * Exported for unit-testing with injected readers. Production code uses
+ * {@link defaultIsParentAlive} (captured once at module load).
+ */
+export function makeDefaultIsParentAlive(deps: IsParentAliveDeps = {}): () => boolean {
+  const getPpid = deps.getPpid ?? (() => process.ppid);
+  const readGp = deps.readGrandparentPpid ?? readGrandparentPpidImpl;
+  const originalPpid = getPpid();
+  const originalGrandparentPpid = readGp();
+
+  return () => {
+    const ppid = getPpid();
+    if (ppid !== originalPpid) return false;
+    if (ppid === 0 || ppid === 1) return false;
+
+    // Grandparent orphan check (#311): npm-exec wrappers stay alive past the
+    // session owner. If our grandparent is now PID 1 but wasn't at startup,
+    // the wrapping chain is orphaned and we should shut down.
+    if (!Number.isNaN(originalGrandparentPpid) && originalGrandparentPpid > 1) {
+      if (readGp() === 1) return false;
+    }
+
+    return true;
+  };
+}
+
+const defaultIsParentAlive = makeDefaultIsParentAlive();
 
 /**
  * Start the lifecycle guard. Returns a cleanup function.

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -9,7 +9,7 @@ import { describe, test, assert } from "vitest";
 import { spawn, execSync } from "node:child_process";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { startLifecycleGuard } from "../src/lifecycle.js";
+import { startLifecycleGuard, makeDefaultIsParentAlive } from "../src/lifecycle.js";
 
 const TSX_PATH = execSync("which tsx", { encoding: "utf-8" }).trim();
 
@@ -178,6 +178,92 @@ describe("Lifecycle Guard", () => {
     });
 
     await new Promise((r) => setTimeout(r, 80));
+    cleanup();
+    assert.equal(shutdownCalled, true);
+  });
+});
+
+// Regression coverage for #311 — zombie context-mode servers persist because
+// the Claude Code process tree is
+//   Claude Code → start.mjs → npm exec → server
+// and when Claude Code dies, `start.mjs` reparents to init (PID 1) but
+// `npm exec` (our direct parent) keeps running, so a ppid-only check stays
+// green forever. The grandparent-orphan check closes this gap.
+describe("makeDefaultIsParentAlive — grandparent orphan detection (#311)", () => {
+  test("returns false when grandparent is reparented to init after startup", () => {
+    // Startup chain: server (ppid=100) → npm exec (ppid=50) → start.mjs (ppid=7, alive)
+    let currentGrandparent = 7;
+    const isAlive = makeDefaultIsParentAlive({
+      getPpid: () => 100,
+      readGrandparentPpid: () => currentGrandparent,
+    });
+
+    assert.equal(isAlive(), true, "alive at startup when grandparent is a normal process");
+
+    // Claude Code dies → start.mjs reparents to init.
+    currentGrandparent = 1;
+    assert.equal(isAlive(), false, "must detect grandparent reparenting (#311)");
+  });
+
+  test("does not false-positive when grandparent was already init at startup", () => {
+    // Daemon-style launch — grandparent is init from the start (e.g. launchd,
+    // systemd, or a detached nohup process). The check must skip in this case,
+    // otherwise the guard would shut down immediately on every poll.
+    const isAlive = makeDefaultIsParentAlive({
+      getPpid: () => 100,
+      readGrandparentPpid: () => 1,
+    });
+
+    // Multiple polls — never flip to false while ppid is stable.
+    assert.equal(isAlive(), true);
+    assert.equal(isAlive(), true);
+    assert.equal(isAlive(), true);
+  });
+
+  test("tolerates NaN grandparent (Windows / ps failure)", () => {
+    // On Windows readGrandparentPpidImpl returns NaN; the check must fall
+    // back to the original ppid-only path and stay green while ppid is stable.
+    const isAlive = makeDefaultIsParentAlive({
+      getPpid: () => 100,
+      readGrandparentPpid: () => NaN,
+    });
+
+    assert.equal(isAlive(), true);
+  });
+
+  test("direct ppid death still takes precedence over grandparent check", () => {
+    // If our own parent dies (ppid flips to init), shut down immediately —
+    // don't wait for a grandparent poll to confirm.
+    let ppid = 50;
+    const isAlive = makeDefaultIsParentAlive({
+      getPpid: () => ppid,
+      readGrandparentPpid: () => 7, // grandparent alive the whole time
+    });
+
+    assert.equal(isAlive(), true);
+    ppid = 1; // direct parent dies
+    assert.equal(isAlive(), false);
+  });
+
+  test("grandparent check kicks in through startLifecycleGuard end-to-end", async () => {
+    // Integration-shaped check: plug the orphan-aware factory into the
+    // real guard and prove it triggers onShutdown without touching stdin.
+    let currentGrandparent = 7;
+    const aliveCheck = makeDefaultIsParentAlive({
+      getPpid: () => 100,
+      readGrandparentPpid: () => currentGrandparent,
+    });
+
+    let shutdownCalled = false;
+    const cleanup = startLifecycleGuard({
+      checkIntervalMs: 30,
+      onShutdown: () => { shutdownCalled = true; },
+      isParentAlive: aliveCheck,
+    });
+
+    // Flip the grandparent to init — guard should notice within one interval.
+    currentGrandparent = 1;
+    await new Promise((r) => setTimeout(r, 100));
     cleanup();
     assert.equal(shutdownCalled, true);
   });


### PR DESCRIPTION
## What

Partial fix for the zombie MCP server problem described in #311. The server previously only monitored its direct ppid; this PR also watches the grandparent and shuts down when it reparents to init while the chain was originally not rooted at init.

Fixes the common case described in #311 on macOS/Linux. The second half of the issue (the vendored MCP SDK missing a stdin `end` handler) is deliberately out of scope — see the \"Not fixed here\" section below.

## Why the existing guard wasn't enough

The Ora Studio process chain is:

```
Ora Studio → start.mjs → npm exec → context-mode server
```

When Ora Studio dies:
- `start.mjs` reparents to init (PID 1)
- `npm exec` stays alive, so `context-mode server`'s direct `ppid` never changes
- The existing `defaultIsParentAlive` is still happy, the 30-second ppid tick never flips, and the server spins forever.

Extending the check to \"is the grandparent still a real process?\" catches exactly this case. The grandparent IS `start.mjs`, and `start.mjs`'s ppid flips to 1 the moment Ora Studio dies.

## Why not stdin

The issue suggests adding stdin `end`/`close` handlers. #236 already removed those because the MCP stdio transport owns stdin and transient pipe events caused spurious `-32000` errors. The repo locks that in with three tests in `tests/lifecycle.test.ts`:

- `cleanup does NOT remove stdin listeners (stdin is not used)`
- `startLifecycleGuard does NOT call process.stdin.resume()`
- `child does NOT exit when stdin is closed (#236)`

All three continue to pass — this PR adds zero stdin listeners.

## Changes

**`src/lifecycle.ts`**
- New `readGrandparentPpidImpl()` helper: runs `ps -o ppid= -p $PPID` on POSIX, returns `NaN` on Windows or probe failure.
- New exported factory `makeDefaultIsParentAlive(deps)` with injectable `getPpid` and `readGrandparentPpid` — used by production (`const defaultIsParentAlive = makeDefaultIsParentAlive()`) and by tests with fake readers.
- The default check now additionally returns `false` when the grandparent is now PID 1 but wasn't at startup.

**Safety net for false positives:**
- If the original grandparent was already 1 (daemon / nohup / launchd startup), the grandparent check is skipped entirely.
- On Windows (`ps` unavailable) or if the `ps` probe fails, the reader returns `NaN` and the check is also skipped. So the behavior on Windows is unchanged.

## Not fixed here (out of scope)

#311 also reports that the MCP SDK's `StdioServerTransport` lacks an `end` / `close` handler inside `server.bundle.mjs`. That's vendored third-party code, and #236 explicitly established that we don't drive shutdown via stdin listeners in this process. Addressing that root cause belongs in the SDK bundle (or a separate, coordinated change around #236's constraints).

## Tests added (`tests/lifecycle.test.ts`)

5 regression cases in a new `describe(\"makeDefaultIsParentAlive — grandparent orphan detection (#311)\")`, using the factory with injected readers so each scenario is hermetic:

- `returns false when grandparent is reparented to init after startup` — core regression case.
- `does not false-positive when grandparent was already init at startup` — daemon-start tolerance.
- `tolerates NaN grandparent (Windows / ps failure)` — falls back to original behavior.
- `direct ppid death still takes precedence over grandparent check` — existing contract preserved.
- `grandparent check kicks in through startLifecycleGuard end-to-end` — wiring verification via the public API.

## Test plan

- [x] `npx vitest run tests/lifecycle.test.ts` → 14/14 pass (9 existing + 5 new)
- [x] `npm test` → 1600 pass, 23 skipped, **0 failures**
- [x] `npm run typecheck` → clean
- [x] `npm run build` → clean

Generated by Ora Studio
Vibe coded by ousamabenyounes