### PR TITLE
fix: add ps1 extension for Windows PowerShell -File scripts

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -15,8 +15,10 @@ const isWin = process.platform === "win32";
 
 /**
  * Pure helper: extension map for temp script files per language.
- * On Windows, shell scripts get NO extension to avoid Windows file-association
- * for `.sh` (which spawns a visible Git Bash window over the user's IDE).
+ * On Windows, shell scripts usually get NO extension to avoid Windows
+ * file-association for `.sh` (which spawns a visible Git Bash window over the
+ * user's IDE). Windows PowerShell/pwsh is the exception because `-File`
+ * requires `.ps1` there.
  */
 const SCRIPT_EXT: Record<Language, string> = {
   javascript: "js",
@@ -33,8 +35,17 @@ const SCRIPT_EXT: Record<Language, string> = {
 };
 
 /** Pure helper — exported for unit testing. Returns "script" or "script.<ext>". */
-export function buildScriptFilename(language: Language, platform: NodeJS.Platform): string {
-  if (platform === "win32" && language === "shell") return "script";
+export function buildScriptFilename(
+  language: Language,
+  platform: NodeJS.Platform,
+  shellPath?: string | null,
+): string {
+  if (platform === "win32" && language === "shell") {
+    const shellName = shellPath?.toLowerCase() ?? "";
+    return shellName.includes("powershell") || shellName.includes("pwsh")
+      ? "script.ps1"
+      : "script";
+  }
   return `script.${SCRIPT_EXT[language]}`;
 }
 
@@ -206,7 +217,14 @@ export class PolyglotExecutor {
       code = `Path.wildcard(Path.join(${escaped}, "*/ebin"))\n|> Enum.each(&Code.prepend_path/1)\n\n${code}`;
     }
 
-    const fp = join(tmpDir, buildScriptFilename(language, process.platform));
+    const fp = join(
+      tmpDir,
+      buildScriptFilename(
+        language,
+        process.platform,
+        language === "shell" ? this.#runtimes.shell : null,
+      ),
+    );
     if (language === "shell") {
       writeFileSync(fp, code, { encoding: "utf-8", mode: 0o700 });
     } else {

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -1563,11 +1563,41 @@ describe("Windows Shell Support", () => {
 
   test("buildScriptFilename: shell on Windows has NO extension (avoid .sh file association)", async () => {
     assert.equal(buildScriptFilename("shell", "win32"), "script");
+    assert.equal(buildScriptFilename("shell", "win32", "C:\\Program Files\\Git\\usr\\bin\\bash.exe"), "script");
+    assert.equal(buildScriptFilename("shell", "win32", "sh"), "script");
+  });
+
+  test("buildScriptFilename: PowerShell on Windows uses .ps1 extension", async () => {
+    assert.equal(buildScriptFilename("shell", "win32", "powershell"), "script.ps1");
+    assert.equal(buildScriptFilename("shell", "win32", "pwsh"), "script.ps1");
+    assert.equal(
+      buildScriptFilename("shell", "win32", "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
+      "script.ps1",
+    );
+    assert.equal(
+      buildScriptFilename("shell", "win32", "C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+      "script.ps1",
+    );
+  });
+
+  test.runIf(process.platform === "win32")("PowerShell shell runtime executes generated script", async () => {
+    const powershellRuntimes: RuntimeMap = { ...runtimes, shell: "powershell" };
+    const powershellExecutor = new PolyglotExecutor({ runtimes: powershellRuntimes });
+    const r = await powershellExecutor.execute({
+      language: "shell",
+      code: 'Write-Output "POWERSHELL_EXECUTOR_OK"',
+      timeout: 10_000,
+    });
+
+    assert.equal(r.exitCode, 0, `stderr: ${r.stderr}`);
+    assert.ok(r.stdout.includes("POWERSHELL_EXECUTOR_OK"), `stdout: ${r.stdout}`);
   });
 
   test("buildScriptFilename: shell on Unix keeps .sh extension", async () => {
     assert.equal(buildScriptFilename("shell", "darwin"), "script.sh");
     assert.equal(buildScriptFilename("shell", "linux"), "script.sh");
+    assert.equal(buildScriptFilename("shell", "linux", "pwsh"), "script.sh");
+    assert.equal(buildScriptFilename("shell", "darwin", "powershell"), "script.sh");
   });
 
   test("buildScriptFilename: non-shell languages keep their extension on Windows", async () => {


### PR DESCRIPTION
## What / Why / How

Windows PowerShell shell execution failed when context-mode generated an extensionless temporary script and then executed it through the existing `powershell -File` / `pwsh -File` path.

Both Windows PowerShell and Windows pwsh reject extensionless files for `-File` with messages like:

```text
Processing -File '...\script' failed because the file does not have a '.ps1' extension.
```

This keeps the existing Windows Git Bash behavior unchanged: bash/sh shell scripts still use an extensionless `script` file to avoid `.sh` file-association issues. Windows PowerShell and Windows pwsh are now the only shell runtimes that get `script.ps1`.

I also checked Linux pwsh in WSL. Linux pwsh accepts extensionless files, `.sh`, and `.ps1` with `-File`, and the existing Unix path (`pwsh <script.sh>`) also works. Unix behavior is therefore left unchanged and covered by filename-selection assertions.

Implementation:
- pass the detected shell runtime into `buildScriptFilename`
- return `script.ps1` only for PowerShell/pwsh on Windows
- keep extensionless `script` for Git Bash/sh on Windows
- keep `script.sh` for Unix shell scripts, including Unix pwsh
- add unit coverage for filename selection
- add a Windows executor regression test that verifies PowerShell output is captured through `PolyglotExecutor`

## Affected (*Tested) platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Added/updated tests in `tests/executor.test.ts`:
- Windows Git Bash/sh still use extensionless `script`
- Windows PowerShell/pwsh use `script.ps1`
- Unix shell scripts still use `script.sh`, including Unix pwsh
- Windows PowerShell shell runtime executes a generated script through `PolyglotExecutor` and captures stdout

Ran locally:

```text
npx vitest run tests/executor.test.ts -t "PowerShell shell runtime executes generated script|buildScriptFilename"
```

Result:

```text
Test Files  1 passed
Tests       6 passed | 115 skipped
```

Also ran locally:

```text
npm run typecheck
npm run build
```

Both passed.

Manual behavior checks:
- Windows PowerShell: `powershell.exe -File script` fails, `powershell.exe -File script.ps1` succeeds.
- Windows pwsh: `pwsh.exe -File script` fails, `pwsh.exe -File script.ps1` succeeds.
- WSL/Linux pwsh 7.6.1 via mise: `pwsh -File script`, `pwsh -File script.sh`, `pwsh -File script.ps1`, and `pwsh script.sh` all succeed.

Full `npm test` is left for CI because this local Windows environment has unrelated Python alias/native addon issues.

## Checklist

- [x] Tests added/updated (TDD: red -> green)
- [ ] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (not needed)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
