### PR TITLE
fix: platform-aware session hooks and auto-memory for Qwen Code

### DIFF
--- a/hooks/posttooluse.mjs
+++ b/hooks/posttooluse.mjs
@@ -10,7 +10,7 @@ import "./ensure-deps.mjs";
  * Must be fast (<20ms). No network, no LLM, just SQLite writes.
  */
 
-import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir } from "./session-helpers.mjs";
+import { readStdin, parseStdin, getSessionId, getSessionDBPath, getInputProjectDir, detectPlatform } from "./session-helpers.mjs";
 import { createSessionLoaders, attributeAndInsertEvents } from "./session-loaders.mjs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,20 +18,21 @@ import { readFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 
 // Resolve absolute path for imports — relative dynamic imports can fail
-// when Claude Code invokes hooks from a different working directory.
+// when the host IDE invokes hooks from a different working directory.
 const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
 const { loadSessionDB, loadExtract, loadProjectAttribution } = createSessionLoaders(HOOK_DIR);
+const platformOpts = detectPlatform();
 
 try {
   const raw = await readStdin();
   const input = parseStdin(raw);
-  const projectDir = getInputProjectDir(input);
+  const projectDir = getInputProjectDir(input, platformOpts);
 
   const { extractEvents } = await loadExtract();
   const { resolveProjectAttributions } = await loadProjectAttribution();
   const { SessionDB } = await loadSessionDB();
 
-  const dbPath = getSessionDBPath();
+  const dbPath = getSessionDBPath(platformOpts);
   const db = new SessionDB({ dbPath });
   const sessionId = getSessionId(input);
 

--- a/hooks/precompact.mjs
+++ b/hooks/precompact.mjs
@@ -9,7 +9,7 @@ import "./ensure-deps.mjs";
  * snapshot (<2KB XML), and stores it for injection after compact.
  */
 
-import { readStdin, parseStdin, getSessionId, getSessionDBPath, resolveConfigDir } from "./session-helpers.mjs";
+import { readStdin, parseStdin, getSessionId, getSessionDBPath, resolveConfigDir, detectPlatform } from "./session-helpers.mjs";
 import { createSessionLoaders } from "./session-loaders.mjs";
 import { appendFileSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -18,7 +18,8 @@ import { fileURLToPath } from "node:url";
 // Resolve absolute path for imports
 const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
 const { loadSessionDB, loadSnapshot } = createSessionLoaders(HOOK_DIR);
-const DEBUG_LOG = join(resolveConfigDir(), "context-mode", "precompact-debug.log");
+const platformOpts = detectPlatform();
+const DEBUG_LOG = join(resolveConfigDir(platformOpts), "context-mode", "precompact-debug.log");
 
 try {
   const raw = await readStdin();
@@ -27,7 +28,7 @@ try {
   const { buildResumeSnapshot } = await loadSnapshot();
   const { SessionDB } = await loadSessionDB();
 
-  const dbPath = getSessionDBPath();
+  const dbPath = getSessionDBPath(platformOpts);
   const db = new SessionDB({ dbPath });
   const sessionId = getSessionId(input);
 

--- a/hooks/session-helpers.mjs
+++ b/hooks/session-helpers.mjs
@@ -51,6 +51,14 @@ const CLAUDE_OPTS = {
   sessionIdEnv: "CLAUDE_SESSION_ID",
 };
 
+/** Qwen Code platform options. */
+export const QWEN_OPTS = {
+  configDir: ".qwen",
+  configDirEnv: undefined,        // Qwen Code has no config dir env var
+  projectDirEnv: "QWEN_PROJECT_DIR",
+  sessionIdEnv: "QWEN_SESSION_ID",
+};
+
 /** Gemini CLI platform options. */
 export const GEMINI_OPTS = {
   configDir: ".gemini",
@@ -98,6 +106,41 @@ export const JETBRAINS_OPTS = {
   projectDirEnv: "IDEA_INITIAL_DIRECTORY",
   sessionIdEnv: undefined,
 };
+
+/**
+ * Auto-detect the running platform from environment variables.
+ * Checks platform-specific env vars in priority order.
+ * Supports CONTEXT_MODE_PLATFORM override for explicit pinning.
+ * Falls back to CLAUDE_OPTS when no platform is detected.
+ *
+ * @returns {object} Platform options { configDir, configDirEnv, projectDirEnv, sessionIdEnv }
+ */
+export function detectPlatform() {
+  // Explicit override takes highest priority
+  const override = process.env.CONTEXT_MODE_PLATFORM;
+  if (override) {
+    const map = {
+      "claude-code": CLAUDE_OPTS,
+      "qwen-code": QWEN_OPTS,
+      "gemini-cli": GEMINI_OPTS,
+      "vscode-copilot": VSCODE_OPTS,
+      "cursor": CURSOR_OPTS,
+      "codex": CODEX_OPTS,
+      "kiro": KIRO_OPTS,
+      "jetbrains-copilot": JETBRAINS_OPTS,
+    };
+    if (map[override]) return map[override];
+  }
+  // Env var detection (most specific signal first)
+  if (process.env.QWEN_PROJECT_DIR || process.env.QWEN_SESSION_ID) return QWEN_OPTS;
+  if (process.env.GEMINI_PROJECT_DIR) return GEMINI_OPTS;
+  if (process.env.VSCODE_CWD) return VSCODE_OPTS;
+  if (process.env.CURSOR_CWD) return CURSOR_OPTS;
+  if (process.env.CODEX_HOME) return CODEX_OPTS;
+  if (process.env.IDEA_INITIAL_DIRECTORY) return JETBRAINS_OPTS;
+  // Kiro has no unique env var — detected via tool_name prefix in hook stdin
+  return CLAUDE_OPTS;
+}
 
 /**
  * Resolve the platform config directory, respecting env var overrides.

--- a/hooks/sessionstart.mjs
+++ b/hooks/sessionstart.mjs
@@ -21,7 +21,7 @@ import { buildAutoInjection } from "./auto-injection.mjs";
 
 const toolNamer = createToolNamer("claude-code");
 const ROUTING_BLOCK = createRoutingBlock(toolNamer);
-import { readStdin, parseStdin, getSessionId, getSessionDBPath, getSessionEventsPath, getCleanupFlagPath, resolveConfigDir } from "./session-helpers.mjs";
+import { readStdin, parseStdin, getSessionId, getSessionDBPath, getSessionEventsPath, getCleanupFlagPath, resolveConfigDir, detectPlatform } from "./session-helpers.mjs";
 import { writeSessionEventsFile, buildSessionDirective, getSessionEvents, getLatestSessionEvents } from "./session-directive.mjs";
 import { createSessionLoaders } from "./session-loaders.mjs";
 import { join, dirname } from "node:path";
@@ -31,6 +31,9 @@ import { readFileSync, unlinkSync, readdirSync, rmSync, statSync } from "node:fs
 // Resolve absolute path for imports (fileURLToPath for Windows compat)
 const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
 const { loadSessionDB } = createSessionLoaders(HOOK_DIR);
+
+// Auto-detect platform for correct env vars and config paths
+const platformOpts = detectPlatform();
 
 let additionalContext = ROUTING_BLOCK;
 
@@ -42,7 +45,7 @@ try {
   if (source === "compact") {
     // Session was compacted — write events to file for auto-indexing, inject directive only
     const { SessionDB } = await loadSessionDB();
-    const dbPath = getSessionDBPath();
+    const dbPath = getSessionDBPath(platformOpts);
     const db = new SessionDB({ dbPath });
     const sessionId = getSessionId(input);
     const resume = db.getResume(sessionId);
@@ -79,7 +82,7 @@ try {
     try { unlinkSync(getCleanupFlagPath()); } catch { /* no flag */ }
 
     const { SessionDB } = await loadSessionDB();
-    const dbPath = getSessionDBPath();
+    const dbPath = getSessionDBPath(platformOpts);
     const db = new SessionDB({ dbPath });
 
     const events = getLatestSessionEvents(db);
@@ -90,9 +93,9 @@ try {
 
     db.close();
   } else if (source === "startup") {
-    // Fresh session (no --continue) — clean slate, capture CLAUDE.md rules.
+    // Fresh session (no --continue) — clean slate, capture instruction files.
     const { SessionDB } = await loadSessionDB();
-    const dbPath = getSessionDBPath();
+    const dbPath = getSessionDBPath(platformOpts);
     const db = new SessionDB({ dbPath });
     try { unlinkSync(getSessionEventsPath()); } catch { /* no stale file */ }
 
@@ -102,18 +105,21 @@ try {
     db.cleanupOldSessions(7);
     db.db.exec(`DELETE FROM session_events WHERE session_id NOT IN (SELECT session_id FROM session_meta)`);
 
-    // Proactively capture CLAUDE.md files — Claude Code loads them as system
+    // Proactively capture instruction files — the host IDE loads them as system
     // context at startup, invisible to PostToolUse hooks. We read them from
     // disk so they survive compact/resume via the session events pipeline.
     const sessionId = getSessionId(input);
-    const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+    const projectDir = process.env[platformOpts.projectDirEnv] || process.cwd();
     db.ensureSession(sessionId, projectDir);
-    const claudeMdPaths = [
-      join(resolveConfigDir(), "CLAUDE.md"),
-      join(projectDir, "CLAUDE.md"),
-      join(projectDir, ".claude", "CLAUDE.md"),
+    const memoryFileNames = platformOpts.configDir === ".qwen"
+      ? ["QWEN.md"]
+      : ["CLAUDE.md"];
+    const memoryMdPaths = [
+      join(resolveConfigDir(platformOpts), memoryFileNames[0]),
+      join(projectDir, memoryFileNames[0]),
+      join(projectDir, platformOpts.configDir, memoryFileNames[0]),
     ];
-    for (const p of claudeMdPaths) {
+    for (const p of memoryMdPaths) {
       try {
         const content = readFileSync(p, "utf-8");
         if (content.trim()) {
@@ -128,7 +134,10 @@ try {
     // Age-gated lazy cleanup of old plugin cache version dirs (#181).
     // Only delete dirs older than 1 hour to avoid breaking active sessions.
     try {
-      const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT;
+      const pluginRootEnv = platformOpts.configDir === ".qwen"
+        ? "QWEN_PLUGIN_ROOT"
+        : "CLAUDE_PLUGIN_ROOT";
+      const pluginRoot = process.env[pluginRootEnv];
       if (pluginRoot) {
         const cacheParentMatch = pluginRoot.match(/^(.*[\\/]plugins[\\/]cache[\\/][^\\/]+[\\/][^\\/]+[\\/])/);
         if (cacheParentMatch) {

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -59,5 +59,13 @@ export abstract class BaseAdapter {
     }
   }
 
+  /**
+   * Default instruction files: CLAUDE.md (Claude Code convention).
+   * Override in platform-specific adapters (e.g., Qwen: ["QWEN.md"]).
+   */
+  getInstructionFiles(): string[] {
+    return ["CLAUDE.md"];
+  }
+
   abstract getSettingsPath(): string;
 }

--- a/src/adapters/qwen-code/index.ts
+++ b/src/adapters/qwen-code/index.ts
@@ -60,6 +60,10 @@ export class QwenCodeAdapter extends ClaudeCodeBaseAdapter implements HookAdapte
     return resolve(homedir(), ".qwen", "settings.json");
   }
 
+  getInstructionFiles(): string[] {
+    return ["QWEN.md"];
+  }
+
   generateHookConfig(pluginRoot: string): HookRegistration {
     // Qwen Code passes native tool names in hook stdin (verified from
     // packages/core/src/tools/tool-names.ts). Claude-style names (Bash, Read)

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -209,6 +209,14 @@ export interface HookAdapter {
   /** Path to the platform's settings file (e.g., ~/.claude/settings.json). */
   getSettingsPath(): string;
 
+  /**
+   * Instruction/memory file names to scan for auto-memory search.
+   * Each platform declares its own set (e.g., Claude: ["CLAUDE.md"],
+   * Qwen: ["QWEN.md"], Codex: ["AGENTS.md", "AGENTS.override.md"]).
+   * Used by searchAutoMemory() and sessionstart.mjs.
+   */
+  getInstructionFiles(): string[];
+
   /** Directory where session data is stored. */
   getSessionDir(): string;
 

--- a/src/search/auto-memory.ts
+++ b/src/search/auto-memory.ts
@@ -1,12 +1,12 @@
 /**
- * Auto-memory search — searches CLAUDE.md and MEMORY.md files for
+ * Auto-memory search — searches agent instruction and memory files for
  * persisted decisions, preferences, and context from prior sessions.
  *
  * Returns results in a format compatible with the unified search pipeline.
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join } from "node:path";
 import { homedir } from "node:os";
 
 const DEBUG = process.env.DEBUG?.includes("context-mode");
@@ -20,18 +20,19 @@ export interface AutoMemoryResult {
 }
 
 /**
- * Search auto-memory files (CLAUDE.md, MEMORY.md, user identity files)
+ * Search auto-memory files (CLAUDE.md, QWEN.md, AGENTS.md, MEMORY.md, etc.)
  * for content matching any of the given queries.
  *
  * Scans:
- *   1. Project-level: <projectDir>/CLAUDE.md
- *   2. User-level: <configDir>/CLAUDE.md
- *   3. User memory: <configDir>/memory/*.md
+ *   1. Project-level: <projectDir>/{instructionFiles}
+ *   2. User-level: <configDir>/{instructionFiles}
+ *   3. User memory: <configDir>/{memory,memories}/*.md
  *
  * @param queries  Array of search terms
  * @param limit    Max results to return
  * @param projectDir  Project directory path
- * @param configDir   Config directory (e.g. ~/.claude)
+ * @param configDir   Config directory (e.g. ~/.claude, ~/.qwen)
+ * @param memoryFileNames  Instruction file names to scan (default: ["CLAUDE.md"])
  * @returns Matching auto-memory results
  */
 export function searchAutoMemory(
@@ -39,41 +40,48 @@ export function searchAutoMemory(
   limit: number = 5,
   projectDir?: string,
   configDir?: string,
+  memoryFileNames: string[] = ["CLAUDE.md"],
 ): AutoMemoryResult[] {
   const results: AutoMemoryResult[] = [];
   const effectiveConfigDir = configDir || join(homedir(), ".claude");
 
   // Collect candidate files
   const candidates: Array<{ path: string; label: string }> = [];
+  const seen = new Set<string>();
 
-  // 1. Project-level CLAUDE.md
-  if (projectDir) {
-    const projectClaude = join(projectDir, "CLAUDE.md");
-    if (existsSync(projectClaude)) {
-      candidates.push({ path: projectClaude, label: "project/CLAUDE.md" });
-    }
-  }
+  const addCandidate = (path: string, label: string): void => {
+    if (seen.has(path) || !existsSync(path)) return;
+    seen.add(path);
+    candidates.push({ path, label });
+  };
 
-  // 2. User-level CLAUDE.md
-  const userClaude = join(effectiveConfigDir, "CLAUDE.md");
-  if (existsSync(userClaude)) {
-    candidates.push({ path: userClaude, label: "user/CLAUDE.md" });
-  }
-
-  // 3. User memory directory
-  const memoryDir = join(effectiveConfigDir, "memory");
-  if (existsSync(memoryDir)) {
+  const addMemoryDir = (dir: string, labelPrefix: string): void => {
+    if (!existsSync(dir)) return;
     try {
-      const files = readdirSync(memoryDir).filter(f => f.endsWith(".md"));
+      const files = readdirSync(dir).filter(f => f.endsWith(".md"));
       for (const file of files) {
-        candidates.push({
-          path: join(memoryDir, file),
-          label: `memory/${file}`,
-        });
+        addCandidate(join(dir, file), `${labelPrefix}/${file}`);
       }
     } catch (e) {
       if (DEBUG) process.stderr.write(`[ctx] auto-memory dir scan failed: ${e}\n`);
     }
+  };
+
+  // 1. Project-level instruction files
+  if (projectDir) {
+    for (const file of memoryFileNames) {
+      addCandidate(join(projectDir, file), `project/${file}`);
+    }
+  }
+
+  // 2. User-level instruction files
+  for (const file of memoryFileNames) {
+    addCandidate(join(effectiveConfigDir, file), `user/${file}`);
+  }
+
+  // 3. User memory directories. Codex uses "memories"; Claude/Qwen use "memory".
+  for (const dirName of ["memory", "memories"]) {
+    addMemoryDir(join(effectiveConfigDir, dirName), dirName);
   }
 
   // Search each candidate file for matching queries

--- a/src/server.ts
+++ b/src/server.ts
@@ -133,6 +133,18 @@ function getSessionDir(): string {
 }
 
 /**
+ * Get the platform-specific config root used for auto-memory files.
+ * Derives from the detected adapter's settings path when available.
+ * Falls back to CLAUDE_CONFIG_DIR / ~/.claude for unknown platforms.
+ */
+function getMemoryConfigDir(): string {
+  if (_detectedAdapter) {
+    return dirname(_detectedAdapter.getSettingsPath());
+  }
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+
+/**
  * Project directory detection across supported platforms.
  *
  * Priority:
@@ -1330,14 +1342,14 @@ server.registerTool(
       if (sort === "timeline") {
         try {
           const sessionsDir = getSessionDir();
-          const dbFile = join(sessionsDir, `${hashProjectDir()}.db`);
+          const dbFile = join(sessionsDir, `${hashProjectDir()}${getWorktreeSuffix()}.db`);
           if (existsSync(dbFile)) {
             timelineDB = new SessionDB({ dbPath: dbFile });
           }
         } catch { /* SessionDB unavailable — search ContentStore + auto-memory only */ }
       }
 
-      const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+      const configDir = getMemoryConfigDir();
 
       try {
       for (const q of queryList) {

--- a/src/session/extract.ts
+++ b/src/session/extract.ts
@@ -58,7 +58,7 @@ function safeStringAny(value: unknown): string {
 /**
  * Category 1 & 2: rule + file
  *
- * CLAUDE.md / .claude/ reads → emit both a "rule" event (priority 1) AND a
+ * Agent instruction/memory reads → emit both a "rule" event (priority 1) AND a
  * "file_read" event (priority 1) because the file is being actively accessed.
  *
  * Other Edit/Write/Read tool calls → emit a file_edit / file_write / file_read
@@ -71,8 +71,11 @@ function extractFileAndRule(input: HookInput): SessionEvent[] {
   if (tool_name === "Read") {
     const filePath = String(tool_input["file_path"] ?? "");
 
-    // Rule detection: CLAUDE.md or anything inside a .claude/ directory
-    const isRuleFile = /CLAUDE\.md$|\.claude[\\/]/i.test(filePath);
+    // Rule detection: platform instruction files and agent memory directories.
+    const isRuleFile =
+      /(CLAUDE|QWEN|AGENTS(?:\.override)?|GEMINI|MEMORY)\.md$/i.test(filePath) ||
+      /[\\/]\.claude[\\/]/i.test(filePath) ||
+      /[\\/]\.(codex|qwen|gemini)[\\/](memory|memories)[\\/]/i.test(filePath);
     if (isRuleFile) {
       events.push({
         type: "rule",

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -3089,6 +3089,7 @@ describe("default sort is relevance (backward compatible)", () => {
 describe("searchAutoMemory", () => {
   const AUTO_MEM_ROOT = join(tmpdir(), `ctx-auto-memory-test-${Date.now()}`);
   const CLAUDE_CONFIG = join(AUTO_MEM_ROOT, ".claude");
+  const CODEX_CONFIG = join(AUTO_MEM_ROOT, ".codex");
   const QWEN_CONFIG = join(AUTO_MEM_ROOT, ".qwen");
   const PROJECT_DIR = join(AUTO_MEM_ROOT, "project");
 
@@ -3099,6 +3100,14 @@ describe("searchAutoMemory", () => {
     writeFileSync(
       join(PROJECT_DIR, "CLAUDE.md"),
       "Project instructions: use TypeScript strict mode. Analytics pipeline config here.",
+    );
+    writeFileSync(
+      join(PROJECT_DIR, "AGENTS.md"),
+      "Codex project instruction marker: use platform-aware memory roots.",
+    );
+    writeFileSync(
+      join(PROJECT_DIR, "AGENTS.override.md"),
+      "Codex project override marker: prefer active override instructions.",
     );
 
     // Create user-level configDir for .claude
@@ -3132,6 +3141,16 @@ describe("searchAutoMemory", () => {
     mkdirSync(qwenMemDir, { recursive: true });
     writeFileSync(join(QWEN_CONFIG, "CLAUDE.md"), "Qwen user config.");
     writeFileSync(join(qwenMemDir, "note.md"), "Qwen analytics note content.");
+
+    // Create user-level configDir for .codex
+    const codexMemDir = join(CODEX_CONFIG, "memories");
+    mkdirSync(codexMemDir, { recursive: true });
+    writeFileSync(join(CODEX_CONFIG, "AGENTS.md"), "Codex user instruction marker.");
+    writeFileSync(join(CODEX_CONFIG, "AGENTS.override.md"), "Codex user override marker.");
+    writeFileSync(
+      join(codexMemDir, "MEMORY.md"),
+      "Codex memory marker: timeline proof should read .codex/memories.",
+    );
   })();
 
   test("returns empty for non-existent project and config directories", () => {
@@ -3167,6 +3186,55 @@ describe("searchAutoMemory", () => {
     expect(lower.length).toBeGreaterThanOrEqual(1);
     expect(upper.length).toBe(lower.length);
     expect(mixed.length).toBe(lower.length);
+  });
+
+  test("finds Codex AGENTS.md and .codex/memories files", () => {
+    const projectResults = searchAutoMemory(
+      ["platform-aware memory roots"],
+      10,
+      PROJECT_DIR,
+      CODEX_CONFIG,
+      ["AGENTS.md", "AGENTS.override.md", "MEMORY.md"],
+    );
+    expect(projectResults.some(r => r.source === "project/AGENTS.md")).toBe(true);
+
+    const userResults = searchAutoMemory(
+      ["Codex user instruction marker"],
+      10,
+      undefined,
+      CODEX_CONFIG,
+      ["AGENTS.md", "AGENTS.override.md", "MEMORY.md"],
+    );
+    expect(userResults.some(r => r.source === "user/AGENTS.md")).toBe(true);
+
+    const memoryResults = searchAutoMemory(
+      ["timeline proof"],
+      10,
+      undefined,
+      CODEX_CONFIG,
+      ["AGENTS.md", "AGENTS.override.md", "MEMORY.md"],
+    );
+    expect(memoryResults.some(r => r.source === "memories/MEMORY.md")).toBe(true);
+  });
+
+  test("finds Codex AGENTS.override.md files", () => {
+    const projectResults = searchAutoMemory(
+      ["active override instructions"],
+      10,
+      PROJECT_DIR,
+      CODEX_CONFIG,
+      ["AGENTS.md", "AGENTS.override.md", "MEMORY.md"],
+    );
+    expect(projectResults.some(r => r.source === "project/AGENTS.override.md")).toBe(true);
+
+    const userResults = searchAutoMemory(
+      ["Codex user override marker"],
+      10,
+      undefined,
+      CODEX_CONFIG,
+      ["AGENTS.md", "AGENTS.override.md", "MEMORY.md"],
+    );
+    expect(userResults.some(r => r.source === "user/AGENTS.override.md")).toBe(true);
   });
 
   test("respects limit parameter", () => {

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -1208,6 +1208,25 @@ describe("Platform-aware session paths via adapter", () => {
     expect(statsMatch![0]).not.toMatch(/["']\.claude["']/);
   });
 
+  test("ctx_search uses platform-aware auto-memory config dir", () => {
+    const searchMatch = serverSrc.match(
+      /server\.registerTool\(\s*"ctx_search"[\s\S]*?^\);/m,
+    );
+    expect(searchMatch).not.toBeNull();
+    expect(searchMatch![0]).toContain("getMemoryConfigDir()");
+    expect(searchMatch![0]).not.toContain("CLAUDE_CONFIG_DIR");
+    expect(searchMatch![0]).not.toMatch(/join\(homedir\(\), \["']\.claude["']\)/);
+  });
+
+  test("ctx_search timeline opens the worktree-suffixed SessionDB", () => {
+    const searchMatch = serverSrc.match(
+      /server\.registerTool\(\s*"ctx_search"[\s\S]*?^\);/m,
+    );
+    expect(searchMatch).not.toBeNull();
+    expect(searchMatch![0]).toContain("getWorktreeSuffix()");
+    expect(searchMatch![0]).toMatch(/\$\{hashProjectDir\(\)\}\$\{getWorktreeSuffix\(\)\}\.db/);
+  });
+
   // ── Adapter methods used for session paths ──
   test("session paths derived from adapter.getSessionDir or getSessionDBPath", () => {
     // Either directly uses adapter methods or a helper that delegates to them

--- a/tests/session/session-extract.test.ts
+++ b/tests/session/session-extract.test.ts
@@ -88,6 +88,58 @@ describe("Rule Events", () => {
     assert.equal(ruleEvents.length, 1);
   });
 
+  test("extracts rule event for Codex AGENTS.md", () => {
+    const input = {
+      tool_name: "Read",
+      tool_input: { file_path: "/project/AGENTS.md" },
+      tool_response: "# Instructions\nUse context-mode timeline memory.",
+    };
+
+    const events = extractEvents(input);
+    const ruleEvents = events.filter(e => e.type === "rule");
+    assert.equal(ruleEvents.length, 1);
+    assert.ok(ruleEvents[0].data.includes("AGENTS.md"));
+  });
+
+  test("extracts rule event for Codex AGENTS.override.md", () => {
+    const input = {
+      tool_name: "Read",
+      tool_input: { file_path: "/project/AGENTS.override.md" },
+      tool_response: "# Override instructions\nPrefer override guidance.",
+    };
+
+    const events = extractEvents(input);
+    const ruleEvents = events.filter(e => e.type === "rule");
+    assert.equal(ruleEvents.length, 1);
+    assert.ok(ruleEvents[0].data.includes("AGENTS.override.md"));
+  });
+
+  test("extracts rule event for Codex memories files", () => {
+    const input = {
+      tool_name: "Read",
+      tool_input: { file_path: "/home/user/.codex/memories/MEMORY.md" },
+      tool_response: "Always preserve Codex memory.",
+    };
+
+    const events = extractEvents(input);
+    const ruleEvents = events.filter(e => e.type === "rule");
+    assert.equal(ruleEvents.length, 1);
+    assert.ok(ruleEvents[0].data.includes("MEMORY.md"));
+  });
+
+  test("extracts rule event for QWEN.md", () => {
+    const input = {
+      tool_name: "Read",
+      tool_input: { file_path: "/project/QWEN.md" },
+      tool_response: "# Qwen instructions\nUse context-mode.",
+    };
+
+    const events = extractEvents(input);
+    const ruleEvents = events.filter(e => e.type === "rule");
+    assert.equal(ruleEvents.length, 1);
+    assert.ok(ruleEvents[0].data.includes("QWEN.md"));
+  });
+
   test("CLAUDE.md read yields both rule AND file events", () => {
     const input = {
       tool_name: "Read",


### PR DESCRIPTION
## Summary

v1.0.100 introduced session continuity (compact/resume) and auto-memory search, but these features were hardcoded to Claude Code conventions — Qwen Code users got no benefit. This PR makes the hook layer and auto-memory platform-aware, merging with #379 (Codex memory roots) to cover all 14 adapters.

## Changes

### Adapter contract — `getInstructionFiles()`
- Added `getInstructionFiles(): string[]` to `HookAdapter` interface
- Default in `BaseAdapter` returns `["CLAUDE.md"]`
- `QwenCodeAdapter` overrides to return `["QWEN.md"]`
- Future adapters declare their own (e.g., Codex: `["AGENTS.md", "AGENTS.override.md"]`)

### `src/search/auto-memory.ts` — Platform-aware file scanning
- Merged #379's `addCandidate()` + `addMemoryDir()` structure with #370's `memoryFileNames` parameter
- Scans `{memory,memories}/*.md` for both Claude/Qwen (memory) and Codex (memories) conventions
- Deduplicates via `seen` Set

### `src/server.ts` — Platform-aware config dir
- Added `getMemoryConfigDir()` — derives from adapter's `getSettingsPath()` when available
- `ctx_search` timeline uses worktree-suffixed SessionDB (`getWorktreeSuffix()`)

### `src/session/extract.ts` — Platform-aware rule detection
- Regex covers `CLAUDE.md`, `QWEN.md`, `AGENTS.md`, `AGENTS.override.md`, `GEMINI.md`, `MEMORY.md`
- Also detects `.codex/memories/`, `.qwen/memory/`, `.gemini/memory/` dirs

### Hooks — `detectPlatform()` + platform-aware paths
- `hooks/session-helpers.mjs`: Added `detectPlatform()` with `CONTEXT_MODE_PLATFORM` override env var, `QWEN_OPTS`
- `hooks/sessionstart.mjs`: Uses platform env vars, scans `QWEN.md` for Qwen Code
- `hooks/posttooluse.mjs`: Platform-aware `getSessionDBPath()`
- `hooks/precompact.mjs`: Platform-aware `resolveConfigDir()`

### Tests
- Codex auto-memory tests (`AGENTS.md`, `AGENTS.override.md`, `.codex/memories/`)
- Platform-aware config dir test for `ctx_search`
- Worktree-suffixed SessionDB test for `ctx_search` timeline
- QWEN.md rule event extraction test
- All existing tests pass (155 search, 153 session-extract, 104/106 server)

### Removed
- No bundle files in this PR (per review feedback — let maintainer's pipeline regenerate)

## Test results
- search tests: 155/155 pass
- session-extract tests: 153/153 pass
- server tests: 104/106 pass (2 pre-existing Windows shell failures)
- typecheck: pass