### PR TITLE
fix(store): treat empty content as missing when path provided (#350)

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -727,11 +727,18 @@ export class ContentStore {
   }): IndexResult {
     const { content, path, source } = options;
 
-    if (!content && !path) {
+    // Treat empty string as "no content" so an empty `content` paired with a
+    // valid `path` falls back to reading the file. Some MCP clients
+    // materialize optional string fields as `""` and the previous
+    // `content ?? readFileSync(path)` kept the empty string, indexing 0
+    // chunks. See issue #350.
+    const hasContent = typeof content === "string" && content.length > 0;
+
+    if (!hasContent && !path) {
       throw new Error("Either content or path must be provided");
     }
 
-    const text = content ?? readFileSync(path!, "utf-8");
+    const text = hasContent ? content! : readFileSync(path!, "utf-8");
     const label = source ?? path ?? "untitled";
     const chunks = this.#chunkMarkdown(text);
 

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -104,6 +104,23 @@ describe("Basic Indexing", () => {
     store.close();
   });
 
+  test("index reads file when content is empty string and path is provided (regression #350)", () => {
+    // Some MCP clients send `content: ""` together with `path`. The previous
+    // implementation used `content ?? readFileSync(path)` which kept the empty
+    // string and indexed 0 chunks. Empty content + a valid path must fall
+    // back to reading the file.
+    const store = createStore();
+    const result = store.index({
+      content: "",
+      path: join(fixtureDir, "context7-react-docs.md"),
+      source: "Context7: empty-content path repro",
+    });
+    assert.ok(result.totalChunks > 0, "Should chunk the fixture from path even when content is empty string");
+    assert.ok(result.codeChunks > 0, "React docs have code blocks");
+    assert.equal(result.label, "Context7: empty-content path repro");
+    store.close();
+  });
+
   test("stats update after indexing", () => {
     const store = createStore();
     store.index({


### PR DESCRIPTION
## What

`ContentStore.index()` used `content ?? readFileSync(path)`. Empty string `""` is not nullish, so when an MCP client sent both `content: ""` and a valid `path`, the empty string won and 0 sections were indexed. Treats empty content as missing so a valid `path` falls back to reading the file.

Closes #350.

## Why

Reported in #350: some Claude Code / API-wrapper environments materialize optional string fields as `""`. With both fields present, the call:

```json
{ "content": "", "path": "E:/.../architecture_snapshot.md", "source": "..." }
```

silently logged `Indexed 0 sections (0 with code) from: ...`. The file existed and was readable, but `content ?? readFileSync(path)` short-circuited to `""`.

Touched lines: `src/store.ts:686-690` (was — now `:730-738`).

## How

`src/store.ts`:

```ts
const hasContent = typeof content === "string" && content.length > 0;

if (!hasContent && !path) {
  throw new Error("Either content or path must be provided");
}

const text = hasContent ? content! : readFileSync(path!, "utf-8");
```

This matches the existing tool-level guard at `src/server.ts:1074` (`if (!content && !path)`) which already treated `""` as falsy at the boundary, so the store-level behavior is now consistent with the tool entry point. No behavior change for callers passing real content or a real path.

## Coverage added

`tests/store.test.ts` — added `Basic Indexing > index reads file when content is empty string and path is provided (regression #350)`. The test calls `store.index({ content: "", path: <fixture>, source: ... })` and asserts non-zero `totalChunks` and `codeChunks`. Without the fix, this test fails with `totalChunks === 0`.

Existing `index empty content throws (falsy content requires path)` and `index throws when neither content nor path provided` still pass — same error path, just driven by `hasContent` instead of `!content`.

## Test plan

- [x] `npx vitest run tests/store.test.ts` → 108 passed (1 new)
- [x] `npm run typecheck` → clean
- [x] `npm test` → 1802 passed; 7 pre-existing failures in `tests/core/cli.test.ts` (ABI cache) and `tests/hooks/core-routing.test.ts` (MCP-readiness) reproduce on clean `next` and are unrelated to this change.

Generated by Ora Studio (With Claude)
Vibe-coded by Ousama Ben Younes
