### PR TITLE
Localize Pi doctor status copy

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,87 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+  es: {
+    "ctx.stats.title": "## estadísticas de context-mode (Pi)",
+    "ctx.stats.session": "- Sesión: `{session}...`",
+    "ctx.stats.events": "- Eventos capturados: {count}",
+    "ctx.stats.compactions": "- Compactaciones: {count}",
+    "ctx.stats.breakdown": "- Desglose de eventos:",
+    "ctx.stats.age": "- Edad de la sesión: {minutes}m",
+    "ctx.stats.unavailable": "estadísticas de context-mode no disponibles (error de la BD de sesión)",
+    "ctx.noActiveSession": "context-mode: no hay sesión activa",
+    "ctx.doctor.dbPath": "- Ruta de BD: `{path}`",
+    "ctx.doctor.dbExists": "- La BD existe: {exists}",
+    "ctx.doctor.sessionId": "- ID de sesión: `{session}`",
+    "ctx.doctor.events": "- Eventos: {count}",
+    "ctx.doctor.compactions": "- Compactaciones: {count}",
+    "ctx.doctor.resume": "- Instantánea de reanudación: {status}",
+    "ctx.doctor.dbError": "- Error de consulta de BD",
+  },
+  fr: {
+    "ctx.stats.title": "## statistiques context-mode (Pi)",
+    "ctx.stats.session": "- Session : `{session}...`",
+    "ctx.stats.events": "- Événements capturés : {count}",
+    "ctx.stats.compactions": "- Compactages : {count}",
+    "ctx.stats.breakdown": "- Répartition des événements :",
+    "ctx.stats.age": "- Âge de la session : {minutes}m",
+    "ctx.stats.unavailable": "statistiques context-mode indisponibles (erreur de BD de session)",
+    "ctx.noActiveSession": "context-mode : aucune session active",
+    "ctx.doctor.dbPath": "- Chemin BD : `{path}`",
+    "ctx.doctor.dbExists": "- BD présente : {exists}",
+    "ctx.doctor.sessionId": "- ID de session : `{session}`",
+    "ctx.doctor.events": "- Événements : {count}",
+    "ctx.doctor.compactions": "- Compactages : {count}",
+    "ctx.doctor.resume": "- Instantané de reprise : {status}",
+    "ctx.doctor.dbError": "- Erreur de requête BD",
+  },
+  "pt-BR": {
+    "ctx.stats.title": "## estatísticas do context-mode (Pi)",
+    "ctx.stats.session": "- Sessão: `{session}...`",
+    "ctx.stats.events": "- Eventos capturados: {count}",
+    "ctx.stats.compactions": "- Compactações: {count}",
+    "ctx.stats.breakdown": "- Detalhamento de eventos:",
+    "ctx.stats.age": "- Idade da sessão: {minutes}m",
+    "ctx.stats.unavailable": "estatísticas do context-mode indisponíveis (erro no BD da sessão)",
+    "ctx.noActiveSession": "context-mode: nenhuma sessão ativa",
+    "ctx.doctor.dbPath": "- Caminho do BD: `{path}`",
+    "ctx.doctor.dbExists": "- BD existe: {exists}",
+    "ctx.doctor.sessionId": "- ID da sessão: `{session}`",
+    "ctx.doctor.events": "- Eventos: {count}",
+    "ctx.doctor.compactions": "- Compactações: {count}",
+    "ctx.doctor.resume": "- Snapshot de retomada: {status}",
+    "ctx.doctor.dbError": "- Erro de consulta ao BD",
+  },
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: ExtensionAPI): void {
+  pi.events?.emit?.("pi-core/i18n/registerBundle", {
+    namespace: "context-mode",
+    defaultLocale: "en",
+    locales: translations,
+  });
+
+  pi.events?.emit?.("pi-core/i18n/requestApi", {
+    onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+      const next = api.getLocale?.();
+      if (isLocale(next)) currentLocale = next;
+      api.onLocaleChange?.((locale) => {
+        if (isLocale(locale)) currentLocale = locale;
+      });
+    },
+  });
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+  const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+  return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+  return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -21,6 +21,7 @@ import { extractEvents, extractUserEvents } from "./session/extract.js";
 import type { HookInput } from "./session/extract.js";
 import { buildResumeSnapshot } from "./session/snapshot.js";
 import type { SessionEvent } from "./types.js";
