### PR TITLE
fix(openclaw): register MCP sidecar on install so ctx_* tools surface to agent

### DIFF
--- a/configs/openclaw/AGENTS.md
+++ b/configs/openclaw/AGENTS.md
@@ -4,48 +4,48 @@ You have context-mode MCP tools available. These rules are NOT optional — they
 
 ## Think in Code — MANDATORY
 
-When you need to analyze, count, filter, compare, search, parse, transform, or process data: **write code** that does the work via `ctx_execute(language, code)` and `console.log()` only the answer. Do NOT read raw data into context to process mentally. Your role is to PROGRAM the analysis, not to COMPUTE it. Write robust, pure JavaScript — no npm dependencies, only Node.js built-ins (`fs`, `path`, `child_process`). Always use `try/catch`, handle `null`/`undefined`, and ensure compatibility with both Node.js and Bun. One script replaces ten tool calls and saves 100x context.
+When you need to analyze, count, filter, compare, search, parse, transform, or process data: **write code** that does the work via `context-mode__ctx_execute(language, code)` and `console.log()` only the answer. Do NOT read raw data into context to process mentally. Your role is to PROGRAM the analysis, not to COMPUTE it. Write robust, pure JavaScript — no npm dependencies, only Node.js built-ins (`fs`, `path`, `child_process`). Always use `try/catch`, handle `null`/`undefined`, and ensure compatibility with both Node.js and Bun. One script replaces ten tool calls and saves 100x context.
 
 ## BLOCKED commands — do NOT attempt these
 
 ### curl / wget — BLOCKED
 Any shell command containing `curl` or `wget` will be intercepted and blocked by the context-mode plugin. Do NOT retry.
 Instead use:
-- `ctx_fetch_and_index(url, source)` to fetch and index web pages
-- `ctx_execute(language: "javascript", code: "const r = await fetch(...)")` to run HTTP calls in sandbox
+- `context-mode__ctx_fetch_and_index(url, source)` to fetch and index web pages
+- `context-mode__ctx_execute(language: "javascript", code: "const r = await fetch(...)")` to run HTTP calls in sandbox
 
 ### Inline HTTP — BLOCKED
 Any shell command containing `fetch('http`, `requests.get(`, `requests.post(`, `http.get(`, or `http.request(` will be intercepted and blocked. Do NOT retry with shell.
 Instead use:
-- `ctx_execute(language, code)` to run HTTP calls in sandbox — only stdout enters context
+- `context-mode__ctx_execute(language, code)` to run HTTP calls in sandbox — only stdout enters context
 
 ### Direct web fetching — BLOCKED
 Do NOT use any direct URL fetching tool. Use the sandbox equivalent.
 Instead use:
