### PR TITLE
fix(stats): persist dollars_saved_lifetime for statusline

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -398,11 +398,17 @@ const STATS_PERSIST_THROTTLE_MS = 500;
 // Bump when a field is added/renamed/removed. Statusline reads `schemaVersion ?? 0` and warns when
 // it sees a future schema, so legacy bundles degrade gracefully on upgrade rather than silently
 // rendering missing fields (PR #401 architect review P1.3).
-const STATS_SCHEMA_VERSION = 1;
+// v2: added tokens_saved_lifetime + dollars_saved_lifetime.
+const STATS_SCHEMA_VERSION = 2;
 // OPUS_INPUT_PRICE_PER_TOKEN intentionally NOT defined here — single source in
 // src/session/analytics.ts re-exported above. (P1.1 — pricing constant dedup,
 // PR #401 architect + ops 2-vote convergence.)
+const LIFETIME_REFRESH_MS = 30_000;
+// Matches the conversion factor in src/session/analytics.ts renderBottomLine:
+// ~1KB per session event ÷ 4 bytes/token = 256 tokens/event.
+const TOKENS_PER_EVENT = 256;
 let _lastStatsPersist = 0;
+let _lifetimeCache: { tokens: number; computedAt: number } | undefined;
 
 /**
  * Resolve the per-session stats file path.
@@ -441,12 +447,20 @@ function persistStats(): void {
         : 0;
     const tokensSaved = Math.round(keptOut / 4);
 
-    // Lifetime $ across sessions intentionally omitted from this payload.
-    // The b392c2f concurrency refactor removed analytics.getLifetimeStats(),
-    // so there is no longer a single source of truth for cumulative event
-    // totals. Statusline conditionally renders the lifetime block only when
-    // dollars_saved_lifetime > 0; absence degrades gracefully to a session-
-    // only render. Re-add when an analytics aggregator returns to next.
+    // Lifetime savings — cached separately because getLifetimeStats() scans
+    // disk (per-project SessionDBs + auto-memory dirs) and is too expensive
+    // for the 500ms persist throttle. Refresh every 30s; the statusline
+    // doesn't need second-by-second lifetime accuracy.
+    let lifetimeTokens = _lifetimeCache?.tokens ?? 0;
+    if (!_lifetimeCache || now - _lifetimeCache.computedAt > LIFETIME_REFRESH_MS) {
+      try {
+        const life = getLifetimeStats({ sessionsDir: getSessionDir() });
+        lifetimeTokens = (life?.totalEvents ?? 0) * TOKENS_PER_EVENT;
+        _lifetimeCache = { tokens: lifetimeTokens, computedAt: now };
+      } catch {
+        // best-effort — keep stale cache or 0
+      }
+    }
 
     const payload = {
       schemaVersion: STATS_SCHEMA_VERSION,
@@ -464,10 +478,12 @@ function persistStats(): void {
       total_processed: totalProcessed,
       reduction_pct: reductionPct,
       tokens_saved: tokensSaved,
-      // statusline-facing $ value — pre-computed at Opus input rate so the
+      // statusline-facing $ values — pre-computed at Opus input rate so the
       // statusline doesn't have to know pricing. Lets us evolve pricing in
       // one place without touching consumers.
       dollars_saved_session: +(tokensSaved * OPUS_INPUT_PRICE_PER_TOKEN).toFixed(2),
+      tokens_saved_lifetime: lifetimeTokens,
+      dollars_saved_lifetime: +(lifetimeTokens * OPUS_INPUT_PRICE_PER_TOKEN).toFixed(2),
       by_tool: Object.fromEntries(
         Object.keys({ ...sessionStats.calls, ...sessionStats.bytesReturned }).map(
           (t) => [


### PR DESCRIPTION
## What / Why

`bin/statusline.mjs` reads `stats.dollars_saved_lifetime` and conditionally renders the *\"X saved across sessions\"* block when > 0. After the b392c2f concurrency refactor + e638bd6 analytics restoration, `getLifetimeStats` was back in `analytics.ts` but `persistStats()` never wired it into the JSON sidecar — the statusline would always read 0 and the *remembers-more* half of the brand-poem triad (the README-shipped *\"\\$ saved this session · \\$ saved across sessions · % efficient\"*) would never render.

Addresses **Critical 3** from the PR #399 review:
https://github.com/mksglu/context-mode/pull/399#issuecomment-4364664233

## How

Wire `getLifetimeStats({ sessionsDir: getSessionDir() })` into `persistStats()` with a **30s cache**. The 500ms persist throttle would be too aggressive for a function that scans every per-project SessionDB plus the auto-memory dir; the statusline doesn't need second-by-second lifetime accuracy.

Conversion factor (`256 tokens/event` = ~1KB ÷ 4 bytes/token) is the same one used by `analytics.ts renderBottomLine`, extracted to a `TOKENS_PER_EVENT` constant so it stays in lockstep if either side moves.

Failures during the disk scan keep the stale cache (or 0) — same best-effort discipline as the surrounding `persistStats()` try/catch.

## Affected platforms

- [x] Claude Code (status line is Claude Code-specific; persistence layer is platform-agnostic)
- [ ] Cursor / Codex / Gemini / Qwen / OpenCode / KiloCode / Antigravity / Zed / Pi / Kiro / VS Code Copilot / JetBrains Copilot / OpenClaw

## Verification

```
npm run typecheck         ✓
npm run build             ✓ (cli 552kb, server 511kb)
npx vitest run            ✓ Test Files 74 passed (74) | Tests 2130 passed | 24 skipped (2154)
```

Targeted (16/16 pass):
- `tests/statusline.test.ts`
- `tests/session/lifetime-stats.test.ts`
- `tests/session/stats-output-format.test.ts`

## Notes for review

- 30s cache TTL is a tradeoff: fast enough that a user sees the lifetime number tick after a long session, slow enough that hot tool-call loops don't pay for `readdirSync` + per-DB sqlite open on every persist. Open to making it configurable via env var if you'd prefer.
- `TOKENS_PER_EVENT = 256` mirrors `analytics.ts` line 484-ish (`~1KB per session event ÷ 4 bytes/token`). If you'd rather move both consumers to import a single exported constant, happy to do that in a follow-up.
- No README changes needed — the existing copy from `58a60d8` matches what the bar will now actually render.