### PR TITLE
Security: Potential XSS via unsanitized `highlighted` content rendered with `dangerouslySetInnerHTML`

### DIFF
--- a/insight/src/routes/search.tsx
+++ b/insight/src/routes/search.tsx
@@ -79,7 +79,7 @@ function SearchPage() {
                       <pre
                         className="text-xs text-muted-foreground whitespace-pre-wrap break-words font-mono leading-relaxed"
                         dangerouslySetInnerHTML={{
-                          __html: (r.highlighted || esc(r.content))
+                          __html: (r.highlighted ? esc(r.highlighted) : esc(r.content))
                             .replace(/«/g, '<mark class="bg-amber-500/20 text-foreground rounded px-0.5">')
                             .replace(/»/g, "</mark>"),
                         }}

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "86.5k+",
+  "message": "87.3k+",
   "color": "brightgreen",
-  "npm": "73.7k+",
+  "npm": "74.5k+",
   "marketplace": "12.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "92.1k+",
+  "message": "92.9k+",
   "color": "brightgreen",
-  "npm": "77.5k+",
+  "npm": "78.3k+",
   "marketplace": "14.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "89k+",
+  "message": "89.8k+",
   "color": "brightgreen",
   "npm": "75.7k+",
-  "marketplace": "13.2k+"
+  "marketplace": "14k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "85.4k+",
+  "message": "86.5k+",
   "color": "brightgreen",
-  "npm": "72.6k+",
+  "npm": "73.7k+",
   "marketplace": "12.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "89.8k+",
+  "message": "90.8k+",
   "color": "brightgreen",
-  "npm": "75.7k+",
+  "npm": "76.7k+",
   "marketplace": "14k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "87.4k+",
+  "message": "88k+",
   "color": "brightgreen",
-  "npm": "74.5k+",
+  "npm": "75.1k+",
   "marketplace": "12.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "87.3k+",
+  "message": "87.4k+",
   "color": "brightgreen",
   "npm": "74.5k+",
-  "marketplace": "12.7k+"
+  "marketplace": "12.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "93.4k+",
+  "message": "94.2k+",
   "color": "brightgreen",
-  "npm": "78.3k+",
+  "npm": "79.1k+",
   "marketplace": "15k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "90.8k+",
+  "message": "91.3k+",
   "color": "brightgreen",
   "npm": "76.7k+",
-  "marketplace": "14k+"
+  "marketplace": "14.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "82.2k+",
+  "message": "83.1k+",
   "color": "brightgreen",
   "npm": "71.2k+",
-  "marketplace": "11k+"
+  "marketplace": "11.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "83.7k+",
+  "message": "85.1k+",
   "color": "brightgreen",
-  "npm": "71.2k+",
+  "npm": "72.6k+",
   "marketplace": "12.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "83.1k+",
+  "message": "83.7k+",
   "color": "brightgreen",
   "npm": "71.2k+",
-  "marketplace": "11.8k+"
+  "marketplace": "12.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -4,5 +4,5 @@
   "message": "88k+",
   "color": "brightgreen",
   "npm": "75.1k+",
-  "marketplace": "12.8k+"
+  "marketplace": "12.9k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "91.3k+",
+  "message": "92.1k+",
   "color": "brightgreen",
-  "npm": "76.7k+",
+  "npm": "77.5k+",
   "marketplace": "14.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "85.1k+",
+  "message": "85.4k+",
   "color": "brightgreen",
   "npm": "72.6k+",
-  "marketplace": "12.4k+"
+  "marketplace": "12.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "94.2k+",
+  "message": "95k+",
   "color": "brightgreen",
   "npm": "79.1k+",
-  "marketplace": "15k+"
+  "marketplace": "15.9k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "88k+",
+  "message": "89k+",
   "color": "brightgreen",
-  "npm": "75.1k+",
-  "marketplace": "12.9k+"
+  "npm": "75.7k+",
+  "marketplace": "13.2k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "92.9k+",
+  "message": "93.4k+",
   "color": "brightgreen",
   "npm": "78.3k+",
-  "marketplace": "14.5k+"
+  "marketplace": "15k+"
 }


### PR DESCRIPTION
## Problem

The search results view renders HTML using `dangerouslySetInnerHTML` and prefers `r.highlighted` when present. While `r.content` is escaped via `esc()`, `r.highlighted` is inserted without sanitization. If `highlighted` can be influenced by user-controlled indexed content or backend responses, an attacker could inject arbitrary HTML/JS (stored or reflected XSS).

**Severity**: `high`
**File**: `insight/src/routes/search.tsx`

## Solution

Avoid `dangerouslySetInnerHTML` for search highlights. Return structured highlight spans from the backend or sanitize `r.highlighted` with a robust HTML sanitizer (e.g., DOMPurify) before rendering. Prefer rendering text nodes and explicit `<mark>` elements instead of raw HTML.

## Changes

- `insight/src/routes/search.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
