### PR TITLE
feat(codex): wire prompt and stop hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,12 +523,14 @@ Full documentation: [`docs/adapters/openclaw.md`](docs/adapters/openclaw.md)
      "hooks": {
        "PreToolUse": [{ "matcher": "local_shell|shell|shell_command|exec_command|container.exec|Bash|Shell|grep_files|mcp__plugin_context-mode_context-mode__ctx_execute|mcp__plugin_context-mode_context-mode__ctx_execute_file|mcp__plugin_context-mode_context-mode__ctx_batch_execute", "hooks": [{ "type": "command", "command": "context-mode hook codex pretooluse" }] }],
        "PostToolUse": [{ "hooks": [{ "type": "command", "command": "context-mode hook codex posttooluse" }] }],
-       "SessionStart": [{ "hooks": [{ "type": "command", "command": "context-mode hook codex sessionstart" }] }]
+       "SessionStart": [{ "hooks": [{ "type": "command", "command": "context-mode hook codex sessionstart" }] }],
+       "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "context-mode hook codex userpromptsubmit" }] }],
+       "Stop": [{ "hooks": [{ "type": "command", "command": "context-mode hook codex stop" }] }]
      }
    }
    ```
 
-   `PreToolUse` enforces deny/block routing today and is prepared for input rewrites once Codex supports them. `PostToolUse` captures session events. `SessionStart` restores state after compaction.
+   `PreToolUse` enforces deny/block routing today and is prepared for input rewrites once Codex supports them. `PostToolUse` captures session events. `SessionStart` restores state after compaction. `UserPromptSubmit` captures user decisions and corrections. `Stop` records turn-end state.
 
    > **Note:** Codex PreToolUse routing currently supports deny rules only (blocks dangerous commands). It still needs upstream `updatedInput` support before context-mode can rewrite tool input; track [openai/codex#18491](https://github.com/openai/codex/issues/18491). Context injection (`additionalContext`) is not supported in Codex PreToolUse — it works via PostToolUse and SessionStart instead. This is handled automatically.
 
@@ -912,12 +914,12 @@ Session continuity requires 4 hooks working together:
 |---|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **PreToolUse** | Enforces sandbox routing before tool execution | Yes | -- | -- | -- | Yes | -- | -- | -- | Yes | -- | Yes | -- | ✓ (via tool_call event) |
 | **PostToolUse** | Captures events after each tool call | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | ✓ (via tool_result event) |
-| **UserPromptSubmit** | Captures user decisions and corrections | Yes | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **UserPromptSubmit** | Captures user decisions and corrections | Yes | -- | -- | -- | -- | -- | -- | -- | Yes | -- | -- | -- | -- |
 | **PreCompact** | Builds snapshot before compaction | Yes | Yes | Yes | Yes | -- | Plugin | Plugin | Plugin | -- | -- | -- | -- | ✓ (via session_before_compact) |
 | **SessionStart** | Restores state after compaction or resume | Yes | Yes | Yes | Yes | -- | -- | -- | Plugin | Yes | -- | -- | -- | ✓ (via session_start event) |
 | | **Session completeness** | **Full** | **High** | **High** | **High** | **Partial** | **High** | **High** | **High** | **Partial** | **--** | **Partial** | **--** | **High** |
 
-> **Note:** Full session continuity (capture + snapshot + restore) works on **Claude Code**, **Gemini CLI**, **VS Code Copilot**, and **JetBrains Copilot**. **OpenCode** provides **high** session continuity: it captures tool events and injects compaction snapshots via the plugin, but SessionStart is not yet available ([#14808](https://github.com/sst/opencode/issues/14808)), so startup/resume restore is not supported. **KiloCode** shares the same plugin architecture as OpenCode via the OpenCodeAdapter, so its continuity level depends on KiloCode's SessionStart support. **Cursor** captures tool events via `preToolUse`/`postToolUse`, but `sessionStart` is currently rejected by Cursor's validator ([forum report](https://forum.cursor.com/t/unknown-hook-type-sessionstart/149566)), so session restore after compaction is not available yet. **OpenClaw** uses native gateway plugin hooks (`api.on()`) for full session continuity. **Pi Coding Agent** provides high session continuity via extension hooks (`tool_call`, `tool_result`, `session_start`, `session_before_compact`). **Codex CLI** provides partial hook-based session tracking through PreToolUse, PostToolUse, and SessionStart; MCP tools work. **Antigravity**, **Kiro**, and **Zed** have no hook support in the current release, so session tracking is not available.
+> **Note:** Full session continuity (capture + snapshot + restore) works on **Claude Code**, **Gemini CLI**, **VS Code Copilot**, and **JetBrains Copilot**. **OpenCode** provides **high** session continuity: it captures tool events and injects compaction snapshots via the plugin, but SessionStart is not yet available ([#14808](https://github.com/sst/opencode/issues/14808)), so startup/resume restore is not supported. **KiloCode** shares the same plugin architecture as OpenCode via the OpenCodeAdapter, so its continuity level depends on KiloCode's SessionStart support. **Cursor** captures tool events via `preToolUse`/`postToolUse`, but `sessionStart` is currently rejected by Cursor's validator ([forum report](https://forum.cursor.com/t/unknown-hook-type-sessionstart/149566)), so session restore after compaction is not available yet. **OpenClaw** uses native gateway plugin hooks (`api.on()`) for full session continuity. **Pi Coding Agent** provides high session continuity via extension hooks (`tool_call`, `tool_result`, `session_start`, `session_before_compact`). **Codex CLI** provides partial hook-based session tracking through PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, and Stop; MCP tools work. **Antigravity**, **Kiro**, and **Zed** have no hook support in the current release, so session tracking is not available.
 
 <details>
 <summary><strong>What gets captured</strong></summary>
@@ -1002,7 +1004,7 @@ Detailed event data is also indexed into FTS5 for on-demand retrieval via `searc
 
 **OpenClaw / Pi Agent** — High coverage. All tool lifecycle hooks (`after_tool_call`, `before_compaction`, `session_start`) fire via the native gateway plugin. User decisions aren't captured but file edits, git ops, errors, and tasks are fully tracked. Falls back to DB snapshot reconstruction if compaction hooks fail on older gateway versions. See [`docs/adapters/openclaw.md`](docs/adapters/openclaw.md).
 
