### PR TITLE
fix(executor): Windows shell execution silent output and .sh popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,18 @@ Without hooks, one unrouted `curl` or Playwright snapshot can dump 56 KB into co
 
 See [`docs/platform-support.md`](docs/platform-support.md) for the full capability comparison.
 
+### Windows Shell Execution
+
+On Windows, `ctx_execute(language: "shell", ...)` uses Git Bash (if available) with three safety measures:
+
+1. **No `.sh` extension** — temp scripts are written without an extension to prevent Windows file associations from opening a visible Git Bash window on top of your workspace.
+2. **`bash -c "source 'path'"`** — scripts are sourced via `-c` instead of passed as a direct argument. This avoids MSYS2 path-mangling issues and file-association side effects.
+3. **`windowsHide: true`** — the spawned process runs with a hidden console window, preventing any popup from appearing.
+
+If Git Bash is not installed, context-mode falls back to `cmd.exe` or PowerShell.
+
+**Override the shell:** Set the `SHELL` environment variable (e.g., in your MCP server config) to any executable path. If the file exists, context-mode uses it instead of auto-detecting. This works on all operating systems.
+
 ## Utility Commands
 
 **Inside any AI session** — just type the command. The LLM calls the MCP tool automatically:

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -168,9 +168,22 @@ export class PolyglotExecutor {
       code = `Path.wildcard(Path.join(${escaped}, "*/ebin"))\n|> Enum.each(&Code.prepend_path/1)\n\n${code}`;
     }
 
-    const fp = join(tmpDir, `script.${extMap[language]}`);
+    // On Windows, choose shell-specific extension to prevent file association popups
+    // while still allowing the shell to execute the script
+    let ext = extMap[language];
+    if (language === "shell" && isWin) {
+      const shellName = this.#runtimes.shell.toLowerCase();
+      if (shellName.includes("powershell") || shellName.includes("pwsh")) {
+        ext = "ps1";
+      } else if (shellName.includes("cmd")) {
+        ext = "cmd";
+      } else {
+        ext = ""; // bash/sh: no extension avoids file association
+      }
+    }
+    const fp = ext ? join(tmpDir, `script.${ext}`) : join(tmpDir, "script");
     if (language === "shell") {
-      writeFileSync(fp, code, { encoding: "utf-8", mode: 0o700 });
+      writeFileSync(fp, code, { encoding: "utf-8", mode: isWin ? undefined : 0o700 });
     } else {
       writeFileSync(fp, code, "utf-8");
     }