+import { initI18n, t } from "./i18n.js";
 
 // ── Pi Tool Name Mapping ─────────────────────────────────
 // Pi uses lowercase; shared extractors expect PascalCase (Claude Code convention).
@@ -94,11 +95,11 @@ function buildStatsText(db: SessionDB, sessionId: string): string {
     const events = db.getEvents(sessionId);
     const stats = db.getSessionStats(sessionId);
     const lines: string[] = [
-      "## context-mode stats (Pi)",
+      t("ctx.stats.title", "## context-mode stats (Pi)"),
       "",
-      `- Session: \`${sessionId.slice(0, 8)}...\``,
-      `- Events captured: ${events.length}`,
-      `- Compactions: ${stats?.compact_count ?? 0}`,
+      t("ctx.stats.session", "- Session: `{session}...`", { session: sessionId.slice(0, 8) }),
+      t("ctx.stats.events", "- Events captured: {count}", { count: events.length }),
+      t("ctx.stats.compactions", "- Compactions: {count}", { count: stats?.compact_count ?? 0 }),
     ];
 
     // Event breakdown by category
@@ -108,7 +109,7 @@ function buildStatsText(db: SessionDB, sessionId: string): string {
       byCategory[key] = (byCategory[key] ?? 0) + 1;
     }
     if (Object.keys(byCategory).length > 0) {
-      lines.push("- Event breakdown:");
+      lines.push(t("ctx.stats.breakdown", "- Event breakdown:"));
       for (const [category, count] of Object.entries(byCategory)) {
         lines.push(`  - ${category}: ${count}`);
       }
@@ -118,12 +119,12 @@ function buildStatsText(db: SessionDB, sessionId: string): string {
     if (stats?.started_at) {
       const startedMs = new Date(stats.started_at).getTime();
       const ageMinutes = Math.round((Date.now() - startedMs) / 60_000);
-      lines.push(`- Session age: ${ageMinutes}m`);
+      lines.push(t("ctx.stats.age", "- Session age: {minutes}m", { minutes: ageMinutes }));
     }
 
     return lines.join("\n");
   } catch {
-    return "context-mode stats unavailable (session DB error)";
+    return t("ctx.stats.unavailable", "context-mode stats unavailable (session DB error)");
   }
 }
 
@@ -149,6 +150,7 @@ function handleCommandText(
 
 /** Pi extension default export. Called once by Pi runtime with the extension API. */
 export default function piExtension(pi: any): void {
+  initI18n(pi);
   const buildDir = dirname(fileURLToPath(import.meta.url));
   const pluginRoot = resolve(buildDir, "..");
   const projectDir = process.env.PI_PROJECT_DIR || process.cwd();
@@ -365,7 +367,7 @@ export default function piExtension(pi: any): void {
       const ctx = resolveCommandContext(argsOrCtx, maybeCtx);
       const text =
         !_db || !_sessionId
-          ? "context-mode: no active session"
+          ? t("ctx.noActiveSession", "context-mode: no active session")
           : buildStatsText(_db, _sessionId);
 
       return handleCommandText(text, ctx);
@@ -381,9 +383,9 @@ export default function piExtension(pi: any): void {
       const lines: string[] = [
         "## ctx-doctor (Pi)",
         "",
-        `- DB path: \`${dbPath}\``,
-        `- DB exists: ${dbExists}`,
-        `- Session ID: \`${_sessionId ? _sessionId.slice(0, 8) + "..." : "none"}\``,
+        t("ctx.doctor.dbPath", "- DB path: `{path}`", { path: dbPath }),
+        t("ctx.doctor.dbExists", "- DB exists: {exists}", { exists: String(dbExists) }),
+        t("ctx.doctor.sessionId", "- Session ID: `{session}`", { session: _sessionId ? _sessionId.slice(0, 8) + "..." : "none" }),
         `- Plugin root: \`${pluginRoot}\``,
         `- Project dir: \`${projectDir}\``,
       ];
@@ -392,14 +394,14 @@ export default function piExtension(pi: any): void {
         try {
           const stats = _db.getSessionStats(_sessionId);
           const eventCount = _db.getEventCount(_sessionId);
-          lines.push(`- Events: ${eventCount}`);
-          lines.push(`- Compactions: ${stats?.compact_count ?? 0}`);
+          lines.push(t("ctx.doctor.events", "- Events: {count}", { count: eventCount }));
+          lines.push(t("ctx.doctor.compactions", "- Compactions: {count}", { count: stats?.compact_count ?? 0 }));
           const resume = _db.getResume(_sessionId);
           lines.push(
-            `- Resume snapshot: ${resume ? (resume.consumed ? "consumed" : "available") : "none"}`,
+            t("ctx.doctor.resume", "- Resume snapshot: {status}", { status: resume ? (resume.consumed ? "consumed" : "available") : "none" }),
           );
         } catch {
-          lines.push("- DB query error");
+          lines.push(t("ctx.doctor.dbError", "- DB query error"));
         }
       }
 

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "103k+",
+  "message": "106.1k+",
   "color": "brightgreen",
-  "npm": "85.1k+",
+  "npm": "88.3k+",
   "marketplace": "17.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "114.2k+",
+  "message": "114.6k+",
   "color": "brightgreen",
   "npm": "95.1k+",
-  "marketplace": "19k+"
+  "marketplace": "19.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "111.2k+",
+  "message": "111.8k+",
   "color": "brightgreen",
   "npm": "92.7k+",
-  "marketplace": "18.4k+"
+  "marketplace": "19k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "106.8k+",
+  "message": "111.2k+",
   "color": "brightgreen",
-  "npm": "88.3k+",
+  "npm": "92.7k+",
   "marketplace": "18.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "111.8k+",
+  "message": "114.2k+",
   "color": "brightgreen",
-  "npm": "92.7k+",
+  "npm": "95.1k+",
   "marketplace": "19k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "106.1k+",
+  "message": "106.8k+",
   "color": "brightgreen",
   "npm": "88.3k+",
-  "marketplace": "17.8k+"
+  "marketplace": "18.4k+"
 }

--- a/tests/adapters/claude-code.test.ts
+++ b/tests/adapters/claude-code.test.ts
@@ -555,9 +555,10 @@ describe("ClaudeCodeAdapter", () => {
       const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
       const sessionHooks = settings.hooks.SessionStart;
       expect(sessionHooks).toHaveLength(1);
-      // The fresh entry should point to the new pluginRoot (path may use \ on Windows)
+      // buildNodeCommand() normalizes all paths to forward slashes (#369, #372),
+      // so compare with forward-slash pluginRoot on Windows too.
       const command = sessionHooks[0].hooks[0].command;
-      expect(command).toContain(pluginRoot);
+      expect(command).toContain(pluginRoot.replace(/\\/g, "/"));
       expect(command).toContain("sessionstart.mjs");
     });
 


### PR DESCRIPTION
Reposting this as a much smaller follow-up after retracting the earlier over-broad PR.

The Pi `/ctx-stats` and `/ctx-doctor` commands are diagnostics surfaces: users read them when checking session capture, compaction, DB state, and resume state. I kept this PR limited to those Pi-only diagnostic labels instead of touching routing docs, CLI output, adapter copy, or broader status text.

What changed:
- added a tiny optional i18n bridge in `src/i18n.ts`
- registered `es`, `fr`, and `pt-BR` strings
- wrapped only Pi `/ctx-stats` and `/ctx-doctor` diagnostic labels/error states

What did not change:
- no required dependency
- no behavior change without a Pi i18n provider
- English fallback strings stay in the call sites
- no README, CLI, MCP server, hooks, or non-Pi adapter behavior changed
- easy to revert by deleting `src/i18n.ts` and the small wrappers in `src/pi-extension.ts`

Validation:
- targeted `tsc` for `src/pi-extension.ts` and `src/i18n.ts` passed after installing Pi types locally
- `npm run build` passed
- `npm test` ran; failures are from missing `better-sqlite3` native bindings on this Windows checkout, while non-SQLite tests continued to pass

If useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.
