### PR TITLE
feat(qwen-code): improve adapter — configureAllHooks, getInstalledVersion, projectDir fallback, PostToolUse matchers

### DIFF
--- a/src/adapters/claude-code-base.ts
+++ b/src/adapters/claude-code-base.ts
@@ -61,7 +61,7 @@ export abstract class ClaudeCodeBaseAdapter extends BaseAdapter {
       toolName: input.tool_name ?? "",
       toolInput: input.tool_input ?? {},
       sessionId: this.extractSessionId(input),
-      projectDir: process.env[this.projectDirEnvVar],
+      projectDir: process.env[this.projectDirEnvVar] ?? process.cwd(),
       raw,
     };
   }
@@ -74,7 +74,7 @@ export abstract class ClaudeCodeBaseAdapter extends BaseAdapter {
       toolOutput: input.tool_output,
       isError: input.is_error,
       sessionId: this.extractSessionId(input),
-      projectDir: process.env[this.projectDirEnvVar],
+      projectDir: process.env[this.projectDirEnvVar] ?? process.cwd(),
       raw,
     };
   }
@@ -83,7 +83,7 @@ export abstract class ClaudeCodeBaseAdapter extends BaseAdapter {
     const input = raw as ClaudeCodeWireInput;
     return {
       sessionId: this.extractSessionId(input),
-      projectDir: process.env[this.projectDirEnvVar],
+      projectDir: process.env[this.projectDirEnvVar] ?? process.cwd(),
       raw,
     };
   }
@@ -110,7 +110,7 @@ export abstract class ClaudeCodeBaseAdapter extends BaseAdapter {
     return {
       sessionId: this.extractSessionId(input),
       source,
-      projectDir: process.env[this.projectDirEnvVar],
+      projectDir: process.env[this.projectDirEnvVar] ?? process.cwd(),
       raw,
     };
   }

