### PR TITLE
fix(openclaw): route native tool aliases

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -153,6 +153,11 @@ const TOOL_ALIASES = {
   "container.exec": "Bash",
   "local_shell": "Bash",
   "grep_files": "Grep",
+  // OpenClaw native tools
+  "exec": "Bash",
+  "read": "Read",
+  "grep": "Grep",
+  "search": "Grep",
   // Cursor
   "mcp_web_fetch": "WebFetch",
   "mcp_fetch_tool": "WebFetch",

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "103k+",
+  "message": "106.1k+",
   "color": "brightgreen",
-  "npm": "85.1k+",
+  "npm": "88.3k+",
   "marketplace": "17.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "106.1k+",
+  "message": "106.8k+",
   "color": "brightgreen",
   "npm": "88.3k+",
-  "marketplace": "17.8k+"
+  "marketplace": "18.4k+"
 }

--- a/tests/adapters/claude-code.test.ts
+++ b/tests/adapters/claude-code.test.ts
@@ -555,9 +555,10 @@ describe("ClaudeCodeAdapter", () => {
       const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
       const sessionHooks = settings.hooks.SessionStart;
       expect(sessionHooks).toHaveLength(1);
-      // The fresh entry should point to the new pluginRoot (path may use \ on Windows)
+      // buildNodeCommand() normalizes all paths to forward slashes (#369, #372),
+      // so compare with forward-slash pluginRoot on Windows too.
       const command = sessionHooks[0].hooks[0].command;
-      expect(command).toContain(pluginRoot);
+      expect(command).toContain(pluginRoot.replace(/\\/g, "/"));
       expect(command).toContain("sessionstart.mjs");
     });
 

--- a/tests/hooks/tool-naming.test.ts
+++ b/tests/hooks/tool-naming.test.ts
@@ -316,6 +316,23 @@ describe("routePreToolUse with platform parameter", () => {
     expect(result!.additionalContext).not.toContain("mcp__");
   });
 
+  it("OpenClaw lowercase native tools route through canonical aliases", () => {
+    const exec = routePreToolUse("exec", { command: "ls" }, "/tmp", "openclaw");
+    expect(exec).not.toBeNull();
+    expect(exec!.action).toBe("context");
+    expect(exec!.additionalContext).toContain("ctx_batch_execute");
+
+    const read = routePreToolUse("read", { file_path: "/tmp/a.ts" }, "/tmp", "openclaw");
+    expect(read).not.toBeNull();
+    expect(read!.action).toBe("context");
+    expect(read!.additionalContext).toContain("ctx_execute_file");
+
+    const search = routePreToolUse("search", { pattern: "TODO" }, "/tmp", "openclaw");
+    expect(search).not.toBeNull();
+    expect(search!.action).toBe("context");
+    expect(search!.additionalContext).toContain("ctx_execute");
+  });
+
   it("build tool redirect uses platform tool names when platform=gemini-cli", () => {
     const result = routePreToolUse("Bash", { command: "./gradlew build" }, "/tmp", "gemini-cli");
     expect(result).not.toBeNull();


### PR DESCRIPTION
## Summary
- add OpenClaw's lowercase native tool names to the shared routing alias table
- cover `exec`, `read`, and `search` in the OpenClaw platform routing test

## Why
OpenClaw emits native tool names in lowercase (`exec`, `read`, `grep`, `search`). Without aliases, these calls bypass the canonical Bash/Read/Grep routing behavior, so OpenClaw sessions miss the context-mode guidance or curl/wget redirect path.

## Test
- `npx vitest run tests/hooks/tool-naming.test.ts tests/hooks/core-routing.test.ts`
