### PR TITLE
fix(hooks): scope MCP sentinel scan via env override for tests

### DIFF
--- a/hooks/core/mcp-ready.mjs
+++ b/hooks/core/mcp-ready.mjs
@@ -17,8 +17,14 @@ import { join } from "node:path";
 
 const SENTINEL_PREFIX = "context-mode-mcp-ready-";
 
-/** Resolve the temp root — hardcoded /tmp on Unix to avoid TMPDIR mismatch. */
+/**
+ * Resolve the temp root — hardcoded /tmp on Unix to avoid TMPDIR mismatch.
+ * Tests may override via CONTEXT_MODE_MCP_SENTINEL_DIR to isolate scan from
+ * leftover sentinels in the real /tmp.
+ */
 export function sentinelDir() {
+  const override = process.env.CONTEXT_MODE_MCP_SENTINEL_DIR;
+  if (override && override.length > 0) return override;
   return process.platform === "win32" ? tmpdir() : "/tmp";
 }
 

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from "vitest";
+import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
 
 // Dynamic import for .mjs module
 let routePreToolUse: (
@@ -35,7 +35,12 @@ beforeAll(async () => {
 
 // MCP readiness sentinel — most tests expect MCP to be ready (deny behavior).
 // Tests for graceful degradation (#230) remove sentinel explicitly.
-const _sentinelDir = process.platform === "win32" ? tmpdir() : "/tmp";
+//
+// Use an isolated temp dir for sentinels so the directory scan in isMCPReady()
+// is not polluted by leftover sentinels from real MCP servers running on the
+// developer's machine. The hook honors CONTEXT_MODE_MCP_SENTINEL_DIR.
+const _sentinelDir = mkdtempSync(join(tmpdir(), "ctx-test-sentinels-"));
+process.env.CONTEXT_MODE_MCP_SENTINEL_DIR = _sentinelDir;
 const mcpSentinel = resolve(_sentinelDir, `context-mode-mcp-ready-${process.pid}`);
 
 beforeEach(() => {
@@ -45,6 +50,11 @@ beforeEach(() => {
 
 afterEach(() => {
   try { unlinkSync(mcpSentinel); } catch {}
+});
+
+afterAll(() => {
+  try { rmSync(_sentinelDir, { recursive: true, force: true }); } catch {}
+  delete process.env.CONTEXT_MODE_MCP_SENTINEL_DIR;
 });
 
 describe("routePreToolUse", () => {


### PR DESCRIPTION
## What

`isMCPReady()` in `hooks/core/mcp-ready.mjs` scans the entire `sentinelDir()` (`/tmp` on Unix) for any `context-mode-mcp-ready-*` file and probes the embedded PID with `kill(pid, 0)`. On a developer machine (or any host) running a real `context-mode` MCP server, that scan finds the live sentinel **regardless** of whether the test's own sentinel was unlinked.

Result: the `#230` graceful-degradation tests in `tests/hooks/core-routing.test.ts` are flaky / fail on machines that have a live MCP server, because they cannot meaningfully simulate "MCP not ready".

```
$ ls /tmp/context-mode-mcp-ready-*
/tmp/context-mode-mcp-ready-55834   # alive node MCP server, unrelated to test
```

## Why

- Pre-existing failures observed locally on `main` for 5 tests in `core-routing.test.ts`:
  - `WebFetch tool allows WebFetch when MCP server not ready (#230)`
  - `WebFetch tool allows mcp_web_fetch alias when MCP server not ready (#230)`
  - `MCP readiness graceful degradation (#230) allows curl when MCP server not ready`
  - `MCP readiness graceful degradation (#230) allows inline HTTP when MCP server not ready`
  - `MCP readiness graceful degradation (#230) allows build tools when MCP server not ready`
- Root cause: directory-scan in `isMCPReady()` (introduced by #347) is correct in production but is unscopable from the test side.

## How

1. `hooks/core/mcp-ready.mjs` — `sentinelDir()` honors `CONTEXT_MODE_MCP_SENTINEL_DIR` env var if set. Production behavior is unchanged when the var is unset.
2. `tests/hooks/core-routing.test.ts` — at import time, create an isolated `mkdtempSync(...)` directory and set `process.env.CONTEXT_MODE_MCP_SENTINEL_DIR` to it. `afterAll` cleans up the temp dir and the env var.

This way the test suite scans an empty directory by default, and the existing `writeFileSync(mcpSentinel, String(process.pid))` / `unlinkSync(mcpSentinel)` choreography becomes deterministic again.

## Affected platforms

- Linux: yes (also macOS — both use `/tmp` as sentinel root)
- macOS: yes (verified locally — failure reproduces with a live MCP server)
- Windows: behavior unchanged (env var is platform-agnostic; default still `tmpdir()`)

## Test plan

- [x] `npx vitest run tests/hooks/core-routing.test.ts` passes 49/49 with the env override
- [x] Verified failures reproduce on `main` when a live MCP server's sentinel is in `/tmp`
- [x] `npx tsc --noEmit` clean
- [x] No production code paths read the new env var; only `sentinelDir()` does, and only when the var is set

## Checklist

- [x] Tests pass on macOS / Linux
- [x] No bundle changes (only `.mjs` hook + `.ts` test)
- [x] Production semantics unchanged when env var absent
- [x] Single-purpose root-cause fix