-- `ctx_fetch_and_index(url, source)` then `ctx_search(queries)` to query the indexed content
+- `context-mode__ctx_fetch_and_index(url, source)` then `context-mode__ctx_search(queries)` to query the indexed content
 
 ## REDIRECTED tools — use sandbox equivalents
 
 ### Shell (>20 lines output)
 Shell is ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`, and other short-output commands.
 For everything else, use:
-- `ctx_batch_execute(commands, queries)` — run multiple commands + search in ONE call
-- `ctx_execute(language: "shell", code: "...")` — run in sandbox, only stdout enters context
+- `context-mode__ctx_batch_execute(commands, queries)` — run multiple commands + search in ONE call
+- `context-mode__ctx_execute(language: "shell", code: "...")` — run in sandbox, only stdout enters context
 
 ### File reading (for analysis)
 If you are reading a file to **edit** it → reading is correct (edit needs content in context).
-If you are reading to **analyze, explore, or summarize** → use `ctx_execute_file(path, language, code)` instead. Only your printed summary enters context.
+If you are reading to **analyze, explore, or summarize** → use `context-mode__ctx_execute_file(path, language, code)` instead. Only your printed summary enters context.
 
 ### grep / search (large results)
-Search results can flood context. Use `ctx_execute(language: "shell", code: "grep ...")` to run searches in sandbox. Only your printed summary enters context.
+Search results can flood context. Use `context-mode__ctx_execute(language: "shell", code: "grep ...")` to run searches in sandbox. Only your printed summary enters context.
 
 ## Tool selection hierarchy
 
-1. **GATHER**: `ctx_batch_execute(commands, queries)` — Primary tool. Runs all commands, auto-indexes output, returns search results. ONE call replaces 30+ individual calls. Each command: `{label: "descriptive header", command: "..."}`. Label becomes FTS5 chunk title — descriptive labels improve search.
-2. **FOLLOW-UP**: `ctx_search(queries: ["q1", "q2", ...])` — Query indexed content. Pass ALL questions as array in ONE call.
-3. **PROCESSING**: `ctx_execute(language, code)` | `ctx_execute_file(path, language, code)` — Sandbox execution. Only stdout enters context.
-4. **WEB**: `ctx_fetch_and_index(url, source)` then `ctx_search(queries)` — Fetch, chunk, index, query. Raw HTML never enters context.
-5. **INDEX**: `ctx_index(content, source)` — Store content in FTS5 knowledge base for later search.
+1. **GATHER**: `context-mode__ctx_batch_execute(commands, queries)` — Primary tool. Runs all commands, auto-indexes output, returns search results. ONE call replaces 30+ individual calls. Each command: `{label: "descriptive header", command: "..."}`. Label becomes FTS5 chunk title — descriptive labels improve search.
+2. **FOLLOW-UP**: `context-mode__ctx_search(queries: ["q1", "q2", ...])` — Query indexed content. Pass ALL questions as array in ONE call.
+3. **PROCESSING**: `context-mode__ctx_execute(language, code)` | `context-mode__ctx_execute_file(path, language, code)` — Sandbox execution. Only stdout enters context.
+4. **WEB**: `context-mode__ctx_fetch_and_index(url, source)` then `context-mode__ctx_search(queries)` — Fetch, chunk, index, query. Raw HTML never enters context.
+5. **INDEX**: `context-mode__ctx_index(content, source)` — Store content in FTS5 knowledge base for later search.
 
 ## Output constraints
 

--- a/docs/adapters/openclaw.md
+++ b/docs/adapters/openclaw.md
@@ -50,6 +50,17 @@ The state directory doesn't exist at the expected path. If you installed OpenCla
 **Plugin installed but not loading**
 Clear the jiti cache (`rm -f /tmp/jiti/context-mode-*.cjs`) and restart the gateway. If the issue persists, verify the plugin appears in `openclaw plugins list`.
 
+**Plugin loads but `ctx_*` tools are missing from the agent's tool list**
+The plugin registers its hooks via `api.on(...)` / `api.registerCommand(...)`, but the agent-callable `ctx_*` tools live in the MCP server (`server.bundle.mjs`). OpenClaw surfaces them by spawning the server as an MCP sidecar declared in `mcp.servers.context-mode`. The install script writes this entry automatically (step 5); if you configured OpenClaw manually, verify with `openclaw mcp list` and add it if missing:
+
+```bash
+openclaw mcp set context-mode \
+  "{\"command\":\"node\",\"args\":[\"/absolute/path/to/context-mode/server.bundle.mjs\"]}"
+openclaw gateway restart
+```
+
+After the restart, the agent's tool inventory should include `context-mode__ctx_execute`, `context-mode__ctx_search`, `context-mode__ctx_fetch_and_index`, and the rest of the `ctx_*` surface (OpenClaw prefixes MCP-sourced tools with the server name).
+
 ## Hook Registration
 
 The adapter uses two different registration APIs, matching OpenClaw's internal architecture:

--- a/scripts/install-openclaw-plugin.sh
+++ b/scripts/install-openclaw-plugin.sh
@@ -69,42 +69,11 @@ else
   echo "  ⚠ could not verify discovery (openclaw not in PATH or plugin not found) — continuing anyway"
 fi
 
-# 5. Register in runtime config (idempotent)
+# 5. Register in runtime config (idempotent) — delegates to
+# scripts/lib/register-openclaw-config.mjs so the logic can be unit-tested
+# and so we can extend it (now also registers mcp.servers.context-mode).
 echo "→ registering in $OPENCLAW_JSON..."
-node -e "
-const fs = require('fs');
-const [runtimePath, pluginRoot] = process.argv.slice(1);
-let cfg;
-try {
-  cfg = JSON.parse(fs.readFileSync(runtimePath, 'utf8'));
-} catch (e) {
-  console.error('  ✗ Failed to parse ' + runtimePath + ' — is it valid JSON?');
-  process.exit(1);
-}
-const plugins = cfg.plugins ??= {};
-
-// Remove plugins.load.paths entry (causes duplicate registration)
-const load = plugins.load ?? {};
-const paths = load.paths ?? [];
-const idx = paths.indexOf(pluginRoot);
-if (idx !== -1) {
-  paths.splice(idx, 1);
-  if (!paths.length) delete load.paths;
-  if (!Object.keys(load).length) delete plugins.load;
-  console.log('  removed plugins.load.paths entry (caused duplicate registration)');
-}
-
-// Add to plugins.allow
-const allow = plugins.allow ??= [];
-if (!allow.includes('context-mode')) allow.unshift('context-mode');
-
-// Add to plugins.entries
-const entries = plugins.entries ??= {};
-if (!entries['context-mode']) entries['context-mode'] = { enabled: true };
-
-fs.writeFileSync(runtimePath, JSON.stringify(cfg, null, 2) + '\n');
-console.log('  plugins.allow:', JSON.stringify(allow));
-" "$OPENCLAW_JSON" "$PLUGIN_ROOT"
+node "$PLUGIN_ROOT/scripts/lib/register-openclaw-config.mjs" "$OPENCLAW_JSON" "$PLUGIN_ROOT"
 
 # 6. Restart gateway
 echo "→ restarting openclaw gateway..."

--- a/scripts/lib/register-openclaw-config.mjs
+++ b/scripts/lib/register-openclaw-config.mjs
@@ -1,0 +1,92 @@
+// Idempotent runtime-config mutation for `openclaw.json`, extracted from
+// scripts/install-openclaw-plugin.sh so the logic can be unit-tested.
+//
+// Responsibilities:
+//   1. Remove the legacy `plugins.load.paths` entry (caused duplicate registration).
+//   2. Ensure `context-mode` is present in `plugins.allow` + `plugins.entries`.
+//   3. Register `mcp.servers.context-mode` → `{command:"node", args:["<pluginRoot>/server.bundle.mjs"]}`
+//      so OpenClaw spawns the MCP sidecar and surfaces `ctx_*` tools to the agent.
+//
+// Can be used as a library (`import { registerContextModeInOpenclawConfig } from ...`)
+// or as a CLI (`node register-openclaw-config.mjs <runtimePath> <pluginRoot>`).
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+export function registerContextModeInOpenclawConfig(runtimePath, pluginRoot) {
+  let cfg;
+  try {
+    cfg = JSON.parse(readFileSync(runtimePath, "utf8"));
+  } catch (e) {
+    throw new Error(`Failed to parse ${runtimePath} — is it valid JSON? (${e.message})`);
+  }
+
+  const messages = [];
+  const plugins = (cfg.plugins ??= {});
+
+  // 1. Remove plugins.load.paths entry (causes duplicate registration)
+  const load = plugins.load ?? {};
+  const paths = load.paths ?? [];
+  const idx = paths.indexOf(pluginRoot);
+  if (idx !== -1) {
+    paths.splice(idx, 1);
+    if (!paths.length) delete load.paths;
+    if (!Object.keys(load).length) delete plugins.load;
+    messages.push("removed plugins.load.paths entry (caused duplicate registration)");
+  }
+
+  // 2. Add to plugins.allow (idempotent)
+  const allow = (plugins.allow ??= []);
+  if (!allow.includes("context-mode")) allow.unshift("context-mode");
+
+  // 3. Add to plugins.entries (idempotent)
+  const entries = (plugins.entries ??= {});
+  if (!entries["context-mode"]) entries["context-mode"] = { enabled: true };
+
+  // 4. Register MCP sidecar so OpenClaw spawns server.bundle.mjs and surfaces
+  //    ctx_* tools to the agent. Without this entry the plugin loads but its
+  //    tools never reach the agent's tool list (confirmed against OpenClaw
+  //    2026.4.22: context-mode 1.0.89 plugin "loaded" but no ctx_* tools
+  //    visible until mcp.servers.context-mode was set).
+  const mcp = (cfg.mcp ??= {});
+  const servers = (mcp.servers ??= {});
+  const serverBundle = `${pluginRoot}/server.bundle.mjs`;
+  const existing = servers["context-mode"];
+  const needsWrite =
+    !existing ||
+    existing.command !== "node" ||
+    !Array.isArray(existing.args) ||
+    existing.args[0] !== serverBundle;
+  if (needsWrite) {
+    servers["context-mode"] = { command: "node", args: [serverBundle] };
+    messages.push(`registered mcp.servers.context-mode → ${serverBundle}`);
+  }
+
+  writeFileSync(runtimePath, JSON.stringify(cfg, null, 2) + "\n");
+
+  return {
+    pluginsAllow: allow,
+    mcpServer: servers["context-mode"],
+    messages,
+  };
+}
+
+// CLI entry point — preserves the output format used by the previous inline
+// `node -e` block in install-openclaw-plugin.sh so existing installers keep
+// the same stdout contract.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [runtimePath, pluginRoot] = process.argv.slice(2);
+  if (!runtimePath || !pluginRoot) {
+    console.error("Usage: node register-openclaw-config.mjs <runtimePath> <pluginRoot>");
+    process.exit(1);
+  }
+  try {
+    const { pluginsAllow, messages } = registerContextModeInOpenclawConfig(runtimePath, pluginRoot);
+    for (const msg of messages) console.log(`  ${msg}`);
+    console.log("  plugins.allow:", JSON.stringify(pluginsAllow));
+  } catch (e) {
+    console.error(`  ✗ ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/lib/register-openclaw-config.mjs
+++ b/scripts/lib/register-openclaw-config.mjs
@@ -59,7 +59,11 @@ export function registerContextModeInOpenclawConfig(runtimePath, pluginRoot) {
     !Array.isArray(existing.args) ||
     existing.args[0] !== serverBundle;
   if (needsWrite) {
-    servers["context-mode"] = { command: "node", args: [serverBundle] };
+    // Preserve any unrelated fields a user (or future OpenClaw version) may have
+    // added — e.g. `env`, `cwd`, `timeout` — and only overwrite the two this
+    // helper owns. Full-reset would silently drop those.
+    const base = existing && typeof existing === "object" ? existing : {};
+    servers["context-mode"] = { ...base, command: "node", args: [serverBundle] };
     messages.push(`registered mcp.servers.context-mode → ${serverBundle}`);
   }
 

--- a/tests/plugins/openclaw.test.ts
+++ b/tests/plugins/openclaw.test.ts
@@ -1270,4 +1270,36 @@ describe("registerContextModeInOpenclawConfig", () => {
     const cfg = JSON.parse(readFileSync(runtimePath, "utf8"));
     expect(cfg.plugins.load?.paths ?? []).not.toContain(pluginRoot);
   });
+
+  it("preserves unrelated fields on the existing mcp.servers entry when refreshing the path", () => {
+    writeFileSync(
+      runtimePath,
+      JSON.stringify({
+        mcp: {
+          servers: {
+            "context-mode": {
+              command: "node",
+              args: ["/old/path/server.bundle.mjs"],
+              env: { CTX_LOG_LEVEL: "debug" },
+              cwd: "/opt/custom",
+              timeout: 45000,
+            },
+          },
+        },
+      }),
+    );
+    registerContextModeInOpenclawConfig(runtimePath, "/new/path");
+    const entry = JSON.parse(readFileSync(runtimePath, "utf8")).mcp.servers["context-mode"];
+    expect(entry.args[0]).toEqual("/new/path/server.bundle.mjs");
+    expect(entry.env).toEqual({ CTX_LOG_LEVEL: "debug" });
+    expect(entry.cwd).toEqual("/opt/custom");
+    expect(entry.timeout).toEqual(45000);
+  });
+
+  it("throws a useful error when the runtime config is not valid JSON", () => {
+    writeFileSync(runtimePath, "{ this is not json");
+    expect(() => registerContextModeInOpenclawConfig(runtimePath, pluginRoot)).toThrow(
+      /Failed to parse.*valid JSON/,
+    );
+  });
 });

