### PR TITLE
feat: add CTX_QUIET env var to hide verbose session start output

### DIFF
--- a/hooks/gemini-cli/sessionstart.mjs
+++ b/hooks/gemini-cli/sessionstart.mjs
@@ -118,5 +118,13 @@ try {
   } catch { /* ignore logging failure */ }
 }
 
-const output = `SessionStart:compact hook success: Success\nSessionStart hook additional context: \n${additionalContext}`;
-process.stdout.write(output);
+// When CTX_QUIET is set, output only a minimal status marker instead of the
+// full routing block + additional context. The routing instructions are still
+// active — they're just not echoed to the terminal.
+const quiet = process.env.CTX_QUIET === '1' || process.env.CTX_QUIET === 'true';
+if (quiet) {
+  process.stdout.write('ℹ context-mode active\n');
+} else {
+  const output = `SessionStart:compact hook success: Success\nSessionStart hook additional context: \n${additionalContext}`;
+  process.stdout.write(output);
+}

--- a/hooks/sessionstart.mjs
+++ b/hooks/sessionstart.mjs
@@ -147,9 +147,22 @@ try {
   } catch { /* ignore logging failure */ }
 }
 
-console.log(JSON.stringify({
-  hookSpecificOutput: {
-    hookEventName: "SessionStart",
-    additionalContext,
-  },
-}));
+// When CTX_QUIET is set, suppress the verbose additionalContext from the output.
+// The routing instructions are still injected into the agent's context — they
+// just won't be echoed to the terminal on session start.
+const quiet = process.env.CTX_QUIET === '1' || process.env.CTX_QUIET === 'true';
+if (quiet) {
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: "context-mode active (quiet mode)",
+    },
+  }));
+} else {
+  console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext,
+    },
+  }));
+}


### PR DESCRIPTION
## Problem

On session start (especially Gemini CLI), context-mode outputs the full routing block XML to the terminal, which is very verbose and distracting. (#299)

## Solution

Add `CTX_QUIET` environment variable. When set to `1` or `true`:

- **Gemini CLI**: Outputs only `ℹ context-mode active` instead of the full block
- **Claude Code**: Outputs `context-mode active (quiet mode)` instead of the full additionalContext

The routing instructions are still active — they're just not echoed to the terminal.

### Usage

```bash
# In MCP config
CTX_QUIET=1 npx context-mode@latest

# Or in .env
export CTX_QUIET=1
```

Non-breaking: existing verbose behavior is the default.

Fixes #299