### PR TITLE
fix(npm): include ctx-debug.sh in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     ".mcp.json",
     "openclaw.plugin.json",
     "start.mjs",
+    "scripts/ctx-debug.sh",
     "scripts/postinstall.mjs",
     "README.md",
     "LICENSE"

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "103k+",
+  "message": "106.1k+",
   "color": "brightgreen",
-  "npm": "85.1k+",
+  "npm": "88.3k+",
   "marketplace": "17.8k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "114.6k+",
+  "message": "116.5k+",
   "color": "brightgreen",
-  "npm": "95.1k+",
+  "npm": "97k+",
   "marketplace": "19.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "114.2k+",
+  "message": "114.6k+",
   "color": "brightgreen",
   "npm": "95.1k+",
-  "marketplace": "19k+"
+  "marketplace": "19.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "111.2k+",
+  "message": "111.8k+",
   "color": "brightgreen",
   "npm": "92.7k+",
-  "marketplace": "18.4k+"
+  "marketplace": "19k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "106.8k+",
+  "message": "111.2k+",
   "color": "brightgreen",
-  "npm": "88.3k+",
+  "npm": "92.7k+",
   "marketplace": "18.4k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "111.8k+",
+  "message": "114.2k+",
   "color": "brightgreen",
-  "npm": "92.7k+",
+  "npm": "95.1k+",
   "marketplace": "19k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "106.1k+",
+  "message": "106.8k+",
   "color": "brightgreen",
   "npm": "88.3k+",
-  "marketplace": "17.8k+"
+  "marketplace": "18.4k+"
 }

--- a/tests/adapters/claude-code.test.ts
+++ b/tests/adapters/claude-code.test.ts
@@ -555,9 +555,10 @@ describe("ClaudeCodeAdapter", () => {
       const settings = JSON.parse(readFileSync(join(tempDir, "settings.json"), "utf-8"));
       const sessionHooks = settings.hooks.SessionStart;
       expect(sessionHooks).toHaveLength(1);
-      // The fresh entry should point to the new pluginRoot (path may use \ on Windows)
+      // buildNodeCommand() normalizes all paths to forward slashes (#369, #372),
+      // so compare with forward-slash pluginRoot on Windows too.
       const command = sessionHooks[0].hooks[0].command;
-      expect(command).toContain(pluginRoot);
+      expect(command).toContain(pluginRoot.replace(/\\/g, "/"));
       expect(command).toContain("sessionstart.mjs");
     });
 

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -718,6 +718,9 @@ describe("Cross-OS compatibility", () => {
   });
 
   it("published package includes the documented debug script", () => {
+    for (const doc of ["README.md", "CONTRIBUTING.md"]) {
+      expect(readFileSync(resolve(ROOT, doc), "utf-8")).toContain("scripts/ctx-debug.sh");
+    }
     expect(existsSync(resolve(ROOT, "scripts", "ctx-debug.sh"))).toBe(true);
     expect(pkg.files).toContain("scripts/ctx-debug.sh");
   });

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -717,6 +717,11 @@ describe("Cross-OS compatibility", () => {
     expect(pkg.files).toContain("scripts/postinstall.mjs");
   });
 
+  it("published package includes the documented debug script", () => {
+    expect(existsSync(resolve(ROOT, "scripts", "ctx-debug.sh"))).toBe(true);
+    expect(pkg.files).toContain("scripts/ctx-debug.sh");
+  });
+
   it("install:openclaw gracefully handles missing bash on Windows", () => {
     // Direct 'bash' invocation fails on Windows without Git Bash
     expect(pkg.scripts["install:openclaw"]).not.toMatch(/^bash /);


### PR DESCRIPTION
Fixes #394.

## Summary
- add the documented diagnostic script to the npm `files` whitelist
- add a regression test covering both `README.md` and `CONTRIBUTING.md` references to `scripts/ctx-debug.sh`
- keep the published script set minimal: only `scripts/ctx-debug.sh` plus the existing `scripts/postinstall.mjs`

## Pack proof
Before:
```text
npm notice 6.4kB scripts/postinstall.mjs
```

After:
```text
npm notice 43.4kB scripts/ctx-debug.sh
```

Real tarball check:
```text
package/scripts/ctx-debug.sh
```

## Regression test
Red check without the whitelist entry:
```text
FAIL  tests/core/cli.test.ts > Cross-OS compatibility > published package includes the documented debug script
AssertionError: expected [...] to include 'scripts/ctx-debug.sh'
```

Green check with the fix restored:
```text
npx vitest run tests/core/cli.test.ts -t "published package includes the documented debug script"
Test Files  1 passed (1)
Tests  1 passed | 104 skipped (105)
```

The test also asserts that `README.md` and `CONTRIBUTING.md` still document `scripts/ctx-debug.sh`, so a documented diagnostic path cannot drift out of the published package list unnoticed.

## Tests
```text
npm test
Test Files  54 passed (54)
Tests  1907 passed | 15 skipped (1922)
```

Note: this fresh worktree needed `npm install --no-package-lock`, `npm run build`, and a minimal stable Rust toolchain before the full test suite could run.