--- a/tests/plugins/openclaw.test.ts
+++ b/tests/plugins/openclaw.test.ts
@@ -1174,3 +1174,100 @@ describe("WorkspaceRouter", () => {
       .toBeNull();
   });
 });
+
+// ═══════════════════════════════════════════════════════════
+// Install-time runtime-config mutation
+// (scripts/lib/register-openclaw-config.mjs, called by
+//  scripts/install-openclaw-plugin.sh step 5)
+// ═══════════════════════════════════════════════════════════
+
+describe("registerContextModeInOpenclawConfig", () => {
+  const { readFileSync } = require("node:fs") as typeof import("node:fs");
+  let tmp: string;
+  let runtimePath: string;
+  const pluginRoot = "/fake/plugin/root";
+  const expectedBundle = `${pluginRoot}/server.bundle.mjs`;
+
+  // Dynamic import avoids a TS `allowJs: false` compile error for the .mjs
+  // helper while still running the real implementation under vitest.
+  let registerContextModeInOpenclawConfig: (
+    runtimePath: string,
+    pluginRoot: string,
+  ) => {
+    pluginsAllow: string[];
+    mcpServer: { command: string; args: string[] };
+    messages: string[];
+  };
+
+  beforeAll(async () => {
+    ({ registerContextModeInOpenclawConfig } = (await import(
+      "../../scripts/lib/register-openclaw-config.mjs"
+    )) as {
+      registerContextModeInOpenclawConfig: typeof registerContextModeInOpenclawConfig;
+    });
+  });
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "openclaw-install-cfg-"));
+    runtimePath = join(tmp, "openclaw.json");
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("registers mcp.servers.context-mode with an absolute server.bundle.mjs path", () => {
+    writeFileSync(runtimePath, "{}");
+    registerContextModeInOpenclawConfig(runtimePath, pluginRoot);
+    const cfg = JSON.parse(readFileSync(runtimePath, "utf8"));
+    expect(cfg.mcp?.servers?.["context-mode"]).toEqual({
+      command: "node",
+      args: [expectedBundle],
+    });
+  });
+
+  it("is idempotent — re-running against an already-configured file is a no-op", () => {
+    writeFileSync(runtimePath, "{}");
+    registerContextModeInOpenclawConfig(runtimePath, pluginRoot);
+    const first = readFileSync(runtimePath, "utf8");
+    registerContextModeInOpenclawConfig(runtimePath, pluginRoot);
+    const second = readFileSync(runtimePath, "utf8");
+    expect(second).toEqual(first);
+  });
+
+  it("updates a stale MCP server path when pluginRoot changes", () => {
+    writeFileSync(
+      runtimePath,
+      JSON.stringify({
+        mcp: {
+          servers: {
+            "context-mode": { command: "node", args: ["/old/path/server.bundle.mjs"] },
+          },
+        },
+      }),
+    );
+    registerContextModeInOpenclawConfig(runtimePath, "/new/path");
+    const cfg = JSON.parse(readFileSync(runtimePath, "utf8"));
+    expect(cfg.mcp.servers["context-mode"].args[0]).toEqual(
+      "/new/path/server.bundle.mjs",
+    );
+  });
+
+  it("keeps the existing plugins.allow / plugins.entries contract", () => {
+    writeFileSync(runtimePath, "{}");
+    registerContextModeInOpenclawConfig(runtimePath, pluginRoot);
+    const cfg = JSON.parse(readFileSync(runtimePath, "utf8"));
+    expect(cfg.plugins.allow).toContain("context-mode");
+    expect(cfg.plugins.entries["context-mode"]).toEqual({ enabled: true });
+  });
+
+  it("removes the legacy plugins.load.paths entry when present", () => {
+    writeFileSync(
+      runtimePath,
+      JSON.stringify({ plugins: { load: { paths: [pluginRoot, "/other/plugin"] } } }),
+    );
+    registerContextModeInOpenclawConfig(runtimePath, pluginRoot);
+    const cfg = JSON.parse(readFileSync(runtimePath, "utf8"));
+    expect(cfg.plugins.load?.paths ?? []).not.toContain(pluginRoot);
+  });
+});


