### PR TITLE
Add proxy support for fetch indexing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "picocolors": "^1.1.1",
         "turndown": "^7.2.0",
         "turndown-plugin-gfm": "^1.0.2",
+        "undici": "^6.25.0",
         "zod": "^3.25.0",
       },
       "devDependencies": {
@@ -493,6 +494,8 @@
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "picocolors": "^1.1.1",
     "turndown": "^7.2.0",
     "turndown-plugin-gfm": "^1.0.2",
+    "undici": "^6.25.0",
     "zod": "^3.25.0"
   },
   "optionalDependencies": {

--- a/src/fetch-proxy.ts
+++ b/src/fetch-proxy.ts
@@ -1,0 +1,216 @@
+type ProxyEnv = Record<string, string | undefined>;
+
+const HTTPS_PROXY_KEYS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] as const;
+const HTTP_PROXY_KEYS = ["HTTP_PROXY", "http_proxy"] as const;
+const UNSUPPORTED_SOCKS_PROXY_MESSAGE = "SOCKS proxies are not supported — only HTTP/HTTPS";
+
+export function getProxyUrlForRequest(rawUrl: string, env: ProxyEnv = process.env) {
+  const requestUrl = new URL(rawUrl);
+  const protocol = requestUrl.protocol;
+
+  if (protocol !== "http:" && protocol !== "https:") return undefined;
+  if (shouldBypassProxy(requestUrl, getNoProxyValue(env))) return undefined;
+
+  const keys = protocol === "https:" ? HTTPS_PROXY_KEYS : HTTP_PROXY_KEYS;
+  for (const key of keys) {
+    const value = env[key]?.trim();
+    if (value) return validateProxyUrl(value);
+  }
+
+  return undefined;
+}
+
+export function buildFetchProxyRuntimeCode(undiciPath: string) {
+  return `
+const undiciPath = ${JSON.stringify(undiciPath)};
+const HTTPS_PROXY_KEYS = ${JSON.stringify(HTTPS_PROXY_KEYS)};
+const HTTP_PROXY_KEYS = ${JSON.stringify(HTTP_PROXY_KEYS)};
+const UNSUPPORTED_SOCKS_PROXY_MESSAGE = ${JSON.stringify(UNSUPPORTED_SOCKS_PROXY_MESSAGE)};
+
+function getNoProxyValue(env) {
+  return env.NO_PROXY || env.no_proxy || "";
+}
+
+function normalizeHost(host) {
+  return host.replace(/^\\[/, "").replace(/\\]$/, "").replace(/\\.$/, "").toLowerCase();
+}
+
+function defaultPort(protocol) {
+  return protocol === "https:" ? "443" : "80";
+}
+
+function splitNoProxyToken(token) {
+  const trimmed = token.trim().toLowerCase();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    if (end === -1) return { host: normalizeHost(trimmed) };
+    const host = normalizeHost(trimmed.slice(0, end + 1));
+    const portPart = trimmed.slice(end + 1);
+    return portPart.startsWith(":") && portPart.slice(1) ? { host, port: portPart.slice(1) } : { host };
+  }
+  const colon = trimmed.lastIndexOf(":");
+  if (colon > -1 && trimmed.indexOf(":") === colon && /^\\d+$/.test(trimmed.slice(colon + 1))) {
+    return { host: normalizeHost(trimmed.slice(0, colon)), port: trimmed.slice(colon + 1) };
+  }
+  return { host: normalizeHost(trimmed) };
+}
+
+function ipv4ToNumber(ip) {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return undefined;
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\\d+$/.test(part)) return undefined;
+    const octet = Number(part);
+    if (octet < 0 || octet > 255) return undefined;
+    value = ((value << 8) + octet) >>> 0;
+  }
+  return value >>> 0;
+}
+
+function matchesIpv4Cidr(host, cidr) {
+  const pieces = cidr.split("/");
+  if (pieces.length !== 2) return false;
+  const base = ipv4ToNumber(pieces[0]);
+  const target = ipv4ToNumber(host);
+  const prefix = Number(pieces[1]);
+  if (base === undefined || target === undefined || !Number.isInteger(prefix) || prefix < 0 || prefix > 32) return false;
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (base & mask) === (target & mask);
+}
+
+function shouldBypassProxy(requestUrl, noProxy) {
+  if (!noProxy.trim()) return false;
+  const hostname = normalizeHost(requestUrl.hostname);
+  const port = requestUrl.port || defaultPort(requestUrl.protocol);
+  for (const rawToken of noProxy.split(",")) {
+    const token = splitNoProxyToken(rawToken);
+    if (!token) continue;
+    if (token.host === "*") return true;
+    if (token.port && token.port !== port) continue;
+    if (token.host.includes("/") && matchesIpv4Cidr(hostname, token.host)) return true;
+    if (token.host.startsWith(".") && (hostname === token.host.slice(1) || hostname.endsWith(token.host))) return true;
+    if (hostname === token.host || hostname.endsWith("." + token.host)) return true;
+  }
+  return false;
+}
+
+function getProxyUrlForRequest(rawUrl, env) {
+  const requestUrl = new URL(rawUrl);
+  const protocol = requestUrl.protocol;
+  if (protocol !== "http:" && protocol !== "https:") return undefined;
+  if (shouldBypassProxy(requestUrl, getNoProxyValue(env))) return undefined;
+  const keys = protocol === "https:" ? HTTPS_PROXY_KEYS : HTTP_PROXY_KEYS;
+  for (const key of keys) {
+    const value = env[key] && env[key].trim();
+    if (value) return validateProxyUrl(value);
+  }
+  return undefined;
+}
+
+function validateProxyUrl(proxyUrl) {
+  const protocol = new URL(proxyUrl).protocol;
+  if (protocol === "http:" || protocol === "https:") return proxyUrl;
+  if (protocol.startsWith("socks")) throw new Error(UNSUPPORTED_SOCKS_PROXY_MESSAGE);
+  throw new Error("Unsupported proxy protocol: " + protocol + " — only HTTP/HTTPS");
+}
+
+async function fetchWithProxy(targetUrl) {
+  const proxyUrl = getProxyUrlForRequest(targetUrl, process.env);
+  if (!proxyUrl) return fetch(targetUrl);
+  if (typeof Bun !== "undefined") return fetch(targetUrl, { proxy: proxyUrl });
+  const { ProxyAgent } = require(undiciPath);
+  return fetch(targetUrl, { dispatcher: new ProxyAgent(proxyUrl) });
+}
+`;
+}
+
+function getNoProxyValue(env: ProxyEnv) {
+  return env.NO_PROXY || env.no_proxy || "";
+}
+
+function validateProxyUrl(proxyUrl: string) {
+  const protocol = new URL(proxyUrl).protocol;
+  if (protocol === "http:" || protocol === "https:") return proxyUrl;
+  if (protocol.startsWith("socks")) throw new Error(UNSUPPORTED_SOCKS_PROXY_MESSAGE);
+  throw new Error(`Unsupported proxy protocol: ${protocol} — only HTTP/HTTPS`);
+}
+
+function shouldBypassProxy(requestUrl: URL, noProxy: string) {
+  if (!noProxy.trim()) return false;
+
+  const hostname = normalizeHost(requestUrl.hostname);
+  const port = requestUrl.port || defaultPort(requestUrl.protocol);
+
+  for (const rawToken of noProxy.split(",")) {
+    const token = splitNoProxyToken(rawToken);
+    if (!token) continue;
+    if (token.host === "*") return true;
+    if (token.port && token.port !== port) continue;
+    if (token.host.includes("/") && matchesIpv4Cidr(hostname, token.host)) return true;
+    if (token.host.startsWith(".") && (hostname === token.host.slice(1) || hostname.endsWith(token.host))) return true;
+    if (hostname === token.host || hostname.endsWith("." + token.host)) return true;
+  }
+
+  return false;
+}
+
+function splitNoProxyToken(token: string) {
+  const trimmed = token.trim().toLowerCase();
+  if (!trimmed) return undefined;
+
+  if (trimmed.startsWith("[")) {
+    const end = trimmed.indexOf("]");
+    if (end === -1) return { host: normalizeHost(trimmed) };
+
+    const host = normalizeHost(trimmed.slice(0, end + 1));
+    const portPart = trimmed.slice(end + 1);
+    return portPart.startsWith(":") && portPart.slice(1) ? { host, port: portPart.slice(1) } : { host };
+  }
+
+  const colon = trimmed.lastIndexOf(":");
+  if (colon > -1 && trimmed.indexOf(":") === colon && /^\d+$/.test(trimmed.slice(colon + 1))) {
+    return { host: normalizeHost(trimmed.slice(0, colon)), port: trimmed.slice(colon + 1) };
+  }
+
+  return { host: normalizeHost(trimmed) };
+}
+
+function normalizeHost(host: string) {
+  return host.replace(/^\[/, "").replace(/\]$/, "").replace(/\.$/, "").toLowerCase();
+}
+
+function defaultPort(protocol: string) {
+  return protocol === "https:" ? "443" : "80";
+}
+
+function matchesIpv4Cidr(host: string, cidr: string) {
+  const pieces = cidr.split("/");
+  if (pieces.length !== 2) return false;
+
+  const base = ipv4ToNumber(pieces[0] ?? "");
+  const target = ipv4ToNumber(host);
+  const prefix = Number(pieces[1]);
+  if (base === undefined || target === undefined || !Number.isInteger(prefix) || prefix < 0 || prefix > 32) {
+    return false;
+  }
+
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return (base & mask) === (target & mask);
+}
+
+function ipv4ToNumber(ip: string) {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return undefined;
+
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return undefined;
+    const octet = Number(part);
+    if (octet < 0 || octet > 255) return undefined;
+    value = ((value << 8) + octet) >>> 0;
+  }
+
+  return value >>> 0;
+}