@@ -240,6 +253,8 @@ export class PolyglotExecutor {
         shell: needsShell,
         // On Unix, create a new process group so killTree can kill all children
         detached: !isWin,
+        // On Windows, hide the console window to prevent .sh file association popups
+        windowsHide: isWin,
       });
 
       let timedOut = false;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -128,6 +128,10 @@ export function detectRuntimes(): RuntimeMap {
   const hasBun = bunExists();
   const bun = hasBun ? bunCommand() : null;
 
+  // Respect user-override via SHELL env var if the executable exists
+  const userShell = process.env.SHELL;
+  const shellOverride = userShell && existsSync(userShell) ? userShell : null;
+
   return {
     javascript: bun ?? process.execPath,
     typescript: bun
@@ -142,9 +146,9 @@ export function detectRuntimes(): RuntimeMap {
       : commandExists("python")
         ? "python"
         : null,
-    shell: isWindows
+    shell: shellOverride ?? (isWindows
       ? (resolveWindowsBash() ?? (commandExists("sh") ? "sh" : commandExists("powershell") ? "powershell" : "cmd.exe"))
-      : commandExists("bash") ? "bash" : "sh",
+      : commandExists("bash") ? "bash" : "sh"),
     ruby: commandExists("ruby") ? "ruby" : null,
     go: commandExists("go") ? "go" : null,
     rust: commandExists("rustc") ? "rustc" : null,
@@ -273,6 +277,20 @@ export function buildCommand(
       return [runtimes.python, filePath];
 
     case "shell":
+      if (isWindows) {
+        const shellName = runtimes.shell.toLowerCase();
+        // For bash/sh on Windows, use `bash -c "source 'filePath'"` to avoid:
+        // 1. .sh file association popups
+        // 2. MSYS2 path mangling when passing script as direct argument
+        if (shellName.includes("bash") || shellName.includes("/sh")) {
+          return [runtimes.shell, "-c", `source "${filePath}"`];
+        }
+        // For PowerShell, use -File with .ps1 extension
+        if (shellName.includes("powershell") || shellName.includes("pwsh")) {
+          return [runtimes.shell, "-File", filePath];
+        }
+        // For cmd.exe, pass directly with .cmd extension
+      }
       return [runtimes.shell, filePath];
 
     case "ruby":

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -76,6 +76,42 @@ describe("Runtime Detection", () => {
       assert.ok(r.stdout.includes("chinese path ok"), `Got: ${r.stdout}`);
       try { rmSync(chineseDir, { recursive: true, force: true }); } catch {}
     });
+
+    test("SHELL env var overrides auto-detected shell", async () => {
+      const { detectRuntimes } = await import("../src/runtime.js");
+      const { existsSync } = await import("node:fs");
+      const originalShell = process.env.SHELL;
+      // Use the currently-detected shell as the override (guaranteed to exist)
+      const realShell = runtimes.shell;
+      process.env.SHELL = realShell;
+      try {
+        const rt = detectRuntimes();
+        assert.equal(rt.shell, realShell, `Expected SHELL override, got: ${rt.shell}`);
+      } finally {
+        if (originalShell !== undefined) {
+          process.env.SHELL = originalShell;
+        } else {
+          delete process.env.SHELL;
+        }
+      }
+    });
+
+    test("SHELL env var ignored when path does not exist", async () => {
+      const { detectRuntimes } = await import("../src/runtime.js");
+      const originalShell = process.env.SHELL;
+      const fakeShell = isWin ? "C:\\fake\\bash.exe" : "/fake/shell";
+      process.env.SHELL = fakeShell;
+      try {
+        const rt = detectRuntimes();
+        assert.notEqual(rt.shell, fakeShell, `Should fallback when SHELL path does not exist, got: ${rt.shell}`);
+      } finally {
+        if (originalShell !== undefined) {
+          process.env.SHELL = originalShell;
+        } else {
+          delete process.env.SHELL;
+        }
+      }
+    });
   }
 
   test("detects TypeScript runtime", async () => {
@@ -1537,9 +1573,23 @@ describe("Windows Shell Support", () => {
   });
 
   test("buildCommand returns shell command array", async () => {
-    const cmd = buildCommand(runtimes, "shell", "/tmp/script.sh");
-    assert.ok(Array.isArray(cmd) && cmd.length === 2, `Expected [shell, path], got: ${cmd}`);
-    assert.equal(cmd[1], "/tmp/script.sh");
+    const isWin = process.platform === "win32";
+    const cmd = buildCommand(runtimes, "shell", "/tmp/script");
+    const shellName = runtimes.shell.toLowerCase();
+    const isBashLike = shellName.includes("bash") || shellName.includes("/sh");
+    const isPowerShell = shellName.includes("powershell") || shellName.includes("pwsh");
+    if (isWin && isBashLike) {
+      assert.ok(Array.isArray(cmd) && cmd.length === 3, `Expected [shell, "-c", source], got: ${cmd}`);
+      assert.equal(cmd[1], "-c");
+      assert.ok(cmd[2].includes("source"), `Expected source command, got: ${cmd[2]}`);
+    } else if (isWin && isPowerShell) {
+      assert.ok(Array.isArray(cmd) && cmd.length === 3, `Expected [shell, "-File", path], got: ${cmd}`);
+      assert.equal(cmd[1], "-File");
+      assert.equal(cmd[2], "/tmp/script");
+    } else {
+      assert.ok(Array.isArray(cmd) && cmd.length === 2, `Expected [shell, path], got: ${cmd}`);
+      assert.equal(cmd[1], "/tmp/script");
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes two Windows shell execution issues in `ctx_execute(language: "shell", ...)`:

1. **Silent/no output** — `bash.exe script.sh` caused MSYS2 path-mangling and stdin issues, returning empty output even when `SHELL` was set.
2. **`.sh` file association popup** — Windows file associations for `.sh` files caused a Git Bash console window to appear on top of the workspace.

Also adds support for the `SHELL` environment variable to override the auto-detected shell on all platforms.

## Changes

### `src/executor.ts`
- **Shell-specific extensions on Windows** — temp scripts use the right extension for each shell:
  - Bash/sh: no extension (prevents file association popups)
  - PowerShell: `.ps1` (required for `-File` to work)
  - CMD: `.cmd`
- **Add `windowsHide: true` to spawn options** — hides console windows for spawned processes on Windows.

### `src/runtime.ts`
- **Use `bash -c "source 'path'"` for bash/sh on Windows** — avoids MSYS2 path-mangling and file-association side effects.
- **Use `-File` for PowerShell on Windows** — required for `.ps1` scripts to execute correctly.
- **Respect `SHELL` env var** — if `SHELL` is set and the executable exists, it overrides auto-detection on all platforms.

### `tests/executor.test.ts`
- Updated `buildCommand` shell test to expect 3-element array only when shell is bash-like on Windows.
- Added tests for `SHELL` env var override.

### `README.md`
- Added "Windows Shell Execution" section documenting safety measures and the `SHELL` override.

## Testing

Verified on Windows:
- **Git Bash**: `ctx_execute(language: "shell", code: "echo test")` returns `"test\n"` with no popup.
- **PowerShell**: `ctx_execute(language: "shell", code: "Write-Host test")` returns `"test\n"` with no popup.
- **SHELL override**: Setting `SHELL=C:/Git/bin/bash.exe` forces bash instead of auto-detected PowerShell.

Fixes #384
