### PR TITLE
Localize Pi session diagnostics

### DIFF
--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -21,6 +21,7 @@ import { extractEvents, extractUserEvents } from "./session/extract.js";
 import type { HookInput } from "./session/extract.js";
 import { buildResumeSnapshot } from "./session/snapshot.js";
 import type { SessionEvent } from "./types.js";
+import { initI18n, t } from "./pi-i18n.js";
 
 // ── Pi Tool Name Mapping ─────────────────────────────────
 // Pi uses lowercase; shared extractors expect PascalCase (Claude Code convention).
@@ -94,11 +95,11 @@ function buildStatsText(db: SessionDB, sessionId: string): string {
     const events = db.getEvents(sessionId);
     const stats = db.getSessionStats(sessionId);
     const lines: string[] = [
-      "## context-mode stats (Pi)",
+      t("stats.title", "## context-mode stats (Pi)"),
       "",
-      `- Session: \`${sessionId.slice(0, 8)}...\``,
-      `- Events captured: ${events.length}`,
-      `- Compactions: ${stats?.compact_count ?? 0}`,
+      t("stats.session", `- Session: \`${sessionId.slice(0, 8)}...\``, { session: `${sessionId.slice(0, 8)}...` }),
+      t("stats.events", `- Events captured: ${events.length}`, { count: events.length }),
+      t("stats.compactions", `- Compactions: ${stats?.compact_count ?? 0}`, { count: stats?.compact_count ?? 0 }),
     ];
 
     // Event breakdown by category
@@ -108,7 +109,7 @@ function buildStatsText(db: SessionDB, sessionId: string): string {
       byCategory[key] = (byCategory[key] ?? 0) + 1;
     }
     if (Object.keys(byCategory).length > 0) {
-      lines.push("- Event breakdown:");
+      lines.push(t("stats.breakdown", "- Event breakdown:"));
       for (const [category, count] of Object.entries(byCategory)) {
         lines.push(`  - ${category}: ${count}`);
       }
@@ -118,12 +119,12 @@ function buildStatsText(db: SessionDB, sessionId: string): string {
     if (stats?.started_at) {
       const startedMs = new Date(stats.started_at).getTime();
       const ageMinutes = Math.round((Date.now() - startedMs) / 60_000);
-      lines.push(`- Session age: ${ageMinutes}m`);
+      lines.push(t("stats.age", `- Session age: ${ageMinutes}m`, { minutes: ageMinutes }));
     }
 
     return lines.join("\n");
   } catch {
-    return "context-mode stats unavailable (session DB error)";
+    return t("stats.unavailable", "context-mode stats unavailable (session DB error)");
   }
 }
 
@@ -149,6 +150,7 @@ function handleCommandText(
 
 /** Pi extension default export. Called once by Pi runtime with the extension API. */
 export default function piExtension(pi: any): void {
+  initI18n(pi);
   const buildDir = dirname(fileURLToPath(import.meta.url));
   const pluginRoot = resolve(buildDir, "..");
   const projectDir = process.env.PI_PROJECT_DIR || process.cwd();
@@ -185,9 +187,10 @@ export default function piExtension(pi: any): void {
       if (isBlocked) {
         return {
           block: true,
-          reason:
-            "Use context-mode MCP tools (execute, fetch_and_index) instead of inline HTTP clients. " +
-            "Raw curl/wget/fetch output floods the context window.",
+          reason: t(
+            "block.inlineHttp",
+            "Use context-mode MCP tools (execute, fetch_and_index) instead of inline HTTP clients. Raw curl/wget/fetch output floods the context window.",
+          ),
         };
       }
     } catch {
@@ -360,12 +363,12 @@ export default function piExtension(pi: any): void {
   // ── 8. Slash commands ──────────────────────────────────
 
   pi.registerCommand("ctx-stats", {
-    description: "Show context-mode session statistics",
+    description: t("cmd.stats.description", "Show context-mode session statistics"),
     handler: async (argsOrCtx: unknown, maybeCtx: unknown) => {
       const ctx = resolveCommandContext(argsOrCtx, maybeCtx);
       const text =
         !_db || !_sessionId
-          ? "context-mode: no active session"
+          ? t("stats.noSession", "context-mode: no active session")
           : buildStatsText(_db, _sessionId);
 
       return handleCommandText(text, ctx);
@@ -373,33 +376,36 @@ export default function piExtension(pi: any): void {
   });
 
   pi.registerCommand("ctx-doctor", {
-    description: "Run context-mode diagnostics",
+    description: t("cmd.doctor.description", "Run context-mode diagnostics"),
     handler: async (argsOrCtx: unknown, maybeCtx: unknown) => {
       const ctx = resolveCommandContext(argsOrCtx, maybeCtx);
       const dbPath = getDBPath();
       const dbExists = existsSync(dbPath);
       const lines: string[] = [
-        "## ctx-doctor (Pi)",
+        t("doctor.title", "## ctx-doctor (Pi)"),
         "",
-        `- DB path: \`${dbPath}\``,
-        `- DB exists: ${dbExists}`,
-        `- Session ID: \`${_sessionId ? _sessionId.slice(0, 8) + "..." : "none"}\``,
-        `- Plugin root: \`${pluginRoot}\``,
-        `- Project dir: \`${projectDir}\``,
+        t("doctor.dbPath", `- DB path: \`${dbPath}\``, { path: dbPath }),
+        t("doctor.dbExists", `- DB exists: ${dbExists}`, { exists: dbExists }),
+        t("doctor.sessionId", `- Session ID: \`${_sessionId ? _sessionId.slice(0, 8) + "..." : "none"}\``, { session: _sessionId ? _sessionId.slice(0, 8) + "..." : t("state.none", "none") }),
+        t("doctor.pluginRoot", `- Plugin root: \`${pluginRoot}\``, { path: pluginRoot }),
+        t("doctor.projectDir", `- Project dir: \`${projectDir}\``, { path: projectDir }),
       ];
 
       if (_db && _sessionId) {
         try {
           const stats = _db.getSessionStats(_sessionId);
           const eventCount = _db.getEventCount(_sessionId);
-          lines.push(`- Events: ${eventCount}`);
-          lines.push(`- Compactions: ${stats?.compact_count ?? 0}`);
+          lines.push(t("doctor.events", `- Events: ${eventCount}`, { count: eventCount }));
+          lines.push(t("doctor.compactions", `- Compactions: ${stats?.compact_count ?? 0}`, { count: stats?.compact_count ?? 0 }));
           const resume = _db.getResume(_sessionId);
-          lines.push(
-            `- Resume snapshot: ${resume ? (resume.consumed ? "consumed" : "available") : "none"}`,
-          );
+          const state = resume
+            ? resume.consumed
+              ? t("state.consumed", "consumed")
+              : t("state.available", "available")
+            : t("state.none", "none");
+          lines.push(t("doctor.resume", `- Resume snapshot: ${state}`, { state }));
         } catch {
-          lines.push("- DB query error");
+          lines.push(t("doctor.dbQueryError", "- DB query error"));
         }
       }
 

--- a/src/pi-i18n.ts
+++ b/src/pi-i18n.ts
@@ -1,0 +1,118 @@
+type Params = Record<string, string | number | boolean>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+  if (!params) return text;
+  return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+  return translate(key, fallback, params);
+}
+
+const bundles = [
+  {
+    locale: "ja",
+    namespace: "context-mode",
+    messages: {
+      "block.inlineHttp": "インライン HTTP クライアントではなく context-mode MCP ツール（execute、fetch_and_index）を使ってください。生の curl/wget/fetch 出力はコンテキストウィンドウを圧迫します。",
+      "cmd.stats.description": "context-mode のセッション統計を表示",
+      "cmd.doctor.description": "context-mode の診断を実行",
+      "stats.title": "## context-mode 統計（Pi）",
+      "stats.session": "- セッション: `{session}`",
+      "stats.events": "- 取得イベント数: {count}",
+      "stats.compactions": "- 圧縮回数: {count}",
+      "stats.breakdown": "- イベント内訳:",
+      "stats.age": "- セッション経過時間: {minutes}分",
+      "stats.unavailable": "context-mode 統計を利用できません（セッション DB エラー）",
+      "stats.noSession": "context-mode: アクティブなセッションがありません",
+      "doctor.title": "## ctx-doctor（Pi）",
+      "doctor.dbPath": "- DB パス: `{path}`",
+      "doctor.dbExists": "- DB あり: {exists}",
+      "doctor.sessionId": "- セッション ID: `{session}`",
+      "doctor.pluginRoot": "- プラグインルート: `{path}`",
+      "doctor.projectDir": "- プロジェクトディレクトリ: `{path}`",
+      "doctor.events": "- イベント: {count}",
+      "doctor.compactions": "- 圧縮回数: {count}",
+      "doctor.resume": "- 再開スナップショット: {state}",
+      "doctor.dbQueryError": "- DB クエリエラー",
+      "state.none": "なし",
+      "state.consumed": "消費済み",
+      "state.available": "利用可能",
+    },
+  },
+  {
+    locale: "zh-CN",
+    namespace: "context-mode",
+    messages: {
+      "block.inlineHttp": "请使用 context-mode MCP 工具（execute、fetch_and_index），不要使用内联 HTTP 客户端。原始 curl/wget/fetch 输出会淹没上下文窗口。",
+      "cmd.stats.description": "显示 context-mode 会话统计",
+      "cmd.doctor.description": "运行 context-mode 诊断",
+      "stats.title": "## context-mode 统计（Pi）",
+      "stats.session": "- 会话: `{session}`",
+      "stats.events": "- 已捕获事件: {count}",
+      "stats.compactions": "- 压缩次数: {count}",
+      "stats.breakdown": "- 事件分类:",
+      "stats.age": "- 会话时长: {minutes} 分钟",
+      "stats.unavailable": "context-mode 统计不可用（会话 DB 错误）",
+      "stats.noSession": "context-mode: 没有活动会话",
+      "doctor.title": "## ctx-doctor（Pi）",
+      "doctor.dbPath": "- DB 路径: `{path}`",
+      "doctor.dbExists": "- DB 存在: {exists}",
+      "doctor.sessionId": "- 会话 ID: `{session}`",
+      "doctor.pluginRoot": "- 插件根目录: `{path}`",
+      "doctor.projectDir": "- 项目目录: `{path}`",
+      "doctor.events": "- 事件: {count}",
+      "doctor.compactions": "- 压缩次数: {count}",
+      "doctor.resume": "- 恢复快照: {state}",
+      "doctor.dbQueryError": "- DB 查询错误",
+      "state.none": "无",
+      "state.consumed": "已消耗",
+      "state.available": "可用",
+    },
+  },
+  {
+    locale: "es",
+    namespace: "context-mode",
+    messages: {
+      "block.inlineHttp": "Usa las herramientas MCP de context-mode (execute, fetch_and_index) en lugar de clientes HTTP inline. La salida cruda de curl/wget/fetch llena la ventana de contexto.",
+      "cmd.stats.description": "Mostrar estadísticas de sesión de context-mode",
+      "cmd.doctor.description": "Ejecutar diagnósticos de context-mode",
+      "stats.title": "## estadísticas de context-mode (Pi)",
+      "stats.session": "- Sesión: `{session}`",
+      "stats.events": "- Eventos capturados: {count}",
+      "stats.compactions": "- Compactaciones: {count}",
+      "stats.breakdown": "- Desglose de eventos:",
+      "stats.age": "- Edad de la sesión: {minutes}m",
+      "stats.unavailable": "estadísticas de context-mode no disponibles (error de DB de sesión)",
+      "stats.noSession": "context-mode: no hay sesión activa",
+      "doctor.title": "## ctx-doctor (Pi)",
+      "doctor.dbPath": "- Ruta de DB: `{path}`",
+      "doctor.dbExists": "- DB existe: {exists}",
+      "doctor.sessionId": "- ID de sesión: `{session}`",
+      "doctor.pluginRoot": "- Raíz del plugin: `{path}`",
+      "doctor.projectDir": "- Directorio del proyecto: `{path}`",
+      "doctor.events": "- Eventos: {count}",
+      "doctor.compactions": "- Compactaciones: {count}",
+      "doctor.resume": "- Snapshot de reanudación: {state}",
+      "doctor.dbQueryError": "- Error de consulta de DB",
+      "state.none": "ninguno",
+      "state.consumed": "consumido",
+      "state.available": "disponible",
+    },
+  },
+];
+
+export function initI18n(pi: any): void {
+  const events = pi?.events;
+  if (!events) return;
+  for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+  events.emit("pi-core/i18n/requestApi", {
+    namespace: "context-mode",
+    callback(api: { t?: Translate } | undefined) {
+      if (typeof api?.t === "function") translate = api.t;
+    },
+  });
+}


### PR DESCRIPTION
The Pi adapter has a small but high-friction user-facing surface: /ctx-stats, /ctx-doctor, and the routing block message that explains why inline curl/wget/fetch was stopped.

Those messages are exactly where users debug whether context-mode is capturing events, whether resume snapshots exist, and why a command was blocked to protect the context window. This PR makes that surface optionally localizable while keeping the current English strings as fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, es
- Pi adapter only; no CLI/OpenClaw/Claude hook changes
- Does not include generated bundle churn

Validation:
- npm install --ignore-scripts
- npm run typecheck
- npm run build
- npm pack --dry-run