--- a/src/fetch-proxy.ts
+++ b/src/fetch-proxy.ts
@@ -1,8 +1,8 @@
 type ProxyEnv = Record<string, string | undefined>;
-
-const HTTPS_PROXY_KEYS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] as const;
-const HTTP_PROXY_KEYS = ["HTTP_PROXY", "http_proxy"] as const;
-const UNSUPPORTED_SOCKS_PROXY_MESSAGE = "SOCKS proxies are not supported — only HTTP/HTTPS";
+type RuntimeSerializableFunction = {
+  name: string;
+  toString(): string;
+};
 
 export function getProxyUrlForRequest(rawUrl: string, env: ProxyEnv = process.env) {
   const requestUrl = new URL(rawUrl);
@@ -11,113 +11,32 @@ export function getProxyUrlForRequest(rawUrl: string, env: ProxyEnv = process.en
   if (protocol !== "http:" && protocol !== "https:") return undefined;
   if (shouldBypassProxy(requestUrl, getNoProxyValue(env))) return undefined;
 
-  const keys = protocol === "https:" ? HTTPS_PROXY_KEYS : HTTP_PROXY_KEYS;
+  const keys = protocol === "https:"
+    ? ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"]
+    : ["HTTP_PROXY", "http_proxy"];
   for (const key of keys) {
     const value = env[key]?.trim();
-    if (value) return validateProxyUrl(value);
+    if (value) return validateProxyUrl(value, key);
   }
 
   return undefined;
 }
 
 export function buildFetchProxyRuntimeCode(undiciPath: string) {
+  const runtimeFunctionCode = FETCH_PROXY_RUNTIME_FUNCTIONS
+    .map((fn) => fn.toString())
+    .join("\n\n");
+  const getProxyUrlForRequestRuntimeName = getRuntimeFunctionName(getProxyUrlForRequest);
+
   return `
 const undiciPath = ${JSON.stringify(undiciPath)};
-const HTTPS_PROXY_KEYS = ${JSON.stringify(HTTPS_PROXY_KEYS)};
-const HTTP_PROXY_KEYS = ${JSON.stringify(HTTP_PROXY_KEYS)};
-const UNSUPPORTED_SOCKS_PROXY_MESSAGE = ${JSON.stringify(UNSUPPORTED_SOCKS_PROXY_MESSAGE)};
 
-function getNoProxyValue(env) {
-  return env.NO_PROXY || env.no_proxy || "";
-}
+${runtimeFunctionCode}
 
-function normalizeHost(host) {
-  return host.replace(/^\\[/, "").replace(/\\]$/, "").replace(/\\.$/, "").toLowerCase();
-}
-
-function defaultPort(protocol) {
-  return protocol === "https:" ? "443" : "80";
-}
-
-function splitNoProxyToken(token) {
-  const trimmed = token.trim().toLowerCase();
-  if (!trimmed) return null;
-  if (trimmed.startsWith("[")) {
-    const end = trimmed.indexOf("]");
-    if (end === -1) return { host: normalizeHost(trimmed) };
-    const host = normalizeHost(trimmed.slice(0, end + 1));
-    const portPart = trimmed.slice(end + 1);
-    return portPart.startsWith(":") && portPart.slice(1) ? { host, port: portPart.slice(1) } : { host };
-  }
-  const colon = trimmed.lastIndexOf(":");
-  if (colon > -1 && trimmed.indexOf(":") === colon && /^\\d+$/.test(trimmed.slice(colon + 1))) {
-    return { host: normalizeHost(trimmed.slice(0, colon)), port: trimmed.slice(colon + 1) };
-  }
-  return { host: normalizeHost(trimmed) };
-}
-
-function ipv4ToNumber(ip) {
-  const parts = ip.split(".");
-  if (parts.length !== 4) return undefined;
-  let value = 0;
-  for (const part of parts) {
-    if (!/^\\d+$/.test(part)) return undefined;
-    const octet = Number(part);
-    if (octet < 0 || octet > 255) return undefined;
-    value = ((value << 8) + octet) >>> 0;
-  }
-  return value >>> 0;
-}
-
-function matchesIpv4Cidr(host, cidr) {
-  const pieces = cidr.split("/");
-  if (pieces.length !== 2) return false;
-  const base = ipv4ToNumber(pieces[0]);
-  const target = ipv4ToNumber(host);
-  const prefix = Number(pieces[1]);
-  if (base === undefined || target === undefined || !Number.isInteger(prefix) || prefix < 0 || prefix > 32) return false;
-  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
-  return (base & mask) === (target & mask);
-}
-
-function shouldBypassProxy(requestUrl, noProxy) {
-  if (!noProxy.trim()) return false;
-  const hostname = normalizeHost(requestUrl.hostname);
-  const port = requestUrl.port || defaultPort(requestUrl.protocol);
-  for (const rawToken of noProxy.split(",")) {
-    const token = splitNoProxyToken(rawToken);
-    if (!token) continue;
-    if (token.host === "*") return true;
-    if (token.port && token.port !== port) continue;
-    if (token.host.includes("/") && matchesIpv4Cidr(hostname, token.host)) return true;
-    if (token.host.startsWith(".") && (hostname === token.host.slice(1) || hostname.endsWith(token.host))) return true;
-    if (hostname === token.host || hostname.endsWith("." + token.host)) return true;
-  }
-  return false;
-}
-
-function getProxyUrlForRequest(rawUrl, env) {
-  const requestUrl = new URL(rawUrl);
-  const protocol = requestUrl.protocol;
-  if (protocol !== "http:" && protocol !== "https:") return undefined;
-  if (shouldBypassProxy(requestUrl, getNoProxyValue(env))) return undefined;
-  const keys = protocol === "https:" ? HTTPS_PROXY_KEYS : HTTP_PROXY_KEYS;
-  for (const key of keys) {
-    const value = env[key] && env[key].trim();
-    if (value) return validateProxyUrl(value);
-  }
-  return undefined;
-}
-
-function validateProxyUrl(proxyUrl) {
-  const protocol = new URL(proxyUrl).protocol;
-  if (protocol === "http:" || protocol === "https:") return proxyUrl;
-  if (protocol.startsWith("socks")) throw new Error(UNSUPPORTED_SOCKS_PROXY_MESSAGE);
-  throw new Error("Unsupported proxy protocol: " + protocol + " — only HTTP/HTTPS");
-}
+const getProxyUrlForRequestRuntime = ${getProxyUrlForRequestRuntimeName};
 
 async function fetchWithProxy(targetUrl) {
-  const proxyUrl = getProxyUrlForRequest(targetUrl, process.env);
+  const proxyUrl = getProxyUrlForRequestRuntime(targetUrl, process.env);
   if (!proxyUrl) return fetch(targetUrl);
   if (typeof Bun !== "undefined") return fetch(targetUrl, { proxy: proxyUrl });
   const { ProxyAgent } = require(undiciPath);
@@ -130,11 +49,30 @@ function getNoProxyValue(env: ProxyEnv) {
   return env.NO_PROXY || env.no_proxy || "";
 }
 
-function validateProxyUrl(proxyUrl: string) {
-  const protocol = new URL(proxyUrl).protocol;
+function validateProxyUrl(proxyUrl: string, envKey: string) {
+  const protocol = parseProxyProtocol(proxyUrl, envKey);
   if (protocol === "http:" || protocol === "https:") return proxyUrl;
-  if (protocol.startsWith("socks")) throw new Error(UNSUPPORTED_SOCKS_PROXY_MESSAGE);
-  throw new Error(`Unsupported proxy protocol: ${protocol} — only HTTP/HTTPS`);
+  if (protocol.startsWith("socks")) throw new Error("SOCKS proxies are not supported — only HTTP/HTTPS");
+  throw new Error(`Unsupported proxy protocol in ${envKey}: ${protocol} — only HTTP/HTTPS`);
+}
+
+function parseProxyProtocol(proxyUrl: string, envKey: string) {
+  let protocol: string;
+  try {
+    protocol = new URL(proxyUrl).protocol;
+  } catch {
+    throw invalidProxyUrlError(proxyUrl, envKey);
+  }
+
+  if (!proxyUrl.includes("://") && protocol !== "http:" && protocol !== "https:" && !protocol.startsWith("socks")) {
+    throw invalidProxyUrlError(proxyUrl, envKey);
+  }
+
+  return protocol;
+}
+
+function invalidProxyUrlError(proxyUrl: string, envKey: string) {
+  return new Error(`Invalid proxy URL in ${envKey}: ${proxyUrl} — include http:// or https://`);
 }
 
 function shouldBypassProxy(requestUrl: URL, noProxy: string) {
@@ -146,8 +84,8 @@ function shouldBypassProxy(requestUrl: URL, noProxy: string) {
   for (const rawToken of noProxy.split(",")) {
     const token = splitNoProxyToken(rawToken);
     if (!token) continue;
-    if (token.host === "*") return true;
     if (token.port && token.port !== port) continue;
+    if (token.host === "*") return true;
     if (token.host.includes("/") && matchesIpv4Cidr(hostname, token.host)) return true;
     if (token.host.startsWith(".") && (hostname === token.host.slice(1) || hostname.endsWith(token.host))) return true;
     if (hostname === token.host || hostname.endsWith("." + token.host)) return true;
@@ -214,3 +152,23 @@ function ipv4ToNumber(ip: string) {
 
   return value >>> 0;
 }
+
+function getRuntimeFunctionName(fn: RuntimeSerializableFunction) {
+  if (/^[A-Za-z_$][\w$]*$/.test(fn.name)) return fn.name;
+  throw new Error("Fetch proxy runtime function is not serializable");
+}
+
+// Keep subprocess proxy behavior serialized from typed functions so TS and runtime paths cannot drift.
+const FETCH_PROXY_RUNTIME_FUNCTIONS: readonly RuntimeSerializableFunction[] = [
+  getNoProxyValue,
+  validateProxyUrl,
+  parseProxyProtocol,
+  invalidProxyUrlError,
+  shouldBypassProxy,
+  splitNoProxyToken,
+  normalizeHost,
+  defaultPort,
+  matchesIpv4Cidr,
+  ipv4ToNumber,
+  getProxyUrlForRequest,
+];

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ import { searchAllSources } from "./search/unified.js";
 import { buildNodeCommand, type HookAdapter } from "./adapters/types.js";
 import { loadDatabase } from "./db-base.js";
 import { AnalyticsEngine, formatReport, getLifetimeStats } from "./session/analytics.js";
+import { buildFetchProxyRuntimeCode } from "./fetch-proxy.js";
 const __pkg_dir = dirname(fileURLToPath(import.meta.url));
 const VERSION: string = (() => {
   for (const rel of ["../package.json", "./package.json"]) {
@@ -1464,6 +1465,7 @@ server.registerTool(
 
 let _turndownPath: string | null = null;
 let _gfmPluginPath: string | null = null;
+let _undiciPath: string | null = null;
 
 function resolveTurndownPath(): string {
   if (!_turndownPath) {
@@ -1481,6 +1483,14 @@ function resolveGfmPluginPath(): string {
   return _gfmPluginPath;
 }
 
+function resolveUndiciPath(): string {
+  if (!_undiciPath) {
+    const require = createRequire(import.meta.url);
+    _undiciPath = require.resolve("undici");
+  }
+  return _undiciPath;
+}
+
 // ─────────────────────────────────────────────────────────
 // Tool: fetch_and_index
 // ─────────────────────────────────────────────────────────
@@ -1491,6 +1501,7 @@ function resolveGfmPluginPath(): string {
 function buildFetchCode(url: string, outputPath: string): string {
   const turndownPath = JSON.stringify(resolveTurndownPath());
   const gfmPath = JSON.stringify(resolveGfmPluginPath());
+  const proxyRuntimeCode = buildFetchProxyRuntimeCode(resolveUndiciPath());
   const escapedOutputPath = JSON.stringify(outputPath);
   return `
 const TurndownService = require(${turndownPath});
@@ -1498,6 +1509,7 @@ const { gfm } = require(${gfmPath});
 const fs = require('fs');
 const url = ${JSON.stringify(url)};
 const outputPath = ${escapedOutputPath};
+${proxyRuntimeCode}
 
 function emit(ct, content) {
   // Write content to file to bypass executor stdout truncation (100KB limit).
@@ -1507,7 +1519,7 @@ function emit(ct, content) {
 }
 
 async function main() {
-  const resp = await fetch(url);
+  const resp = await fetchWithProxy(url);
   if (!resp.ok) { console.error("HTTP " + resp.status); process.exit(1); }
   const contentType = resp.headers.get('content-type') || '';
 

--- a/tests/core/fetch-proxy.test.ts
+++ b/tests/core/fetch-proxy.test.ts
@@ -19,6 +19,14 @@ describe("fetch proxy support", () => {
     expect(proxyUrl).toBe("http://127.0.0.1:7890");
   });
 
+  test("falls back to HTTP_PROXY for HTTPS URLs when HTTPS_PROXY is absent", () => {
+    const proxyUrl = getProxyUrlForRequest("https://swr.vercel.app/docs/api", {
+      HTTP_PROXY: "http://127.0.0.1:8080",
+    });
+
+    expect(proxyUrl).toBe("http://127.0.0.1:8080");
+  });
+
   test("selects HTTP proxy for HTTP URLs", () => {
     const proxyUrl = getProxyUrlForRequest("http://example.com/docs", {
       HTTP_PROXY: "http://127.0.0.1:8080",
@@ -42,6 +50,12 @@ describe("fetch proxy support", () => {
     })).toThrow("SOCKS proxies are not supported — only HTTP/HTTPS");
   });
 
+  test("rejects malformed proxy URLs with the env var name", () => {
+    expect(() => getProxyUrlForRequest("https://example.com/docs", {
+      HTTPS_PROXY: "corp-proxy.local:8080",
+    })).toThrow("Invalid proxy URL in HTTPS_PROXY: corp-proxy.local:8080");
+  });
+
   test("uses lowercase proxy env vars when uppercase vars are absent", () => {
     const proxyUrl = getProxyUrlForRequest("https://example.com/docs", {
       https_proxy: "http://127.0.0.1:7890",
@@ -63,6 +77,16 @@ describe("fetch proxy support", () => {
     expect(getProxyUrlForRequest("https://100.128.12.8", { ...env, NO_PROXY: "100.64.0.0/10" })).toBe("http://127.0.0.1:7890");
   });
 
+  test("respects wildcard NO_PROXY port constraints", () => {
+    const env = {
+      HTTPS_PROXY: "http://127.0.0.1:7890",
+      NO_PROXY: "*:8443",
+    };
+
+    expect(getProxyUrlForRequest("https://example.com:8443/docs", env)).toBeUndefined();
+    expect(getProxyUrlForRequest("https://example.com/docs", env)).toBe("http://127.0.0.1:7890");
+  });
+
   test("generated runtime code supports Bun proxy option and Node undici dispatcher", () => {
     const code = buildFetchProxyRuntimeCode("/tmp/undici/index.js");
 
@@ -76,6 +100,23 @@ describe("fetch proxy support", () => {
 
   nodeTest("generated runtime code uses a Node dispatcher when a proxy env var is set", () => {
     const output = runRuntimeProbe("node");
+    const calls = parseProbeCalls(output);
+
+    expect(calls).toEqual([{
+      targetUrl: "https://example.com/docs",
+      hasDispatcher: true,
+      dispatcherProxy: "http://127.0.0.1:7890",
+    }]);
+  });
+
+  nodeTest("generated runtime code honors wildcard NO_PROXY port constraints", () => {
+    const output = runRuntimeProbe("node", {
+      env: {
+        HTTPS_PROXY: "http://127.0.0.1:7890",
+        NO_PROXY: "*:8443",
+      },
+      targetUrl: "https://example.com/docs",
+    });
     const calls = parseProbeCalls(output);
 
     expect(calls).toEqual([{
@@ -104,16 +145,27 @@ interface ProbeCall {
   dispatcherProxy?: string;
 }
 
+interface RuntimeProbeOptions {
+  env?: Record<string, string>;
+  targetUrl?: string;
+}
+
 function isCommandAvailable(command: string) {
   const result = spawnSync(command, ["--version"], { encoding: "utf8" });
   return result.status === 0;
 }
 
-function runRuntimeProbe(runtime: "node" | "bun") {
+function runRuntimeProbe(runtime: "node" | "bun", options: RuntimeProbeOptions = {}) {
   const dir = mkdtempSync(join(tmpdir(), "ctx-fetch-proxy-test-"));
   try {
     const undiciPath = join(dir, "fake-undici.cjs");
     const scriptPath = join(dir, "probe.cjs");
+    const targetUrl = options.targetUrl ?? "https://example.com/docs";
+    const proxyEnv = {
+      HTTPS_PROXY: "http://127.0.0.1:7890",
+      NO_PROXY: "",
+      ...options.env,
+    };
 
     writeFileSync(undiciPath, `
 class ProxyAgent {
@@ -135,11 +187,12 @@ globalThis.fetch = async (targetUrl, options) => {
   });
   return { ok: true };
 };
-process.env.HTTPS_PROXY = "http://127.0.0.1:7890";
-process.env.NO_PROXY = "";
+const proxyEnvKeys = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "NO_PROXY", "no_proxy", "ALL_PROXY", "all_proxy"];
+for (const key of proxyEnvKeys) delete process.env[key];
+Object.assign(process.env, ${JSON.stringify(proxyEnv)});
 ${buildFetchProxyRuntimeCode(undiciPath)}
 (async () => {
-  await fetchWithProxy("https://example.com/docs");
+  await fetchWithProxy(${JSON.stringify(targetUrl)});
   console.log(JSON.stringify(calls));
 })().catch((error) => {
   console.error(error && error.stack ? error.stack : String(error));

--- a/tests/core/fetch-proxy.test.ts
+++ b/tests/core/fetch-proxy.test.ts
@@ -1,0 +1,160 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+import {
+  buildFetchProxyRuntimeCode,
+  getProxyUrlForRequest,
+} from "../../src/fetch-proxy.js";
+
+describe("fetch proxy support", () => {
+  test("selects HTTPS proxy before HTTP proxy for HTTPS URLs", () => {
+    const proxyUrl = getProxyUrlForRequest("https://swr.vercel.app/docs/api", {
+      HTTPS_PROXY: "http://127.0.0.1:7890",
+      HTTP_PROXY: "http://127.0.0.1:8080",
+    });
+
+    expect(proxyUrl).toBe("http://127.0.0.1:7890");
+  });
+
+  test("selects HTTP proxy for HTTP URLs", () => {
+    const proxyUrl = getProxyUrlForRequest("http://example.com/docs", {
+      HTTP_PROXY: "http://127.0.0.1:8080",
+    });
+
+    expect(proxyUrl).toBe("http://127.0.0.1:8080");
+  });
+
+  test("ignores ALL_PROXY to avoid SOCKS ambiguity in Node", () => {
+    const proxyUrl = getProxyUrlForRequest("https://example.com/docs", {
+      ALL_PROXY: "socks5://127.0.0.1:7891",
+      all_proxy: "http://127.0.0.1:7890",
+    });
+
+    expect(proxyUrl).toBeUndefined();
+  });
+
+  test("rejects SOCKS proxy URLs with a clear error", () => {
+    expect(() => getProxyUrlForRequest("https://example.com/docs", {
+      HTTPS_PROXY: "socks5://127.0.0.1:7891",
+    })).toThrow("SOCKS proxies are not supported — only HTTP/HTTPS");
+  });
+
+  test("uses lowercase proxy env vars when uppercase vars are absent", () => {
+    const proxyUrl = getProxyUrlForRequest("https://example.com/docs", {
+      https_proxy: "http://127.0.0.1:7890",
+    });
+
+    expect(proxyUrl).toBe("http://127.0.0.1:7890");
+  });
+
+  test("respects NO_PROXY exact host, suffix, wildcard, port, and IPv4 CIDR rules", () => {
+    const env = {
+      HTTPS_PROXY: "http://127.0.0.1:7890",
+    };
+
+    expect(getProxyUrlForRequest("https://example.com", { ...env, NO_PROXY: "example.com" })).toBeUndefined();
+    expect(getProxyUrlForRequest("https://docs.example.com", { ...env, NO_PROXY: ".example.com" })).toBeUndefined();
+    expect(getProxyUrlForRequest("https://anything.test", { ...env, NO_PROXY: "*" })).toBeUndefined();
+    expect(getProxyUrlForRequest("https://example.com:8443", { ...env, NO_PROXY: "example.com:8443" })).toBeUndefined();
+    expect(getProxyUrlForRequest("https://100.64.12.8", { ...env, NO_PROXY: "100.64.0.0/10" })).toBeUndefined();
+    expect(getProxyUrlForRequest("https://100.128.12.8", { ...env, NO_PROXY: "100.64.0.0/10" })).toBe("http://127.0.0.1:7890");
+  });
+
+  test("generated runtime code supports Bun proxy option and Node undici dispatcher", () => {
+    const code = buildFetchProxyRuntimeCode("/tmp/undici/index.js");
+
+    expect(code).toContain("fetch(targetUrl, { proxy: proxyUrl })");
+    expect(code).toContain("ProxyAgent");
+    expect(code).toContain("dispatcher");
+  });
+
+  const nodeTest = isCommandAvailable("node") ? test : test.skip;
+  const bunTest = isCommandAvailable("bun") ? test : test.skip;
+
+  nodeTest("generated runtime code uses a Node dispatcher when a proxy env var is set", () => {
+    const output = runRuntimeProbe("node");
+    const calls = parseProbeCalls(output);
+
+    expect(calls).toEqual([{
+      targetUrl: "https://example.com/docs",
+      hasDispatcher: true,
+      dispatcherProxy: "http://127.0.0.1:7890",
+    }]);
+  });
+
+  bunTest("generated runtime code uses Bun's fetch proxy option when a proxy env var is set", () => {
+    const output = runRuntimeProbe("bun");
+    const calls = parseProbeCalls(output);
+
+    expect(calls).toEqual([{
+      targetUrl: "https://example.com/docs",
+      proxy: "http://127.0.0.1:7890",
+      hasDispatcher: false,
+    }]);
+  });
+});
+
+interface ProbeCall {
+  targetUrl: string;
+  proxy?: string;
+  hasDispatcher: boolean;
+  dispatcherProxy?: string;
+}
+
+function isCommandAvailable(command: string) {
+  const result = spawnSync(command, ["--version"], { encoding: "utf8" });
+  return result.status === 0;
+}
+
+function runRuntimeProbe(runtime: "node" | "bun") {
+  const dir = mkdtempSync(join(tmpdir(), "ctx-fetch-proxy-test-"));
+  try {
+    const undiciPath = join(dir, "fake-undici.cjs");
+    const scriptPath = join(dir, "probe.cjs");
+
+    writeFileSync(undiciPath, `
+class ProxyAgent {
+  constructor(proxyUrl) {
+    this.proxyUrl = proxyUrl;
+  }
+}
+module.exports = { ProxyAgent };
+`);
+
+    writeFileSync(scriptPath, `
+const calls = [];
+globalThis.fetch = async (targetUrl, options) => {
+  calls.push({
+    targetUrl,
+    proxy: options && options.proxy,
+    hasDispatcher: Boolean(options && options.dispatcher),
+    dispatcherProxy: options && options.dispatcher && options.dispatcher.proxyUrl,
+  });
+  return { ok: true };
+};
+process.env.HTTPS_PROXY = "http://127.0.0.1:7890";
+process.env.NO_PROXY = "";
+${buildFetchProxyRuntimeCode(undiciPath)}
+(async () => {
+  await fetchWithProxy("https://example.com/docs");
+  console.log(JSON.stringify(calls));
+})().catch((error) => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});
+`);
+
+    const result = spawnSync(runtime, [scriptPath], { encoding: "utf8" });
+    expect(result.status, result.stderr).toBe(0);
+    return result.stdout.trim();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function parseProbeCalls(output: string) {
+  return JSON.parse(output) as ProbeCall[];
+}


### PR DESCRIPTION
## Summary

`ctx_fetch_and_index` currently generates a subprocess script that calls bare `fetch(url)`. In environments where direct DNS/network access is blocked or polluted, this makes fetch indexing fail even when users have standard proxy variables configured.

This PR adds proxy-aware fetch support for both JavaScript runtimes used by context-mode:

- Bun: passes `fetch(targetUrl, { proxy })`.
- Node: passes `fetch(targetUrl, { dispatcher: new ProxyAgent(proxy) })` through `undici`.

## Details

- Added `src/fetch-proxy.ts` to select proxy URLs from `HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, `http_proxy`, `ALL_PROXY`, and `all_proxy`.
- Added `NO_PROXY` / `no_proxy` bypass support for exact hosts, suffix hosts, wildcard, host:port, and IPv4 CIDR entries.
- Updated `ctx_fetch_and_index` generated fetch code to call `fetchWithProxy(url)` instead of bare `fetch(url)`.
- Added `undici@^6.25.0` as a runtime dependency so Node 18+ can use a stable `ProxyAgent` path.
- Updated bundled artifacts.

## Validation

- `bunx vitest run tests/core/fetch-proxy.test.ts`
- `npm run typecheck`
- `npm test -- tests/core/fetch-proxy.test.ts tests/core/server.test.ts tests/core/search.test.ts`
- `npm run build`

Also ran `npm test`; unrelated existing ABI-cache assertions in `tests/core/cli.test.ts` fail locally under Node 25 because `ensureNativeCompat()` returns early when `hasModernSqlite()` is true:

- `cache hit: copies cached ABI binary to active path`
- `cache hit does not trigger rebuild`