### PR DESCRIPTION
## Summary

Before this PR, installing context-mode on OpenClaw `2026.4.22` produced a silent registration failure: `openclaw plugins list` showed the plugin as `loaded`, `openclaw doctor` reported zero errors, `scripts/ctx-debug.sh` mostly passed — but none of the `ctx_*` tools surfaced to the agent. The model even refused an explicit request:

> "I can't use `ctx_execute` here because that tool isn't available in this session; if you want, I can do the same calculation with `exec` instead."

**Cause**: context-mode's `ctx_*` tools live in `src/server.ts`, exposed over stdio MCP (11× `server.registerTool` + `StdioServerTransport`). Other adapters (Claude Code, Codex, Cursor) spawn `server.bundle.mjs` via their platform's `mcpServers` config. The OpenClaw install script writes `plugins.allow` / `plugins.entries` to `openclaw.json` but never adds the `mcp.servers.context-mode` entry, so the gateway never spawns the sidecar and the agent never sees the tools.

This PR fills in that step.

## Changes

- **`scripts/lib/register-openclaw-config.mjs` (new)** — idempotent helper extracted from the install script. Writes `plugins.allow`, `plugins.entries`, cleans legacy `plugins.load.paths` (existing behavior), **and additionally registers `mcp.servers.context-mode`** pointing at `<pluginRoot>/server.bundle.mjs`. Re-running is a no-op; stale server paths are refreshed.
- **`scripts/install-openclaw-plugin.sh`** — step 5 delegates to the new helper (previously inline `node -e`).
- **`tests/plugins/openclaw.test.ts`** — 5 new unit tests against the helper: MCP entry presence, idempotency, stale-path refresh, `plugins.allow`/`entries` contract, legacy `plugins.load.paths` cleanup.
- **`docs/adapters/openclaw.md`** — new troubleshooting entry documenting the MCP-sidecar requirement and the manual `openclaw mcp set` recovery command.

