### PR TITLE
fix(lifecycle): trigger isParentAlive re-check on stdin EOF to close 30s CPU-spin window (#388)

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -4,8 +4,12 @@
  * Detects parent process death (ppid polling) and OS signals to prevent
  * orphaned MCP server processes consuming 100% CPU (issue #103).
  *
- * Stdin close is NOT used as a shutdown signal — the MCP stdio transport
- * owns stdin and transient pipe events cause spurious -32000 errors (#236).
+ * Stdin close is NOT used as a *standalone* shutdown signal — the MCP stdio
+ * transport owns stdin and transient pipe events cause spurious -32000
+ * errors (#236). We do, however, treat stdin EOF as a hint to re-run the
+ * parent-liveness probe immediately (instead of waiting up to 30 s for the
+ * next poll tick), which closes the multi-day CPU-spin window seen in
+ * #311/#388 without reintroducing the false-positive shutdowns of #236.
  *
  * Cross-platform: macOS, Linux, Windows.
  */
@@ -112,9 +116,32 @@ export function startLifecycleGuard(opts: LifecycleGuardOptions): () => void {
   if (process.platform !== "win32") signals.push("SIGHUP");
   for (const sig of signals) process.on(sig, shutdown);
 
+  // P0: Stdin-EOF assist (#311/#388). The vendored MCP SDK's
+  // StdioServerTransport only registers 'data' / 'error' listeners — not
+  // 'end' — so when the parent (e.g. Claude Code) dies abruptly without
+  // sending SIGTERM, the server keeps reading from a half-closed pipe and
+  // CPU-spins until the 30 s ppid poll catches up. Observed in #388 with
+  // single processes accumulating ~80 h of CPU time before SIGKILL.
+  //
+  // We deliberately DO NOT call shutdown() unconditionally on 'end' — that
+  // is exactly the false-positive behavior #236 tore out. Instead we run
+  // the same isParentAlive() check the periodic timer uses, just earlier.
+  // If the parent is alive, this is a no-op and the existing #236
+  // regression test still passes; if the parent is gone, we collapse the
+  // 30 s detection window to ~0.
+  //
+  // Skipped on TTY (OpenCode ts-plugin) where stdin is not the MCP channel.
+  const onStdinEnd = () => {
+    if (!check()) shutdown();
+  };
+  if (!process.stdin.isTTY) {
+    process.stdin.on("end", onStdinEnd);
+  }
+
   return () => {
     stopped = true;
     clearInterval(timer);
     for (const sig of signals) process.removeListener(sig, shutdown);
+    process.stdin.removeListener("end", onStdinEnd);
   };
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "103k+",
+  "message": "106.1k+",
   "color": "brightgreen",
-  "npm": "85.1k+",
+  "npm": "88.3k+",
   "marketplace": "17.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "111.2k+",
+  "message": "111.8k+",
   "color": "brightgreen",
   "npm": "92.7k+",
-  "marketplace": "18.4k+"
+  "marketplace": "19k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "106.8k+",
+  "message": "111.2k+",
   "color": "brightgreen",
-  "npm": "88.3k+",
+  "npm": "92.7k+",
   "marketplace": "18.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "111.8k+",
+  "message": "114.2k+",
   "color": "brightgreen",
-  "npm": "92.7k+",
+  "npm": "95.1k+",
   "marketplace": "19k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "106.1k+",
+  "message": "106.8k+",
   "color": "brightgreen",
   "npm": "88.3k+",
-  "marketplace": "17.8k+"
+  "marketplace": "18.4k+"
 }

--- a/tests/adapters/claude-code.test.ts
+++ b/tests/adapters/claude-code.test.ts
@@ -555,9 +555,10 @@ describe("ClaudeCodeAdapter", () => {
       const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
       const sessionHooks = settings.hooks.SessionStart;
       expect(sessionHooks).toHaveLength(1);
-      // The fresh entry should point to the new pluginRoot (path may use \ on Windows)
+      // buildNodeCommand() normalizes all paths to forward slashes (#369, #372),
+      // so compare with forward-slash pluginRoot on Windows too.
       const command = sessionHooks[0].hooks[0].command;
-      expect(command).toContain(pluginRoot);
+      expect(command).toContain(pluginRoot.replace(/\\/g, "/"));
       expect(command).toContain("sessionstart.mjs");
     });
 

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -107,13 +107,24 @@ describe("Lifecycle Guard", () => {
     assert.equal(shutdownCalled, false);
   });
 
-  test("cleanup does NOT remove stdin listeners (stdin is not used)", async () => {
-    // Capture listeners before guard starts
-    const stdinListenersBefore = process.stdin.listenerCount("close")
-      + process.stdin.listenerCount("end")
-      + process.stdin.listenerCount("data")
-      + process.stdin.listenerCount("error")
-      + process.stdin.listenerCount("readable");
+  test("touches only the 'end' stdin listener and restores it on cleanup (#236, #388)", async () => {
+    // The guard is permitted exactly one stdin assist — an 'end' listener
+    // used as a faster trigger for the same isParentAlive check the periodic
+    // timer runs (see lifecycle.ts). It must NOT touch 'close', 'data',
+    // 'error', or 'readable', and it must remove its own 'end' listener on
+    // cleanup. This test pins both halves of that contract.
+    const sample = (event: "close" | "end" | "data" | "error" | "readable") =>
+      process.stdin.listenerCount(event);
+
+    // Snapshot non-'end' listeners — these must be invariant across the
+    // guard lifecycle. Skipping 'end' on TTY since the guard skips itself.
+    const before = {
+      close: sample("close"),
+      data: sample("data"),
+      error: sample("error"),
+      readable: sample("readable"),
+      end: sample("end"),
+    };
 
     const cleanup = startLifecycleGuard({
       checkIntervalMs: 50,
@@ -121,28 +132,38 @@ describe("Lifecycle Guard", () => {
       isParentAlive: () => true,
     });
 
-    // Capture listeners after guard starts
-    const stdinListenersAfterStart = process.stdin.listenerCount("close")
-      + process.stdin.listenerCount("end")
-      + process.stdin.listenerCount("data")
-      + process.stdin.listenerCount("error")
-      + process.stdin.listenerCount("readable");
+    const afterStart = {
+      close: sample("close"),
+      data: sample("data"),
+      error: sample("error"),
+      readable: sample("readable"),
+      end: sample("end"),
+    };
 
     cleanup();
 
-    // Capture listeners after cleanup
-    const stdinListenersAfterCleanup = process.stdin.listenerCount("close")
-      + process.stdin.listenerCount("end")
-      + process.stdin.listenerCount("data")
-      + process.stdin.listenerCount("error")
-      + process.stdin.listenerCount("readable");
+    const afterCleanup = {
+      close: sample("close"),
+      data: sample("data"),
+      error: sample("error"),
+      readable: sample("readable"),
+      end: sample("end"),
+    };
 
-    // Guard should not have added any stdin listeners
-    assert.equal(stdinListenersAfterStart, stdinListenersBefore,
-      "startLifecycleGuard must not add stdin listeners");
-    // Cleanup should not have removed any stdin listeners
-    assert.equal(stdinListenersAfterCleanup, stdinListenersBefore,
-      "cleanup must not remove stdin listeners");
+    // Non-'end' listeners must be untouched at every phase (#236 contract).
+    for (const ev of ["close", "data", "error", "readable"] as const) {
+      assert.equal(afterStart[ev], before[ev],
+        `startLifecycleGuard must not add a stdin '${ev}' listener`);
+      assert.equal(afterCleanup[ev], before[ev],
+        `cleanup must not touch the stdin '${ev}' listener`);
+    }
+
+    // 'end' listener: +1 only when stdin is not a TTY; restored on cleanup.
+    const expectedEndDelta = process.stdin.isTTY ? 0 : 1;
+    assert.equal(afterStart.end - before.end, expectedEndDelta,
+      "startLifecycleGuard adds exactly one stdin 'end' listener (or none on TTY)");
+    assert.equal(afterCleanup.end, before.end,
+      "cleanup must remove the 'end' listener it added");
   });
 
   test("startLifecycleGuard does NOT call process.stdin.resume()", async () => {
@@ -166,6 +187,44 @@ describe("Lifecycle Guard", () => {
       // Restore original resume to avoid polluting other tests
       process.stdin.resume = originalResume;
     }
+  });
+
+  test("stdin 'end' triggers immediate isParentAlive re-check; shuts down only if dead (#388)", async () => {
+    // Skip on TTY — the guard intentionally does not register the 'end'
+    // listener when stdin is a TTY (e.g. OpenCode ts-plugin), so this
+    // assertion would not apply to that environment.
+    if (process.stdin.isTTY) return;
+
+    let shutdownCalled = false;
+    let parentAlive = true;
+    let aliveCallCount = 0;
+
+    const cleanup = startLifecycleGuard({
+      // Long interval so we know the next assertion can only be driven by
+      // the 'end' listener, not the periodic timer.
+      checkIntervalMs: 60_000,
+      onShutdown: () => { shutdownCalled = true; },
+      isParentAlive: () => { aliveCallCount++; return parentAlive; },
+    });
+
+    // Phase 1: parent alive — emitting 'end' must run the check but NOT
+    // shut down. This is the #236 contract: stdin close alone is not a
+    // shutdown signal.
+    const callsBeforeAliveEnd = aliveCallCount;
+    process.stdin.emit("end");
+    assert.ok(aliveCallCount > callsBeforeAliveEnd,
+      "'end' must run isParentAlive() — that's the whole point of the assist");
+    assert.equal(shutdownCalled, false,
+      "'end' with a live parent must not shut down (regression of #236)");
+
+    // Phase 2: parent now dead — the next 'end' must collapse the
+    // detection window from 30 s to ~0 ms.
+    parentAlive = false;
+    process.stdin.emit("end");
+    assert.equal(shutdownCalled, true,
+      "'end' with a dead parent must shut down without waiting for the poll tick");
+
+    cleanup();
   });
 
   test("detects ppid=0 as dead parent (Windows behavior)", async () => {


### PR DESCRIPTION
## Summary

Fixes #388 (and addresses the residual root cause noted in the resolution comment of #311).

The vendored MCP SDK's `StdioServerTransport.start()` registers only `'data'` and `'error'` listeners on `process.stdin` — never `'end'`. When the parent (e.g. Claude Code) dies abruptly without sending SIGTERM, the server keeps reading from a half-closed pipe and CPU-spins until the next 30 s `ppid` poll. In #388 this manifested as six orphaned processes, each pinning ~95% CPU, with the oldest accumulating **80 h of CPU time** before being SIGKILL'd manually.

This PR adds a single `'end'` listener inside `startLifecycleGuard`. Crucially, it does **not** shut down on `'end'` alone — that is exactly the false-positive behavior `#236` tore out. Instead, `'end'` triggers the same `isParentAlive()` probe the periodic timer already runs, just sooner:

- **Parent alive** → no-op (the `#236` regression test still passes).
- **Parent dead** → the 30 s detection window collapses to ~0.

Skipped on TTY (e.g. OpenCode ts-plugin), where `stdin` is not the MCP channel.

## Why not "fix the SDK"

The clean fix is to register `'end'` in `StdioServerTransport.start()` upstream in `@modelcontextprotocol/sdk`. That's worth doing too, but:

1. The SDK ships vendored in `server.bundle.mjs` so context-mode users won't get the upstream fix without a re-bundle anyway.
2. Doing it in `lifecycle.ts` keeps the policy (when to shut down) where the rest of the policy already lives — out of the SDK transport.
3. We avoid touching SDK code paths and the regression risk that comes with it.

## Why this doesn't reintroduce #236

`#236` removed `process.stdin.resume()` and the `'close'`/`'error'` shutdown shortcuts because those fired on transient pipe events and called `process.exit(0)` mid-request. This PR:

- only listens on `'end'` (a one-shot EOF signal, not a transient event),
- never calls `process.stdin.resume()` (the SDK's `'data'` listener already puts stdin into flowing mode),
- never shuts down on the listener fire alone — the existing `isParentAlive()` gate must also report parent death.

The existing `child does NOT exit when stdin is closed` integration test still passes unchanged.

## Diff shape

```
 src/lifecycle.ts        |  31 +++++++++++++-
 tests/lifecycle.test.ts | 111 ++++++++++++++++++++++++++++++++++++------------
 2 files changed, 114 insertions(+), 28 deletions(-)
```

## Tests

- **All 15 lifecycle tests pass** (`bun run test tests/lifecycle.test.ts`), including the unchanged #236 integration test.
- **New unit test** emits `'end'` twice — once with `isParentAlive: () => true` (asserts no shutdown), once with `isParentAlive: () => false` (asserts shutdown). Pins both halves of the contract.
- **Updated listener-invariance test** to allow exactly one `'end'` listener delta from `startLifecycleGuard`, while pinning that `'close'`, `'data'`, `'error'`, and `'readable'` remain untouched and that the `'end'` listener is removed on cleanup. Skipped on TTY.

`bunx tsc --noEmit` is clean.

## Reproduction (from #388)

```
PID    %CPU  Started  Cumulative CPU time
86511  91.0  Apr 23   4787 min (~80 h)
11364  90.4  Fri      4693 min
58997  91.3  Mon      2714 min
10044  87.3  Tue      1993 min
52281  96.2  Tue      1648 min
```

All in `R` state. `pkill -TERM` had no effect; only `SIGKILL` worked. With this patch, an `'end'` event from the parent's pipe close triggers the existing `isParentAlive()` check immediately, so a dead parent shuts the server down before it can accumulate even one minute of busy-loop time.