-**Codex CLI** — MCP active, hooks stable. Hook scripts (PreToolUse, PostToolUse, SessionStart) are implemented and tested. PreToolUse deny routing works; input rewriting still depends on upstream `updatedInput` support ([openai/codex#18491](https://github.com/openai/codex/issues/18491)).
+**Codex CLI** — MCP active, hooks stable. Hook scripts (PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, Stop) are implemented and tested. PreToolUse deny routing works; input rewriting still depends on upstream `updatedInput` support ([openai/codex#18491](https://github.com/openai/codex/issues/18491)).
 
 **Antigravity** — No session support. No hooks, no event capture. Requires manually copying `GEMINI.md` to your project root. Auto-detected via MCP protocol handshake (`clientInfo.name`).
 
@@ -1035,7 +1037,7 @@ Detailed event data is also indexed into FTS5 for on-demand retrieval via `searc
 >
 > **OpenClaw** runs context-mode as a native gateway plugin targeting Pi Agent sessions. Hooks register via `api.on()` (tool/lifecycle) and `api.registerHook()` (commands). All tool interception and compaction hooks are supported. See [`docs/adapters/openclaw.md`](docs/adapters/openclaw.md).
 >
-> **Codex CLI** hooks are stable. MCP tools work, and hook scripts activate through `~/.codex/hooks.json`. PreToolUse supports `permissionDecision: "deny"` only; input modification still needs upstream `updatedInput` support ([openai/codex#18491](https://github.com/openai/codex/issues/18491)). `additionalContext` is not supported in PreToolUse (context injection works via PostToolUse and SessionStart instead; the codex formatter handles this automatically). See the Codex install section for setup. **Antigravity** and **Zed** do not support hooks. They rely solely on manually-copied routing instruction files (`AGENTS.md` / `GEMINI.md`) for enforcement (~60% compliance). See each platform's install section for copy instructions. Antigravity and Zed are auto-detected via MCP protocol handshake — no manual platform configuration needed.
+> **Codex CLI** hooks are stable. MCP tools work, and hook scripts activate through `~/.codex/hooks.json`. PreToolUse supports `permissionDecision: "deny"` only; input modification still needs upstream `updatedInput` support ([openai/codex#18491](https://github.com/openai/codex/issues/18491)). `additionalContext` is not supported in PreToolUse (context injection works via PostToolUse and SessionStart instead; the codex formatter handles this automatically). UserPromptSubmit and Stop capture prompt and turn-end continuity events. See the Codex install section for setup. **Antigravity** and **Zed** do not support hooks. They rely solely on manually-copied routing instruction files (`AGENTS.md` / `GEMINI.md`) for enforcement (~60% compliance). See each platform's install section for copy instructions. Antigravity and Zed are auto-detected via MCP protocol handshake — no manual platform configuration needed.
 >
 > **Kiro** supports native `preToolUse` and `postToolUse` hooks for routing enforcement and tool event capture. `agentSpawn` (SessionStart equivalent) and `stop` are not yet wired. Requires manually copying `KIRO.md` to your project root. Kiro is auto-detected via MCP protocol handshake (`clientInfo.name`).
 >

--- a/configs/codex/hooks.json
+++ b/configs/codex/hooks.json
@@ -20,6 +20,20 @@
           { "type": "command", "command": "context-mode hook codex sessionstart" }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "context-mode hook codex userpromptsubmit" }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "context-mode hook codex stop" }
+        ]
+      }
     ]
   }
 }

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -207,6 +207,8 @@ Codex CLI's Rust backend (codex-rs) includes a full hook system with 5 events, u
 context-mode hook codex pretooluse
 context-mode hook codex posttooluse
 context-mode hook codex sessionstart
+context-mode hook codex userpromptsubmit
+context-mode hook codex stop
 ```
 
 **Known Issues / Caveats:**

--- a/hooks/codex/stop.mjs
+++ b/hooks/codex/stop.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import "../suppress-stderr.mjs";
+import "../ensure-deps.mjs";
+/**
+ * Codex CLI Stop hook — record turn/session end state for continuity.
+ */
+
+import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, CODEX_OPTS } from "../session-helpers.mjs";
+import { createSessionLoaders } from "../session-loaders.mjs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
+const { loadSessionDB } = createSessionLoaders(HOOK_DIR);
+const OPTS = CODEX_OPTS;
+
+try {
+  const raw = await readStdin();
+  const input = parseStdin(raw);
+  const projectDir = getInputProjectDir(input, OPTS);
+
+  const { SessionDB } = await loadSessionDB();
+  const dbPath = getSessionDBPath(OPTS);
+  const db = new SessionDB({ dbPath });
+  const sessionId = getSessionId(input, OPTS);
+
+  db.ensureSession(sessionId, projectDir);
+  db.insertEvent(sessionId, {
+    type: "session_end",
+    status: "completed",
+    stop_hook_active: input.stop_hook_active ?? false,
+    last_assistant_message: typeof input.last_assistant_message === "string"
+      ? input.last_assistant_message.slice(0, 2000)
+      : null,
+  }, "Stop");
+
+  db.close();
+} catch {
+  // Codex hooks must not block the session.
+}
+
+process.stdout.write("{}\n");
+

--- a/hooks/codex/userpromptsubmit.mjs
+++ b/hooks/codex/userpromptsubmit.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import "../suppress-stderr.mjs";
+import "../ensure-deps.mjs";
+/**
+ * Codex CLI UserPromptSubmit hook — capture user prompts for continuity.
+ */
+
+import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, CODEX_OPTS } from "../session-helpers.mjs";
+import { createSessionLoaders, attributeAndInsertEvents } from "../session-loaders.mjs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
+const { loadSessionDB, loadExtract, loadProjectAttribution } = createSessionLoaders(HOOK_DIR);
+const OPTS = CODEX_OPTS;
+
+try {
+  const raw = await readStdin();
+  const input = parseStdin(raw);
+  const projectDir = getInputProjectDir(input, OPTS);
+
+  const prompt = input.prompt ?? input.message ?? "";
+  const trimmed = (prompt || "").trim();
+
+  const isSystemMessage = trimmed.startsWith("<task-notification>")
+    || trimmed.startsWith("<system-reminder>")
+    || trimmed.startsWith("<context_guidance>")
+    || trimmed.startsWith("<tool-result>");
+
+  if (trimmed.length > 0 && !isSystemMessage) {
+    const { SessionDB } = await loadSessionDB();
+    const { extractUserEvents } = await loadExtract();
+    const { resolveProjectAttributions } = await loadProjectAttribution();
+    const dbPath = getSessionDBPath(OPTS);
+    const db = new SessionDB({ dbPath });
+    const sessionId = getSessionId(input, OPTS);
+
+    db.ensureSession(sessionId, projectDir);
+
+    const promptEvent = {
+      type: "user_prompt",
+      category: "prompt",
+      data: prompt,
+      priority: 1,
+    };
+    const promptAttributions = attributeAndInsertEvents(
+      db, sessionId, [promptEvent], input, projectDir, "UserPromptSubmit", resolveProjectAttributions,
+    );
+
+    const userEvents = extractUserEvents(trimmed);
+    const savedLastKnown = promptAttributions[0]?.projectDir || null;
+    const sessionStats = db.getSessionStats(sessionId);
+    const lastKnownProjectDir = typeof db.getLatestAttributedProjectDir === "function"
+      ? db.getLatestAttributedProjectDir(sessionId)
+      : null;
+    const userAttributions = resolveProjectAttributions(userEvents, {
+      sessionOriginDir: sessionStats?.project_dir || projectDir,
+      inputProjectDir: projectDir,
+      workspaceRoots: Array.isArray(input.workspace_roots) ? input.workspace_roots : [],
+      lastKnownProjectDir: savedLastKnown || lastKnownProjectDir,
+    });
+    for (let i = 0; i < userEvents.length; i++) {
+      db.insertEvent(sessionId, userEvents[i], "UserPromptSubmit", userAttributions[i]);
+    }
+
+    db.close();
+  }
+} catch {
+  // Codex hooks must not block the session.
+}
+
+process.stdout.write(JSON.stringify({
+  hookSpecificOutput: { hookEventName: "UserPromptSubmit", additionalContext: "" },
+}) + "\n");
+

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -241,6 +241,28 @@ export class CodexAdapter extends BaseAdapter implements HookAdapter {
           ],
         },
       ],