## Verification

```
$ npm run typecheck
> tsc --noEmit
(clean)

$ npx vitest run tests/plugins/openclaw.test.ts tests/adapters/openclaw.test.ts
 Test Files  2 passed (2)
      Tests  117 passed (117)     # baseline 112 + 5 new
```

Live check on OpenClaw `2026.4.22` + context-mode `1.0.89` after the fix — the agent's tool inventory now includes the full `ctx_*` surface (OpenClaw prefixes MCP-sourced tool names with the server name):

```
context-mode__ctx_batch_execute
context-mode__ctx_doctor
context-mode__ctx_execute
context-mode__ctx_execute_file
context-mode__ctx_fetch_and_index
context-mode__ctx_index
context-mode__ctx_insight
context-mode__ctx_purge
context-mode__ctx_search
context-mode__ctx_stats
context-mode__ctx_upgrade
```

## Full debugging writeup

[gist — "OpenClaw MCP sidecar gap: debugging walkthrough"](https://gist.github.com/murataslan1/cd7b27577fcb535d56fe318c2339b400)

Covers initial (incorrect) diagnosis, cross-check with @benzntech on LinkedIn + [his follow-up on #45](https://github.com/mksglu/context-mode/issues/45#issuecomment-4307024324), the `src/server.ts` trace that surfaced the 11 `server.registerTool` calls, and the final resolution path.

## Relation to existing work

- Builds on @ipedro's adapter design in PR #122.
- Companion to issue #45 ([original comment](https://github.com/mksglu/context-mode/issues/45#issuecomment-4307024324), [follow-up](https://github.com/mksglu/context-mode/issues/45#issuecomment-4313313422)).
- The recent PreToolUse relaxation commits (`415ce57` revert of #230, `2731ca2` #166, `ece3abb` #229/#241) are **not** addressed here — they changed hook deny/passthrough behavior but did not cause this particular issue.

## Full test-suite caveats (environment-dependent)

In my local environment, `npm test` surfaces 5 failures in `tests/hooks/integration.test.ts → Security Policy Enforcement`, and `git stash`-ing this PR and re-running reproduces the same 5 failures on `main` — so they are not caused by this change on my machine. However, an independent review of the PR via the OpenAI Codex CLI (summary linked in a follow-up comment) **could not reproduce those** in a clean environment; that environment only hit a `Rust toolchain not configured` failure, also present on both branch and `main`. So whatever is going on in `tests/hooks/integration.test.ts` locally appears to be environment-specific, not a property of this PR or of `main`. CI on the project's own infra is the authoritative signal.

## Scope discipline

No changes outside the OpenClaw adapter, the OpenClaw install script, and OpenClaw docs. Other adapter hooks, `src/server.ts`, the session layer, and all non-OpenClaw tests are untouched.

## Open questions for @ipedro / @mksglu (non-blocking)

1. Should the plugin itself spawn the sidecar from `register()` rather than relying on `openclaw.json` config? If yes, what's the preferred `api.*` call?
2. `configs/openclaw/AGENTS.md` guidance uses unprefixed `ctx_execute` rather than the `context-mode__ctx_execute` name that the agent actually sees. Prefixless names in routing instructions may mildly confuse the model — worth a pass?
3. Is there a way to detect / warn when the OpenClaw version predates the `openclaw mcp set` surface?

