### PR TITLE
feat: add Qwen Code adapter with Windows Bun detection

### DIFF
--- a/configs/qwen-code/QWEN.md
+++ b/configs/qwen-code/QWEN.md
@@ -1,0 +1,69 @@
+# context-mode — MANDATORY routing rules
+
+You have context-mode MCP tools available. These rules are NOT optional — they protect your context window from flooding. A single unrouted command can dump 56 KB into context and waste the entire session.
+
+## Think in Code — MANDATORY
+
+When you need to analyze, count, filter, compare, search, parse, transform, or process data: **write code** that does the work via `mcp__context-mode__ctx_execute(language, code)` and `console.log()` only the answer. Do NOT read raw data into context to process mentally. Your role is to PROGRAM the analysis, not to COMPUTE it. Write robust, pure JavaScript — no npm dependencies, only Node.js built-ins (`fs`, `path`, `child_process`). Always use `try/catch`, handle `null`/`undefined`, and ensure compatibility with both Node.js and Bun. One script replaces ten tool calls and saves 100x context.
+
+## BLOCKED commands — do NOT attempt these
+
+### curl / wget — BLOCKED
+Any `run_shell_command` containing `curl` or `wget` is intercepted and replaced with an error message. Do NOT retry.
+Instead use:
+- `mcp__context-mode__ctx_fetch_and_index(url, source)` to fetch and index web pages
+- `mcp__context-mode__ctx_execute(language: "javascript", code: "const r = await fetch(...)")` to run HTTP calls in sandbox
+
+### Inline HTTP — BLOCKED
+Any `run_shell_command` containing `fetch('http`, `requests.get(`, `requests.post(`, `http.get(`, or `http.request(` is intercepted and replaced with an error message. Do NOT retry with `run_shell_command`.
+Instead use:
+- `mcp__context-mode__ctx_execute(language, code)` to run HTTP calls in sandbox — only stdout enters context
+
+### web_fetch — BLOCKED
+`web_fetch` calls are denied entirely. The URL is extracted and you are told to use `mcp__context-mode__ctx_fetch_and_index` instead.
+Instead use:
+- `mcp__context-mode__ctx_fetch_and_index(url, source)` then `mcp__context-mode__ctx_search(queries)` to query the indexed content
+
+## REDIRECTED tools — use sandbox equivalents
+
+### run_shell_command (>20 lines output)
+`run_shell_command` is ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`, and other short-output commands.
+For everything else, use:
+- `mcp__context-mode__ctx_batch_execute(commands, queries)` — run multiple commands + search in ONE call
+- `mcp__context-mode__ctx_execute(language: "shell", code: "...")` — run in sandbox, only stdout enters context
+
+### read_file (for analysis)
+If you are reading a file to **edit** it → `read_file` is correct (edit needs content in context).
+If you are reading to **analyze, explore, or summarize** → use `mcp__context-mode__ctx_execute_file(path, language, code)` instead. Only your printed summary enters context. The raw file content stays in the sandbox.
+
+### grep_search (large results)
+`grep_search` results can flood context. Use `mcp__context-mode__ctx_execute(language: "shell", code: "grep ...")` to run searches in sandbox. Only your printed summary enters context.
+
+## Tool selection hierarchy
+
+1. **GATHER**: `mcp__context-mode__ctx_batch_execute(commands, queries)` — Primary tool. Runs all commands, auto-indexes output, returns search results. ONE call replaces 30+ individual calls. Each command: `{label: "descriptive header", command: "..."}`. Label becomes FTS5 chunk title — descriptive labels improve search.
+2. **FOLLOW-UP**: `mcp__context-mode__ctx_search(queries: ["q1", "q2", ...])` — Query indexed content. Pass ALL questions as array in ONE call.
+3. **PROCESSING**: `mcp__context-mode__ctx_execute(language, code)` | `mcp__context-mode__ctx_execute_file(path, language, code)` — Sandbox execution. Only stdout enters context.
+4. **WEB**: `mcp__context-mode__ctx_fetch_and_index(url, source)` then `mcp__context-mode__ctx_search(queries)` — Fetch, chunk, index, query. Raw HTML never enters context.
+5. **INDEX**: `mcp__context-mode__ctx_index(content, source)` — Store content in FTS5 knowledge base for later search.
+
+## Subagent routing
+
+When spawning subagents (`agent` tool), the routing block is automatically injected into their prompt. You do NOT need to manually instruct subagents about context-mode.
+
+## Output constraints
+
+- Keep responses under 500 words.
+- Write artifacts (code, configs, PRDs) to FILES — never return them as inline text. Return only: file path + 1-line description.
+- When indexing content, use descriptive source labels so others can `mcp__context-mode__ctx_search(source: "label")` later.
+
+## ctx commands
+
+| Command | Action |
+|---------|--------|
+| `ctx stats` | Call the `mcp__context-mode__ctx_stats` MCP tool and display the full output verbatim |
+| `ctx doctor` | Call the `mcp__context-mode__ctx_doctor` MCP tool, run the returned shell command, display as checklist |
+| `ctx upgrade` | Call the `mcp__context-mode__ctx_upgrade` MCP tool, run the returned shell command, display as checklist |
+| `ctx purge` | Call the `mcp__context-mode__ctx_purge` MCP tool with confirm: true. Warns before wiping the knowledge base. |
+
+After /clear or /compact: knowledge base and session stats are preserved. Use `ctx purge` if you want to start fresh.

--- a/configs/qwen-code/settings.json
+++ b/configs/qwen-code/settings.json
@@ -1,0 +1,59 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "run_shell_command|web_fetch|read_file|grep_search|agent|mcp__context-mode__ctx_execute|mcp__context-mode__ctx_execute_file|mcp__context-mode__ctx_batch_execute",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"{{PLUGIN_ROOT}}/hooks/pretooluse.mjs\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"{{PLUGIN_ROOT}}/hooks/posttooluse.mjs\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"{{PLUGIN_ROOT}}/hooks/precompact.mjs\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"{{PLUGIN_ROOT}}/hooks/sessionstart.mjs\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"{{PLUGIN_ROOT}}/hooks/userpromptsubmit.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/adapters/client-map.ts
+++ b/src/adapters/client-map.ts
@@ -23,4 +23,5 @@ export const CLIENT_NAME_TO_PLATFORM: Record<string, PlatformId> = {
   "Pi Coding Agent": "pi",
   "Zed": "zed",
   "zed": "zed",
+  "qwen-code": "qwen-code",
 };

--- a/src/adapters/detect.ts
+++ b/src/adapters/detect.ts
@@ -15,6 +15,7 @@
  *   - Codex CLI:      CODEX_CI, CODEX_THREAD_ID | ~/.codex/
  *   - Cursor:         CURSOR_TRACE_ID (MCP), CURSOR_CLI (terminal) | ~/.cursor/
  *   - VS Code Copilot: VSCODE_PID, VSCODE_CWD | ~/.vscode/
+ *   - Qwen Code:      QWEN_PROJECT_DIR, QWEN_SESSION_ID | ~/.qwen/
  */
 
 import { existsSync } from "node:fs";
@@ -48,7 +49,7 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
   if (platformOverride) {
     const validPlatforms: PlatformId[] = [
       "claude-code", "gemini-cli", "kilo", "opencode", "codex",
-      "vscode-copilot", "cursor", "antigravity", "kiro", "pi", "zed",
+      "vscode-copilot", "cursor", "antigravity", "kiro", "pi", "zed", "qwen-code",
     ];
     if (validPlatforms.includes(platformOverride as PlatformId)) {
       return {
@@ -122,6 +123,14 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
       platform: "vscode-copilot",
       confidence: "high",
       reason: "VSCODE_PID or VSCODE_CWD env var set",
+    };
+  }
+
+  if (process.env.QWEN_PROJECT_DIR || process.env.QWEN_SESSION_ID) {
+    return {
+      platform: "qwen-code",
+      confidence: "high",
+      reason: "QWEN_PROJECT_DIR or QWEN_SESSION_ID env var set",
     };
   }
 
@@ -209,6 +218,14 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
     };
   }
 
+  if (existsSync(resolve(home, ".qwen"))) {
+    return {
+      platform: "qwen-code",
+      confidence: "medium",
+      reason: "~/.qwen/ directory exists",
+    };
+  }
+
   // ── Low confidence: fallback ───────────────────────────
 
   return {
@@ -275,6 +292,11 @@ export async function getAdapter(platform?: PlatformId): Promise<HookAdapter> {
     case "zed": {
       const { ZedAdapter } = await import("./zed/index.js");
       return new ZedAdapter();
+    }
+
+    case "qwen-code": {
+      const { QwenCodeAdapter } = await import("./qwen-code/index.js");
+      return new QwenCodeAdapter();
     }
 
     default: {

--- a/src/adapters/qwen-code/hooks.ts
+++ b/src/adapters/qwen-code/hooks.ts
@@ -1,0 +1,173 @@
+/**
+ * adapters/qwen-code/hooks — Qwen Code hook definitions and matchers.
+ *
+ * Defines the hook types, matchers, and registration format specific to
+ * Qwen Code's hook system. This module is used by:
+ *   - CLI setup/upgrade commands (to configure hooks in settings.json)
+ *   - Doctor command (to validate hook configuration)
+ *
+ * Qwen Code hook system reference:
+ *   - Hooks are registered in ~/.qwen/settings.json under "hooks" key
+ *   - Each hook type maps to an array of { matcher, hooks } entries
+ *   - matcher: tool name pattern (empty = match all tools)
+ *   - hooks: array of { type: "command", command: "..." }
+ *   - Input: JSON on stdin
+ *   - Output: JSON on stdout (or empty for passthrough)
+ *   - Hook I/O format is identical to Claude Code (hookSpecificOutput.permissionDecision)
+ */
+
+// ─────────────────────────────────────────────────────────
+// Hook type constants
+// ─────────────────────────────────────────────────────────
+
+/** Qwen Code hook types (same names as Claude Code). */
+export const HOOK_TYPES = {
+  PRE_TOOL_USE: "PreToolUse",
+  POST_TOOL_USE: "PostToolUse",
+  PRE_COMPACT: "PreCompact",
+  SESSION_START: "SessionStart",
+  USER_PROMPT_SUBMIT: "UserPromptSubmit",
+} as const;
+
+export type HookType = (typeof HOOK_TYPES)[keyof typeof HOOK_TYPES];
+
+// ─────────────────────────────────────────────────────────
+// PreToolUse matchers
+// ─────────────────────────────────────────────────────────
+
+/** Tools that context-mode's PreToolUse hook intercepts in Qwen Code. */
+export const PRE_TOOL_USE_MATCHERS = [
+  "run_shell_command",
+  "web_fetch",
+  "read_file",
+  "grep_search",
+  "agent",
+  "mcp__context-mode__ctx_execute",
+  "mcp__context-mode__ctx_execute_file",
+  "mcp__context-mode__ctx_batch_execute",
+] as const;
+
+/**
+ * Combined matcher pattern for settings.json (pipe-separated).
+ * Used by the upgrade command when writing a single consolidated entry.
+ */
+export const PRE_TOOL_USE_MATCHER_PATTERN = PRE_TOOL_USE_MATCHERS.join("|");
+
+// ─────────────────────────────────────────────────────────
+// PostToolUse matchers
+// ─────────────────────────────────────────────────────────
+
+/**
+ * Tools that context-mode's PostToolUse hook should fire on.
+ * Only tools that extractEvents() actually handles — all others
+ * produce zero events and cause false "hook error" display.
+ */
+export const POST_TOOL_USE_MATCHERS = [
+  "run_shell_command",
+  "read_file",
+  "write_file",
+  "edit",
+  "glob",
+  "grep_search",
+  "todo_write",
+  "agent",
+  "ask_user_question",
+  "mcp__",
+] as const;
+
+/**
+ * Combined matcher pattern for PostToolUse in settings.json.
+ */
+export const POST_TOOL_USE_MATCHER_PATTERN = POST_TOOL_USE_MATCHERS.join("|");
+
+// ─────────────────────────────────────────────────────────
+// Hook script file names
+// ─────────────────────────────────────────────────────────
+
+/** Map of hook types to their script file names. */
+export const HOOK_SCRIPTS: Record<HookType, string> = {
+  PreToolUse: "pretooluse.mjs",
+  PostToolUse: "posttooluse.mjs",
+  PreCompact: "precompact.mjs",
+  SessionStart: "sessionstart.mjs",
+  UserPromptSubmit: "userpromptsubmit.mjs",
+};
+
+// ─────────────────────────────────────────────────────────
+// Hook validation
+// ─────────────────────────────────────────────────────────
+
+/** Required hooks that must be configured for context-mode to function. */
+export const REQUIRED_HOOKS: HookType[] = [
+  HOOK_TYPES.PRE_TOOL_USE,
+  HOOK_TYPES.SESSION_START,
+];
+
+/** Optional hooks that enhance functionality but aren't critical. */
+export const OPTIONAL_HOOKS: HookType[] = [
+  HOOK_TYPES.POST_TOOL_USE,
+  HOOK_TYPES.PRE_COMPACT,
+  HOOK_TYPES.USER_PROMPT_SUBMIT,
+];
+
+/**
+ * Check if a hook entry points to a context-mode hook script.
+ * Matches both legacy format (node .../pretooluse.mjs) and
+ * CLI dispatcher format (context-mode hook qwen-code pretooluse).
+ */
+export function isContextModeHook(
+  entry: { hooks?: Array<{ command?: string }> },
+  hookType: HookType,
+): boolean {
+  const scriptName = HOOK_SCRIPTS[hookType];
+  const cliCommand = buildHookCommand(hookType);
+  return (
+    entry.hooks?.some((h) =>
+      h.command?.includes(scriptName) || h.command?.includes(cliCommand),
+    ) ?? false
+  );
+}
+
+/**
+ * Build the hook command string for a given hook type.
+ * Uses absolute node path to avoid PATH issues (homebrew, nvm, volta, etc.).
+ * Falls back to CLI dispatcher if pluginRoot is not provided.
+ */
+export function buildHookCommand(hookType: HookType, pluginRoot?: string): string {
+  if (pluginRoot) {
+    const scriptName = HOOK_SCRIPTS[hookType];
+    return `node "${pluginRoot}/hooks/${scriptName}"`;
+  }
+  return `context-mode hook qwen-code ${hookType.toLowerCase()}`;
+}
+
+/**
+ * Extract the hook script file path from a command string.
+ * Returns the path if the command uses the `node "/path/to/hook.mjs"` format,
+ * or null if it uses the CLI dispatcher format (which is path-independent).
+ *
+ * Handles both quoted and unquoted paths, and both forward/back slashes.
+ */
+export function extractHookScriptPath(command: string): string | null {
+  // Match: node "/path/to/hooks/scriptname.mjs" or node /path/to/hooks/scriptname.mjs
+  const match = command.match(/node\s+"?([^"]+\.mjs)"?/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Check if a hook entry is a context-mode hook (any hook type).
+ * Broader than `isContextModeHook` — matches any context-mode script name
+ * without requiring a specific hookType.
+ */
+export function isAnyContextModeHook(
+  entry: { hooks?: Array<{ command?: string }> },
+): boolean {
+  const scriptNames = Object.values(HOOK_SCRIPTS);
+  return (
+    entry.hooks?.some((h) =>
+      h.command != null &&
+      (scriptNames.some((s) => h.command!.includes(s)) ||
+        h.command.includes("context-mode hook")),
+    ) ?? false
+  );
+}

--- a/src/adapters/qwen-code/index.ts
+++ b/src/adapters/qwen-code/index.ts
@@ -1,0 +1,540 @@
+/**
+ * adapters/qwen-code — Qwen Code platform adapter.
+ *
+ * Implements HookAdapter for Qwen Code's JSON stdin/stdout hook paradigm.
+ *
+ * Qwen Code hook specifics:
+ *   - I/O: JSON on stdin, JSON on stdout (identical to Claude Code)
+ *   - Arg modification: `updatedInput` field in response
+ *   - Blocking: `permissionDecision: "deny"` in response
+ *   - PostToolUse output: `updatedMCPToolOutput` field
+ *   - PreCompact: stdout on exit 0
+ *   - Session ID: session_id > QWEN_SESSION_ID > ppid
+ *   - Config: ~/.qwen/settings.json
+ *   - Session dir: ~/.qwen/context-mode/sessions/
+ *   - MCP tool format: mcp__<server>__<tool> (standard MCP, not plugin format)
+ *
+ * Qwen Code supports 14 hook events — more than Claude Code:
+ *   PreToolUse, PostToolUse, PostToolUseFailure, PreCompact, PostCompact,
+ *   SessionStart, SessionEnd, UserPromptSubmit, Stop, StopFailure,
+ *   SubagentStop, SubagentStopFailure, PermissionRequest, Notification
+ */
+
+import { createHash } from "node:crypto";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  copyFileSync,
+  accessSync,
+  existsSync,
+  chmodSync,
+  constants,
+} from "node:fs";
+import { resolve, join } from "node:path";
+import { homedir } from "node:os";
+
+import type {
+  HookAdapter,
+  HookParadigm,
+  PlatformCapabilities,
+  DiagnosticResult,
+  PreToolUseEvent,
+  PostToolUseEvent,
+  PreCompactEvent,
+  SessionStartEvent,
+  PreToolUseResponse,
+  PostToolUseResponse,
+  PreCompactResponse,
+  SessionStartResponse,
+  HookRegistration,
+} from "../types.js";
+import {
+  HOOK_TYPES,
+  HOOK_SCRIPTS,
+  REQUIRED_HOOKS,
+  PRE_TOOL_USE_MATCHER_PATTERN,
+  isContextModeHook,
+  isAnyContextModeHook,
+  extractHookScriptPath,
+  buildHookCommand,
+  type HookType,
+} from "./hooks.js";
+
+// ─────────────────────────────────────────────────────────
+// Qwen Code raw input types
+// ─────────────────────────────────────────────────────────
+
+interface QwenCodeHookInput {
+  tool_name?: string;
+  tool_input?: Record<string, unknown>;
+  tool_output?: string;
+  is_error?: boolean;
+  session_id?: string;
+  transcript_path?: string;
+  source?: string;
+}
+
+// ─────────────────────────────────────────────────────────
+// Adapter implementation
+// ─────────────────────────────────────────────────────────
+
+export class QwenCodeAdapter implements HookAdapter {
+  readonly name = "Qwen Code";
+  readonly paradigm: HookParadigm = "json-stdio";
+
+  readonly capabilities: PlatformCapabilities = {
+    preToolUse: true,
+    postToolUse: true,
+    preCompact: true,
+    sessionStart: true,
+    canModifyArgs: true,
+    canModifyOutput: true,
+    canInjectSessionContext: true,
+  };
+
+  // ── Input parsing ──────────────────────────────────────
+
+  parsePreToolUseInput(raw: unknown): PreToolUseEvent {
+    const input = raw as QwenCodeHookInput;
+    return {
+      toolName: input.tool_name ?? "",
+      toolInput: input.tool_input ?? {},
+      sessionId: this.extractSessionId(input),
+      projectDir: process.env.QWEN_PROJECT_DIR ?? process.cwd(),
+      raw,
+    };
+  }
+
+  parsePostToolUseInput(raw: unknown): PostToolUseEvent {
+    const input = raw as QwenCodeHookInput;
+    return {
+      toolName: input.tool_name ?? "",
+      toolInput: input.tool_input ?? {},
+      toolOutput: input.tool_output,
+      isError: input.is_error,
+      sessionId: this.extractSessionId(input),
+      projectDir: process.env.QWEN_PROJECT_DIR ?? process.cwd(),
+      raw,
+    };
+  }
+
+  parsePreCompactInput(raw: unknown): PreCompactEvent {
+    const input = raw as QwenCodeHookInput;
+    return {
+      sessionId: this.extractSessionId(input),
+      projectDir: process.env.QWEN_PROJECT_DIR ?? process.cwd(),
+      raw,
+    };
+  }
+
+  parseSessionStartInput(raw: unknown): SessionStartEvent {
+    const input = raw as QwenCodeHookInput;
+    const rawSource = input.source ?? "startup";
+
+    let source: SessionStartEvent["source"];
+    switch (rawSource) {
+      case "compact":
+        source = "compact";
+        break;
+      case "resume":
+        source = "resume";
+        break;
+      case "clear":
+        source = "clear";
+        break;
+      default:
+        source = "startup";
+    }
+
+    return {
+      sessionId: this.extractSessionId(input),
+      source,
+      projectDir: process.env.QWEN_PROJECT_DIR ?? process.cwd(),
+      raw,
+    };
+  }
+
+  // ── Response formatting ────────────────────────────────
+
+  formatPreToolUseResponse(response: PreToolUseResponse): unknown {
+    if (response.decision === "deny") {
+      return {
+        permissionDecision: "deny",
+        reason: response.reason ?? "Blocked by context-mode hook",
+      };
+    }
+    if (response.decision === "modify" && response.updatedInput) {
+      return { updatedInput: response.updatedInput };
+    }
+    if (response.decision === "context" && response.additionalContext) {
+      // Qwen Code: inject additionalContext into model context
+      return { additionalContext: response.additionalContext };
+    }
+    if (response.decision === "ask") {
+      // Qwen Code: native "ask" — prompt user for permission
+      return { permissionDecision: "ask" };
+    }
+    // "allow" — return null/undefined for passthrough
+    return undefined;
+  }
+
+  formatPostToolUseResponse(response: PostToolUseResponse): unknown {
+    const result: Record<string, unknown> = {};
+    if (response.additionalContext) {
+      result.additionalContext = response.additionalContext;
+    }
+    if (response.updatedOutput) {
+      result.updatedMCPToolOutput = response.updatedOutput;
+    }
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  formatPreCompactResponse(response: PreCompactResponse): unknown {
+    // Qwen Code: stdout content on exit 0 is injected as context
+    return response.context ?? "";
+  }
+
+  formatSessionStartResponse(response: SessionStartResponse): unknown {
+    // Qwen Code: stdout content is injected as additional context
+    return response.context ?? "";
+  }
+
+  // ── Configuration ──────────────────────────────────────
+
+  getSettingsPath(): string {
+    return resolve(homedir(), ".qwen", "settings.json");
+  }
+
+  getSessionDir(): string {
+    const dir = join(homedir(), ".qwen", "context-mode", "sessions");
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  getSessionDBPath(projectDir: string): string {
+    const hash = createHash("sha256")
+      .update(projectDir)
+      .digest("hex")
+      .slice(0, 16);
+    return join(this.getSessionDir(), `${hash}.db`);
+  }
+
+  getSessionEventsPath(projectDir: string): string {
+    const hash = createHash("sha256")
+      .update(projectDir)
+      .digest("hex")
+      .slice(0, 16);
+    return join(this.getSessionDir(), `${hash}-events.md`);
+  }
+
+  generateHookConfig(pluginRoot: string): HookRegistration {
+    const preToolUseCommand = `node ${pluginRoot}/hooks/pretooluse.mjs`;
+    const preToolUseMatchers = [
+      "run_shell_command",
+      "web_fetch",
+      "read_file",
+      "grep_search",
+      "agent",
+      "mcp__context-mode__ctx_execute",
+      "mcp__context-mode__ctx_execute_file",
+      "mcp__context-mode__ctx_batch_execute",
+    ];
+
+    return {
+      PreToolUse: preToolUseMatchers.map((matcher) => ({
+        matcher,
+        hooks: [{ type: "command", command: preToolUseCommand }],
+      })),
+      PostToolUse: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command: `node ${pluginRoot}/hooks/posttooluse.mjs`,
+            },
+          ],
+        },
+      ],
+      PreCompact: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command: `node ${pluginRoot}/hooks/precompact.mjs`,
+            },
+          ],
+        },
+      ],
+      UserPromptSubmit: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command: `node ${pluginRoot}/hooks/userpromptsubmit.mjs`,
+            },
+          ],
+        },
+      ],
+      SessionStart: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command: `node ${pluginRoot}/hooks/sessionstart.mjs`,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  readSettings(): Record<string, unknown> | null {
+    try {
+      const raw = readFileSync(this.getSettingsPath(), "utf-8");
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  writeSettings(settings: Record<string, unknown>): void {
+    writeFileSync(
+      this.getSettingsPath(),
+      JSON.stringify(settings, null, 2) + "\n",
+      "utf-8",
+    );
+  }
+
+  // ── Diagnostics (doctor) ─────────────────────────────────
+
+  validateHooks(pluginRoot: string): DiagnosticResult[] {
+    const results: DiagnosticResult[] = [];
+    const settings = this.readSettings();
+
+    if (!settings) {
+      results.push({
+        check: "PreToolUse hook",
+        status: "fail",
+        message: "Could not read ~/.qwen/settings.json",
+        fix: "context-mode upgrade",
+      });
+      return results;
+    }
+
+    const hooks = settings.hooks as Record<string, unknown[]> | undefined;
+
+    // Check PreToolUse
+    const hasPreToolUse = this.checkHookType(hooks, HOOK_TYPES.PRE_TOOL_USE);
+    results.push({
+      check: "PreToolUse hook",
+      status: hasPreToolUse ? "pass" : "fail",
+      message: hasPreToolUse
+        ? "PreToolUse hook configured"
+        : "No PreToolUse hooks found",
+      fix: hasPreToolUse ? undefined : "context-mode upgrade",
+    });
+
+    // Check SessionStart
+    const hasSessionStart = this.checkHookType(hooks, HOOK_TYPES.SESSION_START);
+    results.push({
+      check: "SessionStart hook",
+      status: hasSessionStart ? "pass" : "fail",
+      message: hasSessionStart
+        ? "SessionStart hook configured"
+        : "No SessionStart hooks found",
+      fix: hasSessionStart ? undefined : "context-mode upgrade",
+    });
+
+    return results;
+  }
+
+  /** Check if a hook type is configured in settings.json */
+  private checkHookType(
+    settingsHooks: Record<string, unknown[]> | undefined,
+    hookType: HookType,
+  ): boolean {
+    type HookEntry = { matcher?: string; hooks?: Array<{ command?: string }> };
+
+    const fromSettings = settingsHooks?.[hookType] as HookEntry[] | undefined;
+    if (fromSettings && fromSettings.length > 0) {
+      if (fromSettings.some((entry) => isContextModeHook(entry, hookType))) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  checkPluginRegistration(): DiagnosticResult {
+    // Qwen Code does not have a plugin system — hooks are registered
+    // directly in settings.json. This is always a pass.
+    return {
+      check: "Hook registration",
+      status: "pass",
+      message: "Qwen Code uses direct settings.json hook registration (no plugin system)",
+    };
+  }
+
+  getInstalledVersion(): string {
+    // Qwen Code has no plugin registry. Check if context-mode hooks
+    // are configured in settings.json as a proxy for "installed".
+    const settings = this.readSettings();
+    if (!settings) return "not installed";
+
+    const hooks = settings.hooks as Record<string, unknown[]> | undefined;
+    if (!hooks) return "not installed";
+
+    const hasHooks = REQUIRED_HOOKS.some((ht) => this.checkHookType(hooks, ht));
+    return hasHooks ? "installed (hooks configured)" : "not installed";
+  }
+
+  // ── Upgrade ────────────────────────────────────────────
+
+  configureAllHooks(pluginRoot: string): string[] {
+    const settings = this.readSettings() ?? {};
+    const hooks = (settings.hooks ?? {}) as Record<string, unknown>;
+    const changes: string[] = [];
+
+    // Remove stale context-mode hook entries across ALL hook types.
+    // After an update or version change, settings.json may contain
+    // hardcoded paths pointing to deleted version directories.
+    // Clean these before registering fresh entries.
+    for (const hookType of Object.keys(hooks)) {
+      const entries = hooks[hookType];
+      if (!Array.isArray(entries)) continue;
+
+      const filtered = entries.filter((entry: Record<string, unknown>) => {
+        const typedEntry = entry as { hooks?: Array<{ command?: string }> };
+        if (!isAnyContextModeHook(typedEntry)) return true; // preserve non-context-mode hooks
+
+        // Keep CLI dispatcher entries (path-independent, never stale)
+        const commands = typedEntry.hooks ?? [];
+        const hasOnlyDispatcherCommands = commands.every(
+          (h) => !h.command || !extractHookScriptPath(h.command),
+        );
+        if (hasOnlyDispatcherCommands) return true;
+
+        // For node path commands, check if the referenced script file exists
+        return commands.every((h) => {
+          const scriptPath = h.command ? extractHookScriptPath(h.command) : null;
+          if (!scriptPath) return true; // not a path-based command
+          return existsSync(scriptPath);
+        });
+      });
+
+      const removed = entries.length - filtered.length;
+      if (removed > 0) {
+        hooks[hookType] = filtered;
+        changes.push(`Removed ${removed} stale ${hookType} hook(s)`);
+      }
+    }
+
+    // Register fresh hooks for required hook types
+    const hookTypes: HookType[] = [
+      HOOK_TYPES.PRE_TOOL_USE,
+      HOOK_TYPES.SESSION_START,
+    ];
+
+    for (const hookType of hookTypes) {
+      const command = buildHookCommand(hookType, pluginRoot);
+
+      if (hookType === HOOK_TYPES.PRE_TOOL_USE) {
+        const entry = {
+          matcher: PRE_TOOL_USE_MATCHER_PATTERN,
+          hooks: [{ type: "command", command }],
+        };
+        const existing = hooks.PreToolUse as Array<Record<string, unknown>> | undefined;
+        if (existing && Array.isArray(existing)) {
+          const idx = existing.findIndex((e) =>
+            isContextModeHook(e as { hooks?: Array<{ command?: string }> }, hookType),
+          );
+          if (idx >= 0) {
+            existing[idx] = entry;
+            changes.push(`Updated existing ${hookType} hook entry`);
+          } else {
+            existing.push(entry);
+            changes.push(`Added ${hookType} hook entry`);
+          }
+          hooks.PreToolUse = existing;
+        } else {
+          hooks.PreToolUse = [entry];
+          changes.push(`Created ${hookType} hooks section`);
+        }
+      } else {
+        const entry = {
+          matcher: "",
+          hooks: [{ type: "command", command }],
+        };
+        const existing = hooks[hookType] as Array<Record<string, unknown>> | undefined;
+        if (existing && Array.isArray(existing)) {
+          const idx = existing.findIndex((e) =>
+            isContextModeHook(e as { hooks?: Array<{ command?: string }> }, hookType),
+          );
+          if (idx >= 0) {
+            existing[idx] = entry;
+            changes.push(`Updated existing ${hookType} hook entry`);
+          } else {
+            existing.push(entry);
+            changes.push(`Added ${hookType} hook entry`);
+          }
+          hooks[hookType] = existing;
+        } else {
+          hooks[hookType] = [entry];
+          changes.push(`Created ${hookType} hooks section`);
+        }
+      }
+    }
+
+    settings.hooks = hooks;
+    this.writeSettings(settings);
+    return changes;
+  }
+
+  backupSettings(): string | null {
+    const settingsPath = this.getSettingsPath();
+    try {
+      accessSync(settingsPath, constants.R_OK);
+      const backupPath = settingsPath + ".bak";
+      copyFileSync(settingsPath, backupPath);
+      return backupPath;
+    } catch {
+      return null;
+    }
+  }
+
+  setHookPermissions(pluginRoot: string): string[] {
+    const set: string[] = [];
+    for (const [, scriptName] of Object.entries(HOOK_SCRIPTS)) {
+      const scriptPath = resolve(pluginRoot, "hooks", scriptName);
+      try {
+        accessSync(scriptPath, constants.R_OK);
+        chmodSync(scriptPath, 0o755);
+        set.push(scriptPath);
+      } catch {
+        /* skip missing scripts */
+      }
+    }
+    return set;
+  }
+
+  updatePluginRegistry(_pluginRoot: string, _version: string): void {
+    // Qwen Code has no plugin registry — no-op.
+  }
+
+  // ── Internal helpers ───────────────────────────────────
+
+  /**
+   * Extract session ID from Qwen Code hook input.
+   * Priority: session_id field > QWEN_SESSION_ID env > ppid fallback.
+   */
+  private extractSessionId(input: QwenCodeHookInput): string {
+    if (input.session_id) return input.session_id;
+    if (process.env.QWEN_SESSION_ID) return process.env.QWEN_SESSION_ID;
+    return `pid-${process.ppid}`;
+  }
+}

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -288,6 +288,7 @@ export type PlatformId =
   | "kiro"
   | "pi"
   | "zed"
+  | "qwen-code"
   | "unknown";
 
 /** Detection signal used to identify which platform is running. */

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -49,10 +49,17 @@ function commandExists(cmd: string): boolean {
 
 function bunExists(): boolean {
   if (commandExists("bun")) return true;
-  // Bun installs to ~/.bun/bin which may not be in PATH in MCP server environments
-  if (!isWindows) {
-    const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
-    if (home && existsSync(`${home}/.bun/bin/bun`)) return true;
+  // Bun may not be in PATH in MCP server environments — check common install locations
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const candidates = isWindows
+    ? [
+        `${home}/.bun/bin/bun.exe`,
+        "D:/bun/bin/bun.exe",
+        `${process.env.LOCALAPPDATA ?? ""}/bun/bin/bun.exe`,
+      ]
+    : [`${home}/.bun/bin/bun`];
+  for (const p of candidates) {
+    if (p && existsSync(p)) return true;
   }
   return false;
 }
@@ -60,6 +67,16 @@ function bunExists(): boolean {
 function bunCommand(): string {
   if (commandExists("bun")) return "bun";
   const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const candidates = isWindows
+    ? [
+        `${home}/.bun/bin/bun.exe`,
+        "D:/bun/bin/bun.exe",
+        `${process.env.LOCALAPPDATA ?? ""}/bun/bin/bun.exe`,
+      ]
+    : [`${home}/.bun/bin/bun`];
+  for (const p of candidates) {
+    if (p && existsSync(p)) return p;
+  }
   return `${home}/.bun/bin/bun`;
 }
 

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "86.5k+",
+  "message": "87.3k+",
   "color": "brightgreen",
-  "npm": "73.7k+",
+  "npm": "74.5k+",
   "marketplace": "12.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "92.1k+",
+  "message": "92.9k+",
   "color": "brightgreen",
-  "npm": "77.5k+",
+  "npm": "78.3k+",
   "marketplace": "14.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "89k+",
+  "message": "89.8k+",
   "color": "brightgreen",
   "npm": "75.7k+",
-  "marketplace": "13.2k+"
+  "marketplace": "14k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "85.4k+",
+  "message": "86.5k+",
   "color": "brightgreen",
-  "npm": "72.6k+",
+  "npm": "73.7k+",
   "marketplace": "12.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "89.8k+",
+  "message": "90.8k+",
   "color": "brightgreen",
-  "npm": "75.7k+",
+  "npm": "76.7k+",
   "marketplace": "14k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "87.4k+",
+  "message": "88k+",
   "color": "brightgreen",
-  "npm": "74.5k+",
+  "npm": "75.1k+",
   "marketplace": "12.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "87.3k+",
+  "message": "87.4k+",
   "color": "brightgreen",
   "npm": "74.5k+",
-  "marketplace": "12.7k+"
+  "marketplace": "12.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "93.4k+",
+  "message": "94.2k+",
   "color": "brightgreen",
-  "npm": "78.3k+",
+  "npm": "79.1k+",
   "marketplace": "15k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "90.8k+",
+  "message": "91.3k+",
   "color": "brightgreen",
   "npm": "76.7k+",
-  "marketplace": "14k+"
+  "marketplace": "14.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "82.2k+",
+  "message": "83.1k+",
   "color": "brightgreen",
   "npm": "71.2k+",
-  "marketplace": "11k+"
+  "marketplace": "11.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "83.7k+",
+  "message": "85.1k+",
   "color": "brightgreen",
-  "npm": "71.2k+",
+  "npm": "72.6k+",
   "marketplace": "12.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "83.1k+",
+  "message": "83.7k+",
   "color": "brightgreen",
   "npm": "71.2k+",
-  "marketplace": "11.8k+"
+  "marketplace": "12.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -4,5 +4,5 @@
   "message": "88k+",
   "color": "brightgreen",
   "npm": "75.1k+",
-  "marketplace": "12.8k+"
+  "marketplace": "12.9k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "91.3k+",
+  "message": "92.1k+",
   "color": "brightgreen",
-  "npm": "76.7k+",
+  "npm": "77.5k+",
   "marketplace": "14.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "85.1k+",
+  "message": "85.4k+",
   "color": "brightgreen",
   "npm": "72.6k+",
-  "marketplace": "12.4k+"
+  "marketplace": "12.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "94.2k+",
+  "message": "95k+",
   "color": "brightgreen",
   "npm": "79.1k+",
-  "marketplace": "15k+"
+  "marketplace": "15.9k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "88k+",
+  "message": "89k+",
   "color": "brightgreen",
-  "npm": "75.1k+",
-  "marketplace": "12.9k+"
+  "npm": "75.7k+",
+  "marketplace": "13.2k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "92.9k+",
+  "message": "93.4k+",
   "color": "brightgreen",
   "npm": "78.3k+",
-  "marketplace": "14.5k+"
+  "marketplace": "15k+"
 }


### PR DESCRIPTION
## Summary

Adds a new platform adapter for **Qwen Code** (Alibaba's CLI coding agent), enabling context-mode to work with Qwen Code via its Hook system.

## Changes

### New files (4)
- `src/adapters/qwen-code/index.ts` — QwenCodeAdapter class (~280 lines)
- `src/adapters/qwen-code/hooks.ts` — Hook definitions mapping Qwen Code tool names
- `configs/qwen-code/settings.json` — Hook configuration template
- `configs/qwen-code/QWEN.md` — Routing instructions for Qwen Code's system prompt

### Modified files (4)
- `src/adapters/types.ts` — Added `"qwen-code"` to PlatformId union
- `src/adapters/client-map.ts` — Added qwen-code → qwen-code mapping
- `src/adapters/detect.ts` — Added env var detection (`QWEN_PROJECT_DIR`, `QWEN_SESSION_ID`), config dir detection (`~/.qwen/`), and `getAdapter()` case
- `src/runtime.ts` — Fixed `bunExists()` and `bunCommand()` on Windows to check `D:\bun\bin`, `%LOCALAPPDATA%\bun\bin`, and `~/.bun/bin/bun.exe`

## Testing

- TypeScript compilation: zero errors
- Build: `npm run build` succeeds
- `ctx doctor` on Qwen Code: all checks pass (FTS5, Bun detection, hooks)
- Verified with Node 22.20.0 on Windows 10