--- a/src/adapters/qwen-code/index.ts
+++ b/src/adapters/qwen-code/index.ts
@@ -84,7 +84,7 @@ export class QwenCodeAdapter extends ClaudeCodeBaseAdapter implements HookAdapte
       ],
       PostToolUse: [
         {
-          matcher: "",
+          matcher: "run_shell_command|read_file|write_file|edit|glob|grep_search|todo_write|agent|ask_user_question|mcp__",
           hooks: [
             { type: "command", command: `node ${pluginRoot}/hooks/posttooluse.mjs` },
           ],
@@ -190,11 +190,132 @@ export class QwenCodeAdapter extends ClaudeCodeBaseAdapter implements HookAdapte
   }
 
   getInstalledVersion(): string {
+    const settings = this.readSettings();
+    if (!settings) return "not installed";
+
+    const hooks = settings.hooks as Record<string, unknown[]> | undefined;
+    if (!hooks) return "not installed";
+
+    // Check if any hook type has context-mode scripts configured
+    const contextModeScripts = [
+      "pretooluse.mjs",
+      "posttooluse.mjs",
+      "precompact.mjs",
+      "sessionstart.mjs",
+      "userpromptsubmit.mjs",
+    ];
+    for (const [, entries] of Object.entries(hooks)) {
+      if (!Array.isArray(entries)) continue;
+      for (const entry of entries) {
+        const e = entry as { hooks?: Array<{ command?: string }> };
+        if (e.hooks?.some((h) =>
+          h.command && contextModeScripts.some((s) => h.command!.includes(s)),
+        )) {
+          return "installed (hooks configured)";
+        }
+      }
+    }
+
     return "not installed";
   }
 
-  configureAllHooks(_pluginRoot: string): string[] {
-    return [];
+  configureAllHooks(pluginRoot: string): string[] {
+    const settings = this.readSettings() ?? {};
+    const hooks = (settings.hooks ?? {}) as Record<string, unknown>;
+    const changes: string[] = [];
+
+    // ── Phase 1: Clean stale context-mode hooks ──────────
+    // After an upgrade, settings.json may contain hardcoded paths
+    // pointing to deleted version directories. Remove those.
+    for (const hookType of Object.keys(hooks)) {
+      const entries = hooks[hookType];
+      if (!Array.isArray(entries)) continue;
+
+      const filtered = (entries as Array<Record<string, unknown>>).filter(
+        (entry) => {
+          const e = entry as { hooks?: Array<{ command?: string }> };
+          const commands = e.hooks ?? [];
+
+          // Preserve entries that are not context-mode hooks
+          const isContextMode = commands.some(
+            (h) => h.command && /context-mode|pretooluse|posttooluse|precompact|sessionstart|userpromptsubmit/i.test(h.command),
+          );
+          if (!isContextMode) return true;
+
+          // For context-mode hooks, check if referenced script files exist
+          return commands.every((h) => {
+            if (!h.command) return true;
+            // Extract path from "node /path/to/script.mjs" format
+            const match = h.command.match(/node\s+"?([^"]+\.mjs)"?/);
+            if (!match) return true; // CLI dispatcher format, always valid
+            return existsSync(match[1]);
+          });
+        },
+      );
+
+      const removed = entries.length - filtered.length;
+      if (removed > 0) {
+        hooks[hookType] = filtered;
+        changes.push(`Removed ${removed} stale ${hookType} hook(s)`);
+      }
+    }
+
+    // ── Phase 2: Register fresh hooks ────────────────────
+    const hookTypes: Array<{
+      name: string;
+      script: string;
+      matcher: string;
+    }> = [
+      {
+        name: "PreToolUse",
+        script: "pretooluse.mjs",
+        matcher: [
+          "run_shell_command", "read_file", "read_many_files", "grep_search",
+          "web_fetch", "agent",
+          "mcp__plugin_context-mode_context-mode__ctx_execute",
+          "mcp__plugin_context-mode_context-mode__ctx_execute_file",
+          "mcp__plugin_context-mode_context-mode__ctx_batch_execute",
+        ].join("|"),
+      },
+      {
+        name: "SessionStart",
+        script: "sessionstart.mjs",
+        matcher: "",
+      },
+    ];
+
+    for (const { name, script, matcher } of hookTypes) {
+      const entry = {
+        matcher,
+        hooks: [{ type: "command", command: `node ${pluginRoot}/hooks/${script}` }],
+      };
+
+      const existing = hooks[name] as Array<Record<string, unknown>> | undefined;
+      if (existing && Array.isArray(existing)) {
+        // Replace existing context-mode entry or append
+        const idx = existing.findIndex((e) => {
+          const typed = e as { hooks?: Array<{ command?: string }> };
+          return typed.hooks?.some(
+            (h) => h.command?.includes(script),
+          ) ?? false;
+        });
+        if (idx >= 0) {
+          existing[idx] = entry;
+          changes.push(`Updated ${name} hook`);
+        } else {
+          existing.push(entry);
+          changes.push(`Added ${name} hook`);
+        }
+        hooks[name] = existing;
+      } else {
+        hooks[name] = [entry];
+        changes.push(`Created ${name} hooks`);
+      }
+    }
+
+    settings.hooks = hooks;
+    this.writeSettings(settings);
+    return changes;
   }
 
   setHookPermissions(_pluginRoot: string): string[] {


### PR DESCRIPTION
## Summary

This PR ports 4 improvements from a battle-tested custom Qwen Code adapter into the official one:

### 1. `configureAllHooks` — full implementation
Currently returns `[]` (no-op). This PR implements:
- **Phase 1**: Clean stale context-mode hooks (those referencing deleted version directories after upgrade)
- **Phase 2**: Register fresh PreToolUse and SessionStart hooks with correct matchers and paths
- Writes back to `~/.qwen/settings.json`

Without this, `ctx upgrade` on Qwen Code leaves hooks unconfigured.

### 2. `getInstalledVersion` — actual detection
Currently always returns `"not installed"`. This PR checks `~/.qwen/settings.json` for context-mode hook scripts, returning `"installed (hooks configured)"` when found. This fixes `ctx doctor` reporting false negatives.

### 3. `projectDir` fallback in `claude-code-base.ts`
All 4 parse methods (`parsePreToolUseInput`, `parsePostToolUseInput`, `parsePreCompactInput`, `parseSessionStartInput`) now use `process.env[this.projectDirEnvVar] ?? process.cwd()` instead of just the env var. This prevents `undefined` projectDir when the env var is not set — a defensive improvement that benefits both Claude Code and Qwen Code adapters.

### 4. PostToolUse precise matchers
Changed from empty matcher `""` (matches all tools) to a pipe-separated list of tools that actually produce events: `run_shell_command|read_file|write_file|edit|glob|grep_search|todo_write|agent|ask_user_question|mcp__`. This reduces unnecessary hook triggers and avoids "hook error" display for tools that produce zero events.

### Test results
All 22 existing qwen-code adapter tests pass. No regressions.