+      UserPromptSubmit: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command: `node ${pluginRoot}/hooks/codex/userpromptsubmit.mjs`,
+            },
+          ],
+        },
+      ],
+      Stop: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command: `node ${pluginRoot}/hooks/codex/stop.mjs`,
+            },
+          ],
+        },
+      ],
     };
   }
 
@@ -271,7 +293,7 @@ export class CodexAdapter extends BaseAdapter implements HookAdapter {
         check: "Hook support",
         status: "pass",
         message:
-          "Codex CLI hooks are stable. Configure ~/.codex/hooks.json for PreToolUse, PostToolUse, and SessionStart.",
+          "Codex CLI hooks are stable. Configure ~/.codex/hooks.json for PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, and Stop.",
       },
     ];
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -65,6 +65,8 @@ const HOOK_MAP: Record<string, Record<string, string>> = {
     pretooluse: "hooks/codex/pretooluse.mjs",
     posttooluse: "hooks/codex/posttooluse.mjs",
     sessionstart: "hooks/codex/sessionstart.mjs",
+    userpromptsubmit: "hooks/codex/userpromptsubmit.mjs",
+    stop: "hooks/codex/stop.mjs",
   },
   "kiro": {
     pretooluse: "hooks/kiro/pretooluse.mjs",

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -1,6 +1,6 @@
 import "../setup-home";
 import { describe, it, expect, beforeEach } from "vitest";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { CodexAdapter } from "../../src/adapters/codex/index.js";
@@ -214,11 +214,13 @@ describe("CodexAdapter", () => {
   // ── generateHookConfig ────────────────────────────────
 
   describe("generateHookConfig", () => {
-    it("generates hooks.json with PreToolUse, PostToolUse, SessionStart entries", () => {
+    it("generates hooks.json with Codex-supported continuity entries", () => {
       const config = adapter.generateHookConfig("/path/to/plugin");
       expect(config).toHaveProperty("PreToolUse");
       expect(config).toHaveProperty("PostToolUse");
       expect(config).toHaveProperty("SessionStart");
+      expect(config).toHaveProperty("UserPromptSubmit");
+      expect(config).toHaveProperty("Stop");
     });
   });
 });
@@ -240,16 +242,65 @@ describe("Codex pretooluse hook script", () => {
       turn_id: "t1",
     });
 
-    const stdout = execSync(
-      `printf '%s' '${input.replace(/'/g, "'\\''")}' | node ${hookScript}`,
-      {
-        encoding: "utf-8",
-        timeout: 10000,
-      },
-    );
+    const stdout = execFileSync(process.execPath, [hookScript], {
+      input,
+      encoding: "utf-8",
+      timeout: 10000,
+    });
 
     const parsed = JSON.parse(stdout.trim());
     expect(parsed.hookSpecificOutput).toBeDefined();
     expect(parsed.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+  });
+});
+
+describe("Codex userpromptsubmit hook script", () => {
+  it("outputs valid JSON with UserPromptSubmit hookEventName", () => {
+    const hookScript = resolve(__dirname, "../../hooks/codex/userpromptsubmit.mjs");
+    const input = JSON.stringify({
+      session_id: "test-userprompt",
+      cwd: "/tmp",
+      hook_event_name: "UserPromptSubmit",
+      model: "o3",
+      permission_mode: "default",
+      prompt: "remember this decision",
+      transcript_path: null,
+      turn_id: "t1",
+    });
+
+    const stdout = execFileSync(process.execPath, [hookScript], {
+      input,
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.hookSpecificOutput).toBeDefined();
+    expect(parsed.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
+  });
+});
+
+describe("Codex stop hook script", () => {
+  it("outputs valid JSON without requesting continuation", () => {
+    const hookScript = resolve(__dirname, "../../hooks/codex/stop.mjs");
+    const input = JSON.stringify({
+      session_id: "test-stop",
+      cwd: "/tmp",
+      hook_event_name: "Stop",
+      model: "o3",
+      permission_mode: "default",
+      last_assistant_message: "done",
+      stop_hook_active: false,
+      transcript_path: null,
+      turn_id: "t1",
+    });
+
+    const stdout = execFileSync(process.execPath, [hookScript], {
+      input,
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+
+    expect(JSON.parse(stdout.trim())).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

This PR wires Codex CLI's `UserPromptSubmit` and `Stop` hook events into context-mode's Codex adapter.

Codex already exposes these hook events in its hook schema, and context-mode's Codex adapter comments already list them as supported Codex events. Before this change, context-mode only registered three Codex hooks:

- `PreToolUse`
- `PostToolUse`
- `SessionStart`

That meant Codex sessions could capture tool activity and startup/resume context, but not user prompt submissions or turn-end state. This PR closes that gap on the context-mode side without changing the existing Codex limitations around `updatedInput` or `PreCompact`.

## What Changed

- Added Codex dispatcher mappings for:
  - `context-mode hook codex userpromptsubmit`
  - `context-mode hook codex stop`
- Added `UserPromptSubmit` and `Stop` entries to `configs/codex/hooks.json`.
- Updated `CodexAdapter.generateHookConfig()` so generated Codex hook configs include both new events.
- Added `hooks/codex/userpromptsubmit.mjs`:
  - uses `CODEX_OPTS`
  - stores the raw user prompt
  - extracts user decision / role / intent events through the existing session extraction path
- Added `hooks/codex/stop.mjs`:
  - uses `CODEX_OPTS`
  - records turn/session end state
  - stores `stop_hook_active` and a bounded `last_assistant_message`
- Updated README and platform support docs to reflect the expanded Codex hook coverage.
- Added focused Codex adapter/hook tests for the new events.

## Why This Helps Codex

This improves Codex session continuity. With `UserPromptSubmit`, context-mode can preserve user corrections, decisions, and the exact latest prompt. With `Stop`, context-mode gets a turn-end capture point, which is especially useful because Codex does not currently expose `PreCompact`.

This does not make Codex fully equal to Claude Code yet, but it moves Codex closer by using hook events that Codex already supports today.

## Explicit Non-Goals

This PR does not implement `updatedInput` for Codex. Codex still rejects or ignores input rewrite behavior at runtime; that remains blocked on upstream OpenAI Codex support.

This PR does not add `PreCompact` for Codex. Codex does not currently expose a `PreCompact` hook event, so context-mode cannot wire it by itself.

## Verification

Passed locally:

- `bun run test tests/adapters/codex.test.ts`
- `bun run typecheck`
- Dispatcher smoke tests:
  - `bunx tsx src/cli.ts hook codex userpromptsubmit`
  - `bunx tsx src/cli.ts hook codex stop`

I also ran the full `bun run test` suite on Windows. It still has unrelated local failures in executor/core server/routing suites, while the focused Codex adapter tests pass.