### PR TITLE
fix(sessionstart): filter resume events by session id (cross-session bleed)

### DIFF
--- a/hooks/codex/sessionstart.mjs
+++ b/hooks/codex/sessionstart.mjs
@@ -14,7 +14,6 @@ import {
   writeSessionEventsFile,
   buildSessionDirective,
   getSessionEvents,
-  getLatestSessionEvents,
 } from "../session-directive.mjs";
 import {
   readStdin,
@@ -57,9 +56,13 @@ try {
       try { unlinkSync(getCleanupFlagPath(OPTS)); } catch { /* no flag */ }
     }
 
-    const events = source === "compact"
-      ? getSessionEvents(db, getSessionId(input, OPTS))
-      : getLatestSessionEvents(db);
+    // Filter events to the session being resumed/compacted. Falling back to
+    // getLatestSessionEvents(db) for resume leaks events from any other
+    // session whose session_meta.started_at is more recent — observed
+    // cross-session bleed when a different session started after this one
+    // and before the resume.
+    const sessionId = getSessionId(input, OPTS);
+    const events = sessionId ? getSessionEvents(db, sessionId) : [];
     if (events.length > 0) {
       const eventMeta = writeSessionEventsFile(events, getSessionEventsPath(OPTS));
       additionalContext += buildSessionDirective(source, eventMeta, toolNamer);

--- a/hooks/cursor/sessionstart.mjs
+++ b/hooks/cursor/sessionstart.mjs
@@ -14,7 +14,6 @@ import {
   writeSessionEventsFile,
   buildSessionDirective,
   getSessionEvents,
-  getLatestSessionEvents,
 } from "../session-directive.mjs";
 import {
   readStdin,
@@ -61,9 +60,13 @@ try {
       try { unlinkSync(getCleanupFlagPath(OPTS)); } catch { /* no flag */ }
     }
 
-    const events = source === "compact"
-      ? getSessionEvents(db, getSessionId(input, OPTS))
-      : getLatestSessionEvents(db);
+    // Filter events to the session being resumed/compacted. Falling back to
+    // getLatestSessionEvents(db) for resume leaks events from any other
+    // session whose session_meta.started_at is more recent — observed
+    // cross-session bleed when a different session started after this one
+    // and before the resume.
+    const sessionId = getSessionId(input, OPTS);
+    const events = sessionId ? getSessionEvents(db, sessionId) : [];
     if (events.length > 0) {
       const eventMeta = writeSessionEventsFile(events, getSessionEventsPath(OPTS));
       additionalContext += buildSessionDirective(source, eventMeta, toolNamer);

--- a/hooks/gemini-cli/sessionstart.mjs
+++ b/hooks/gemini-cli/sessionstart.mjs
@@ -16,7 +16,7 @@ import { createToolNamer } from "../core/tool-naming.mjs";
 
 const toolNamer = createToolNamer("gemini-cli");
 const ROUTING_BLOCK = createRoutingBlock(toolNamer);
-import { writeSessionEventsFile, buildSessionDirective, getSessionEvents, getLatestSessionEvents } from "../session-directive.mjs";
+import { writeSessionEventsFile, buildSessionDirective, getSessionEvents } from "../session-directive.mjs";
 import {
   readStdin, parseStdin, getSessionId, getSessionDBPath, getSessionEventsPath, getCleanupFlagPath,
   getProjectDir, GEMINI_OPTS,
@@ -63,7 +63,12 @@ try {
     const dbPath = getSessionDBPath(OPTS);
     const db = new SessionDB({ dbPath });
 
-    const events = getLatestSessionEvents(db);
+    // Filter events to the session being resumed. Falling back to
+    // getLatestSessionEvents(db) leaks events from any other session whose
+    // session_meta.started_at is more recent — observed cross-session bleed
+    // when a different session started after this one and before the resume.
+    const sessionId = getSessionId(input, OPTS);
+    const events = sessionId ? getSessionEvents(db, sessionId) : [];
     if (events.length > 0) {
       const eventMeta = writeSessionEventsFile(events, getSessionEventsPath(OPTS));
       additionalContext += buildSessionDirective("resume", eventMeta, toolNamer);

--- a/hooks/jetbrains-copilot/sessionstart.mjs
+++ b/hooks/jetbrains-copilot/sessionstart.mjs
@@ -17,7 +17,7 @@ import { createToolNamer } from "../core/tool-naming.mjs";
 
 const toolNamer = createToolNamer("jetbrains-copilot");
 const ROUTING_BLOCK = createRoutingBlock(toolNamer);
-import { writeSessionEventsFile, buildSessionDirective, getSessionEvents, getLatestSessionEvents } from "../session-directive.mjs";
+import { writeSessionEventsFile, buildSessionDirective, getSessionEvents } from "../session-directive.mjs";
 import {
   readStdin, parseStdin, getSessionId, getSessionDBPath, getSessionEventsPath, getCleanupFlagPath,
   getProjectDir, JETBRAINS_OPTS,
@@ -63,7 +63,12 @@ try {
     const dbPath = getSessionDBPath(OPTS);
     const db = new SessionDB({ dbPath });
 
-    const events = getLatestSessionEvents(db);
+    // Filter events to the session being resumed. Falling back to
+    // getLatestSessionEvents(db) leaks events from any other session whose
+    // session_meta.started_at is more recent — observed cross-session bleed
+    // when a different session started after this one and before the resume.
+    const sessionId = getSessionId(input, OPTS);
+    const events = sessionId ? getSessionEvents(db, sessionId) : [];
     if (events.length > 0) {
       const eventMeta = writeSessionEventsFile(events, getSessionEventsPath(OPTS));
       additionalContext += buildSessionDirective("resume", eventMeta, toolNamer);

--- a/hooks/sessionstart.mjs
+++ b/hooks/sessionstart.mjs
@@ -22,7 +22,7 @@ import { buildAutoInjection } from "./auto-injection.mjs";
 const toolNamer = createToolNamer("claude-code");
 const ROUTING_BLOCK = createRoutingBlock(toolNamer);
 import { readStdin, parseStdin, getSessionId, getSessionDBPath, getSessionEventsPath, getCleanupFlagPath, resolveConfigDir } from "./session-helpers.mjs";
-import { writeSessionEventsFile, buildSessionDirective, getSessionEvents, getLatestSessionEvents } from "./session-directive.mjs";
+import { writeSessionEventsFile, buildSessionDirective, getSessionEvents } from "./session-directive.mjs";
 import { createSessionLoaders } from "./session-loaders.mjs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -82,7 +82,13 @@ try {
     const dbPath = getSessionDBPath();
     const db = new SessionDB({ dbPath });
 
-    const events = getLatestSessionEvents(db);
+    // Filter events to the session being resumed. Falling back to
+    // getLatestSessionEvents(db) leaks events from any other session whose
+    // session_meta.started_at is more recent — observed cross-session bleed
+    // when a different worktree session started after this one and before
+    // the resume.
+    const sessionId = getSessionId(input);
+    const events = sessionId ? getSessionEvents(db, sessionId) : [];
     if (events.length > 0) {
       const eventMeta = writeSessionEventsFile(events, getSessionEventsPath());
       additionalContext += buildSessionDirective("resume", eventMeta, toolNamer);

--- a/hooks/vscode-copilot/sessionstart.mjs
+++ b/hooks/vscode-copilot/sessionstart.mjs
@@ -17,7 +17,7 @@ import { createToolNamer } from "../core/tool-naming.mjs";
 
 const toolNamer = createToolNamer("vscode-copilot");
 const ROUTING_BLOCK = createRoutingBlock(toolNamer);
-import { writeSessionEventsFile, buildSessionDirective, getSessionEvents, getLatestSessionEvents } from "../session-directive.mjs";
+import { writeSessionEventsFile, buildSessionDirective, getSessionEvents } from "../session-directive.mjs";
 import {
   readStdin, parseStdin, getSessionId, getSessionDBPath, getSessionEventsPath, getCleanupFlagPath,
   getProjectDir, VSCODE_OPTS,
@@ -63,7 +63,12 @@ try {
     const dbPath = getSessionDBPath(OPTS);
     const db = new SessionDB({ dbPath });
 
-    const events = getLatestSessionEvents(db);
+    // Filter events to the session being resumed. Falling back to
+    // getLatestSessionEvents(db) leaks events from any other session whose
+    // session_meta.started_at is more recent — observed cross-session bleed
+    // when a different session started after this one and before the resume.
+    const sessionId = getSessionId(input, OPTS);
+    const events = sessionId ? getSessionEvents(db, sessionId) : [];
     if (events.length > 0) {
       const eventMeta = writeSessionEventsFile(events, getSessionEventsPath(OPTS));
       additionalContext += buildSessionDirective("resume", eventMeta, toolNamer);


### PR DESCRIPTION
## Bug — cross-session bleed during resume

The `resume` branch of every `SessionStart` adapter calls
`getLatestSessionEvents(db)`, which is implemented as:

```js
SELECT m.session_id FROM session_meta m
JOIN session_events e ON m.session_id = e.session_id
GROUP BY m.session_id
ORDER BY m.started_at DESC LIMIT 1
```

— "events from whichever session in the database has the most recent
`session_meta.started_at`", **regardless of which session is actually
being resumed**.

When another session (e.g., a worktree session, a parallel repo, a
different IDE) starts after the one being resumed but before the
resume fires, that other session's events get injected into the
`<session_knowledge>` / `additional_context` block of the resumed
session — wrong cwd, wrong file list, wrong unresolved errors, wrong
intent. Reproduces reliably whenever the user runs more than one
context-mode-enabled session in overlapping time windows.

The `compact` branch already does the right thing:
`getSessionEvents(db, sessionId)` filters by the resuming session's
id. The `resume` branch just needed to mirror that.

## Fix

Read the resuming session's id from the hook input
(`getSessionId(input[, OPTS])`, already used in the same files for
the compact and startup branches) and pass it to
`getSessionEvents(db, sessionId)`. If no session id is available,
return `[]` rather than fall back to the global-most-recent session.

Applied uniformly to all six adapters that had the buggy pattern:

- `hooks/sessionstart.mjs`            (claude-code)
- `hooks/codex/sessionstart.mjs`      (codex CLI)
- `hooks/cursor/sessionstart.mjs`     (cursor)
- `hooks/gemini-cli/sessionstart.mjs` (gemini CLI)
- `hooks/jetbrains-copilot/sessionstart.mjs`
- `hooks/vscode-copilot/sessionstart.mjs`

The kiro adapter does not have a `sessionstart.mjs`, so no change
there. The `getLatestSessionEvents` export in
`hooks/session-directive.mjs` is left intact — it's part of the
exported surface and removing it would be a separate breaking-change
concern for you to decide on.

## Reproduction

1. Start session A in repo X (`claude` from repo X).
2. While session A is running or paused, start session B in repo Y
   (or a worktree of repo X) — this writes a row to `session_meta`
   with a `started_at` greater than A's.
3. End session A (`/exit` or close terminal).
4. Resume session A (`claude --continue`).
5. Observe the `<session_knowledge>` block in the SessionStart
   `additionalContext`: it shows session B's `cwd`, file list,
   errors, and intent — none of which belong to A.

After the fix: A's resume contains only A's events (or nothing if A
had no indexed events).

## Risk

Low. The fix narrows query scope; it cannot inject *more* data than
before, only equal-or-less. The fall-through `[]` returns no events
in the previously-broken global-recent fallback case — that's the
correct behavior since "what session is being resumed" is the
question, and an empty answer is more useful than a wrong one.

## Test

I tested the claude-code adapter manually:

1. Patched the cached install
2. Started session A, indexed some events
3. Started session B in a different worktree (more recent
   `started_at`)
4. Exited A, resumed A
5. Verified `<session_knowledge>` no longer contains session B's
   data

If you have automated SessionStart-hook tests
(`tests/session-hooks-smoke.test.ts` looks adjacent), I'd be happy to
add a regression case showing two sessions with overlapping
`started_at` and asserting the resumed session sees only its own
events.

## Notes

- Plain string-replacement in idempotent style — easy to revert.
- All 6 files pass `node --check`.
- Diff: 6 files changed, 43 insertions(+), 16 deletions(-).
