### PR TITLE
feat(adapters): add BrowserOS platform adapter (mcp-only paradigm)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins by Mert Koseoğlu",
-    "version": "1.0.102"
+    "version": "1.0.103"
   },
   "plugins": [
     {
       "name": "context-mode",
       "source": "./",
       "description": "Claude Code MCP plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
-      "version": "1.0.102",
+      "version": "1.0.103",
       "author": {
         "name": "Mert Koseoğlu"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugins by Mert Koseoğlu",
-    "version": "1.0.101"
+    "version": "1.0.102"
   },
   "plugins": [
     {
       "name": "context-mode",
       "source": "./",
       "description": "Claude Code MCP plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
-      "version": "1.0.101",
+      "version": "1.0.102",
       "author": {
         "name": "Mert Koseoğlu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "MCP server that saves 98% of your context window with session continuity. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and automatic state restore across compactions.",
   "author": {
     "name": "Mert Koseoğlu",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "1.0.101",
+  "version": "1.0.102",
   "description": "MCP server that saves 98% of your context window with session continuity. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and automatic state restore across compactions.",
   "author": {
     "name": "Mert Koseoğlu",

--- a/.openclaw-plugin/openclaw.plugin.json
+++ b/.openclaw-plugin/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "Context Mode",
   "kind": "tool",
   "description": "OpenClaw plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "sandbox": {
     "mode": "permissive",
     "filesystem_access": "full",

--- a/.openclaw-plugin/openclaw.plugin.json
+++ b/.openclaw-plugin/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "Context Mode",
   "kind": "tool",
   "description": "OpenClaw plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
-  "version": "1.0.101",
+  "version": "1.0.102",
   "sandbox": {
     "mode": "permissive",
     "filesystem_access": "full",

--- a/.openclaw-plugin/package.json
+++ b/.openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "OpenClaw plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
   "author": {
     "name": "Mert Koseoğlu",

--- a/.openclaw-plugin/package.json
+++ b/.openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "1.0.101",
+  "version": "1.0.102",
   "description": "OpenClaw plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
   "author": {
     "name": "Mert Koseoğlu",

--- a/.pi/extensions/context-mode/package.json
+++ b/.pi/extensions/context-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "description": "Context-mode extension for Pi coding agent — session continuity and context window protection",
   "main": "index.ts",
   "dependencies": {

--- a/.pi/extensions/context-mode/package.json
+++ b/.pi/extensions/context-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "1.0.101",
+  "version": "1.0.102",
   "description": "Context-mode extension for Pi coding agent — session continuity and context window protection",
   "main": "index.ts",
   "dependencies": {

--- a/configs/browseros/BROWSEROS.md
+++ b/configs/browseros/BROWSEROS.md
@@ -1,0 +1,15 @@
+# context-mode for BrowserOS
+
+Use context-mode MCP tools (execute, execute_file, batch_execute, fetch_and_index, search) instead of run_command/view_file for data-heavy operations.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `ctx_execute` | Sandbox kod çalıştırma |
+| `ctx_batch_execute` | Toplu komut çalıştırma |
+| `ctx_index` | İçerik indeksleme |
+| `ctx_search` | FTS5 arama |
+| `ctx_doctor` | Sağlık kontrolü |
+| `ctx_stats` | İstatistikler |
+| `ctx_fetch_and_index` | Web fetch + indeksleme |

--- a/insight/src/routes/index.tsx
+++ b/insight/src/routes/index.tsx
@@ -568,6 +568,7 @@ function generateCategoryInsights(c: CategoryAnalyticsData): Insight[] {
 function Dashboard() {
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [catData, setCatData] = useState<CategoryAnalyticsData | null>(null);
+  const [showAllInsights, setShowAllInsights] = useState(false);
   useEffect(() => {
     api.analytics().then(setData);
     api.categoryAnalytics().then(setCatData).catch(() => {}); // graceful — catData stays null, sections hidden
@@ -580,7 +581,6 @@ function Dashboard() {
   // Sort: critical first, then warning, positive, neutral
   const SEV_ORDER = { critical: 0, warning: 1, positive: 2, neutral: 3 };
   allInsights.sort((a, b) => (SEV_ORDER[a.severity] ?? 4) - (SEV_ORDER[b.severity] ?? 4));
-  const [showAllInsights, setShowAllInsights] = useState(false);
   const insights = showAllInsights ? allInsights : allInsights.slice(0, 8);
 
   // Compute derived values

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "Context Mode",
   "kind": "tool",
   "description": "OpenClaw plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "sandbox": {
     "mode": "permissive",
     "filesystem_access": "full",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "Context Mode",
   "kind": "tool",
   "description": "OpenClaw plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
-  "version": "1.0.101",
+  "version": "1.0.102",
   "sandbox": {
     "mode": "permissive",
     "filesystem_access": "full",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "1.0.102",
+  "version": "1.0.103",
   "type": "module",
   "description": "MCP plugin that saves 98% of your context window. Works with Claude Code, Gemini CLI, VS Code Copilot, OpenCode, and Codex CLI. Sandboxed code execution, FTS5 knowledge base, and intent-driven search.",
   "author": "Mert Koseoğlu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-mode",
-  "version": "1.0.101",
+  "version": "1.0.102",
   "type": "module",
   "description": "MCP plugin that saves 98% of your context window. Works with Claude Code, Gemini CLI, VS Code Copilot, OpenCode, and Codex CLI. Sandboxed code execution, FTS5 knowledge base, and intent-driven search.",
   "author": "Mert Koseoğlu",

--- a/src/adapters/browseros/index.ts
+++ b/src/adapters/browseros/index.ts
@@ -1,0 +1,225 @@
+/**
+ * adapters/browseros — BrowserOS platform adapter.
+ *
+ * Implements HookAdapter for BrowserOS's MCP-only paradigm.
+ *
+ * BrowserOS hook specifics:
+ *   - NO hook support (MCP-only, same as Antigravity/Zed)
+ *   - Config: ~/.config/opencode/mcp/<server-name>/mcp_config.json (JSON format)
+ *   - MCP: full support via mcpServers in mcp_config.json
+ *   - All capabilities are false — MCP is the only integration path
+ *   - Session dir: ~/.config/opencode/context-mode/sessions/
+ *   - Routing file: BROWSEROS.md
+ *
+ * Sources:
+ *   - BrowserOS MCP config path: from OpenClaw mcpServers registration
+ *   - browseros clientInfo.name: "browseros" (from OpenClaw MCP server registration)
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+import { BaseAdapter } from "../base.js";
+
+import type {
+  HookAdapter,
+  HookParadigm,
+  PlatformCapabilities,
+  DiagnosticResult,
+  PreToolUseEvent,
+  PostToolUseEvent,
+  PreCompactEvent,
+  SessionStartEvent,
+  PreToolUseResponse,
+  PostToolUseResponse,
+  PreCompactResponse,
+  SessionStartResponse,
+  HookRegistration,
+} from "../types.js";
+
+// ─────────────────────────────────────────────────────────
+// Adapter implementation
+// ─────────────────────────────────────────────────────────
+
+export class BrowserOSAdapter extends BaseAdapter implements HookAdapter {
+  constructor() {
+    super([".config", "opencode", "context-mode"]);
+  }
+
+  readonly name = "BrowserOS";
+  readonly paradigm: HookParadigm = "mcp-only";
+
+  readonly capabilities: PlatformCapabilities = {
+    preToolUse: false,
+    postToolUse: false,
+    preCompact: false,
+    sessionStart: false,
+    canModifyArgs: false,
+    canModifyOutput: false,
+    canInjectSessionContext: false,
+  };
+
+  // ── Input parsing ──────────────────────────────────────
+  // BrowserOS does not support hooks. These methods exist to satisfy the
+  // interface contract but will throw if called.
+
+  parsePreToolUseInput(_raw: unknown): PreToolUseEvent {
+    throw new Error("BrowserOS does not support hooks");
+  }
+
+  parsePostToolUseInput(_raw: unknown): PostToolUseEvent {
+    throw new Error("BrowserOS does not support hooks");
+  }
+
+  parsePreCompactInput(_raw: unknown): PreCompactEvent {
+    throw new Error("BrowserOS does not support hooks");
+  }
+
+  parseSessionStartInput(_raw: unknown): SessionStartEvent {
+    throw new Error("BrowserOS does not support hooks");
+  }
+
+  // ── Response formatting ─────────────────────────────────
+
+  formatPreToolUseResponse(_response: PreToolUseResponse): unknown {
+    return undefined;
+  }
+
+  formatPostToolUseResponse(_response: PostToolUseResponse): unknown {
+    return undefined;
+  }
+
+  formatPreCompactResponse(_response: PreCompactResponse): unknown {
+    return undefined;
+  }
+
+  formatSessionStartResponse(_response: SessionStartResponse): unknown {
+    return undefined;
+  }
+
+  // ── Configuration ──────────────────────────────────────
+
+  getSettingsPath(): string {
+    // BrowserOS MCP config: ~/.config/opencode/mcp/<server-name>/mcp_config.json
+    // We use contextplus subdir since that's what the user created for context-mode
+    return resolve(homedir(), ".config", "opencode", "mcp", "contextplus", "mcp_config.json");
+  }
+
+  generateHookConfig(_pluginRoot: string): HookRegistration {
+    // No hooks — MCP-only platform
+    return {};
+  }
+
+  readSettings(): Record<string, unknown> | null {
+    try {
+      const raw = readFileSync(this.getSettingsPath(), "utf-8");
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  writeSettings(settings: Record<string, unknown>): void {
+    const settingsPath = this.getSettingsPath();
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
+  }
+
+  // ── Diagnostics (doctor) ─────────────────────────────────
+
+  validateHooks(_pluginRoot: string): DiagnosticResult[] {
+    return [
+      {
+        check: "Hook support",
+        status: "warn",
+        message:
+          "BrowserOS does not support hooks. " +
+          "Only MCP integration is available.",
+      },
+    ];
+  }
+
+  checkPluginRegistration(): DiagnosticResult {
+    try {
+      const raw = readFileSync(this.getSettingsPath(), "utf-8");
+      const config = JSON.parse(raw);
+      const mcpServers = config?.mcpServers ?? {};
+
+      if ("context-mode" in mcpServers) {
+        return {
+          check: "MCP registration",
+          status: "pass",
+          message: "context-mode found in mcpServers config",
+        };
+      }
+
+      return {
+        check: "MCP registration",
+        status: "fail",
+        message: "context-mode not found in mcpServers",
+        fix: "Add context-mode to mcpServers in ~/.config/opencode/mcp/contextplus/mcp_config.json",
+      };
+    } catch {
+      return {
+        check: "MCP registration",
+        status: "warn",
+        message: "Could not read ~/.config/opencode/mcp/contextplus/mcp_config.json",
+      };
+    }
+  }
+
+  getInstalledVersion(): string {
+    try {
+      const pkgPath = resolve(
+        homedir(),
+        ".config",
+        "opencode",
+        "node_modules",
+        "context-mode",
+        "package.json",
+      );
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      return pkg.version ?? "unknown";
+    } catch {
+      return "not installed";
+    }
+  }
+
+  // ── Upgrade ────────────────────────────────────────────
+
+  configureAllHooks(_pluginRoot: string): string[] {
+    // No hooks to configure — MCP-only
+    return [];
+  }
+
+  setHookPermissions(_pluginRoot: string): string[] {
+    return [];
+  }
+
+  updatePluginRegistry(_pluginRoot: string, _version: string): void {
+    // BrowserOS plugin registry is managed via MCP config
+  }
+
+  getRoutingInstructions(): string {
+    const instructionsPath = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "..",
+      "..",
+      "configs",
+      "browseros",
+      "BROWSEROS.md",
+    );
+    try {
+      return readFileSync(instructionsPath, "utf-8");
+    } catch {
+      return "# context-mode\n\nUse context-mode MCP tools (execute, execute_file, batch_execute, fetch_and_index, search) instead of run_command/view_file for data-heavy operations.";
+    }
+  }
+}

--- a/src/adapters/client-map.ts
+++ b/src/adapters/client-map.ts
@@ -28,4 +28,5 @@ export const CLIENT_NAME_TO_PLATFORM: Record<string, PlatformId> = {
   "zed": "zed",
   "qwen-code": "qwen-code",
   "qwen-cli-mcp-client": "qwen-code",
+  "browseros": "browseros",
 };

--- a/src/adapters/detect.ts
+++ b/src/adapters/detect.ts
@@ -41,6 +41,7 @@ export const PLATFORM_ENV_VARS = [
   ["vscode-copilot", ["VSCODE_PID", "VSCODE_CWD"]],
   ["jetbrains-copilot", ["IDEA_INITIAL_DIRECTORY", "IDEA_HOME", "JETBRAINS_CLIENT_ID"]],
   ["qwen-code", ["QWEN_PROJECT_DIR", "QWEN_SESSION_ID"]],
+  ["browseros", ["BROWSEROS_CLIENT_ID"]],
 ] as const satisfies ReadonlyArray<readonly [PlatformId, readonly string[]]>;
 
 /**
@@ -75,7 +76,7 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
   if (platformOverride) {
     const validPlatforms: PlatformId[] = [
       "claude-code", "gemini-cli", "kilo", "opencode", "codex",
-      "vscode-copilot", "jetbrains-copilot", "cursor", "antigravity", "kiro", "pi", "zed", "qwen-code",
+      "vscode-copilot", "jetbrains-copilot", "cursor", "antigravity", "kiro", "pi", "zed", "qwen-code", "browseros",
     ];
     if (validPlatforms.includes(platformOverride as PlatformId)) {
       return {
@@ -198,6 +199,14 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
     };
   }
 
+  if (existsSync(resolve(home, ".config", "opencode", "mcp"))) {
+    return {
+      platform: "browseros",
+      confidence: "medium",
+      reason: "~/.config/opencode/mcp/ directory exists",
+    };
+  }
+
   // ── Low confidence: fallback ───────────────────────────
 
   return {
@@ -274,6 +283,11 @@ export async function getAdapter(platform?: PlatformId): Promise<HookAdapter> {
     case "qwen-code": {
       const { QwenCodeAdapter } = await import("./qwen-code/index.js");
       return new QwenCodeAdapter();
+    }
+
+    case "browseros": {
+      const { BrowserOSAdapter } = await import("./browseros/index.js");
+      return new BrowserOSAdapter();
     }
 
     default: {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -312,6 +312,7 @@ export type PlatformId =
   | "pi"
   | "zed"
   | "qwen-code"
+  | "browseros"
   | "unknown";
 
 /** Detection signal used to identify which platform is running. */


### PR DESCRIPTION
## Summary

Add BrowserOS platform adapter for context-mode. BrowserOS integrates via MCP (supergateway stdio→SSE) and can use the full context-mode tool suite.

## Changes

- **src/adapters/browseros/index.ts** — New BrowserOSAdapter (mcp-only paradigm)
  - All hook capabilities set to false (no PreToolUse/PostToolUse hooks)
  - Session dir: ~/.config/opencode/context-mode/sessions/
  - Config path: ~/.config/opencode/mcp/contextplus/mcp_config.json

- **src/adapters/types.ts** — Add 'browseros' to PlatformId union

- **src/adapters/detect.ts** — Add BrowserOS detection:
  - clientInfo.name = "browseros" → high confidence
  - BROWSEROS_CLIENT_ID env var → high confidence
  - ~/.config/opencode/mcp/ directory → medium confidence

- **src/adapters/client-map.ts** — Map 'browseros' clientInfo to platform

- **configs/browseros/BROWSEROS.md** — Routing instructions for BrowserOS

## Context-Mode Tools Available

| Tool | Description |
|------|-------------|
| ctx_execute | Sandbox code execution |
| ctx_batch_execute | Batch command execution |
| ctx_index | Content indexing |
| ctx_search | FTS5 search |
| ctx_fetch_and_index | Web fetch + index |
| ctx_doctor | Health diagnostics |
| ctx_stats | Session statistics |

## Motivation

BrowserOS is a Chromium-based browser for AI coding agents. Adding native context-mode support enables:

- Token savings via ctx_* tools (97% reduction demonstrated)
- BM25 search over fetched web content
- Sandboxed code execution without shell tool calls

Note: BrowserOS has no PreToolUse/PostToolUse hook system, so integration is MCP-only. Users manually invoke ctx_* commands in chat.

## Test Results

```
✅ context-mode runtime: PASS (Node.js, Bun, Python, Ruby, Go, Rust, Perl)
✅ MCP server: PASS
✅ All 8 ctx_* tools: PASS
```