### PR TITLE
fix: handle batch env prefix by shell

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -790,6 +790,30 @@ interface BatchExecutor {
   execute(input: { language: "shell"; code: string; timeout: number | undefined }): Promise<{ stdout: string; timedOut?: boolean }>;
 }
 
+function quotePosixSingle(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function quotePowerShellSingle(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export function buildBatchNodeOptionsPrefix(shellPath: string, preloadPath: string): string {
+  const option = `--require ${preloadPath}`;
+  const shell = shellPath.toLowerCase();
+  const base = shell.split(/[\\/]/).pop() ?? shell;
+
+  if (shell.includes("powershell") || shell.includes("pwsh")) {
+    return `$env:NODE_OPTIONS=${quotePowerShellSingle(option)}; `;
+  }
+
+  if (base === "cmd" || base === "cmd.exe") {
+    return `set "NODE_OPTIONS=${option.replace(/"/g, '""')}" && `;
+  }
+
+  return `NODE_OPTIONS=${quotePosixSingle(option)} `;
+}
+
 function formatCommandOutput(label: string, raw: string, onFsBytes?: (bytes: number) => void): string {
   let output = raw || "(no output)";
   const fsMatches = output.matchAll(/__CM_FS__:(\d+)/g);
@@ -2328,7 +2352,7 @@ server.registerTool(
       // Inject NODE_OPTIONS for FS read tracking in spawned Node processes.
       // The executor denies NODE_OPTIONS in its env (security), so we set it
       // as an inline shell prefix. This only affects child `node` invocations.
-      const nodeOptsPrefix = `NODE_OPTIONS="--require ${CM_FS_PRELOAD}" `;
+      const nodeOptsPrefix = buildBatchNodeOptionsPrefix(runtimes.shell, CM_FS_PRELOAD);
 
       // Full stdout is preserved per-command and indexed into FTS5 (Issue #61, #197).
       // Concurrency>1 switches to a worker pool with per-command timeouts.

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -2074,7 +2074,7 @@ describe("batch_execute FS read tracking", () => {
   });
 
   test("sets NODE_OPTIONS with --require for batch commands", () => {
-    expect(serverSrc).toContain('NODE_OPTIONS="--require ${CM_FS_PRELOAD}"');
+    expect(serverSrc).toContain("buildBatchNodeOptionsPrefix");
     expect(serverSrc).toContain("nodeOptsPrefix");
   });
 
@@ -2112,7 +2112,11 @@ describe("batch_execute FS read tracking", () => {
 // runBatchCommands — concurrency, ordering, timeout semantics
 // ═══════════════════════════════════════════════════════════════════════════
 
-import { runBatchCommands, type BatchCommand } from "../../src/server.js";
+import {
+  buildBatchNodeOptionsPrefix,
+  runBatchCommands,
+  type BatchCommand,
+} from "../../src/server.js";
 
 interface MockResult { stdout: string; timedOut?: boolean; }
 
@@ -2350,6 +2354,27 @@ describe("runBatchCommands edge cases", () => {
     const cmds: BatchCommand[] = [{ label: "A", command: "echo hi" }];
     await runBatchCommands(cmds, { timeout: 1000, concurrency: 1, nodeOptsPrefix: 'NODE_OPTIONS="--require /tmp/x" ' }, exec);
     expect(seen[0]).toBe('NODE_OPTIONS="--require /tmp/x" echo hi 2>&1');
+  });
+
+  test("buildBatchNodeOptionsPrefix formats POSIX shell assignment", () => {
+    const prefix = buildBatchNodeOptionsPrefix("bash", "/tmp/cm fs'preload.js");
+    expect(prefix).toBe("NODE_OPTIONS='--require /tmp/cm fs'\\''preload.js' ");
+  });
+
+  test("buildBatchNodeOptionsPrefix formats PowerShell assignment", () => {
+    const prefix = buildBatchNodeOptionsPrefix(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      "C:\\Temp\\cm ' fs.js",
+    );
+    expect(prefix).toBe("$env:NODE_OPTIONS='--require C:\\Temp\\cm '' fs.js'; ");
+  });
+
+  test("buildBatchNodeOptionsPrefix formats cmd assignment", () => {
+    const prefix = buildBatchNodeOptionsPrefix(
+      "C:\\Windows\\System32\\cmd.exe",
+      "C:\\Temp\\cm-fs-preload.js",
+    );
+    expect(prefix).toBe('set "NODE_OPTIONS=--require C:\\Temp\\cm-fs-preload.js" && ');
   });
 });
 


### PR DESCRIPTION
## What / Why / How

`ctx_batch_execute` injects `NODE_OPTIONS` for the FS preload by prepending an inline environment assignment to each command. That prefix was POSIX-only, so PowerShell and cmd shells could fail to run the intended command body or fail to preserve command output.

This change adds shell-aware prefix generation for the batch command path:

- POSIX shells use `NODE_OPTIONS='...' command`
- PowerShell uses `$env:NODE_OPTIONS='...'; command`
- cmd uses `set "NODE_OPTIONS=..." && command`

The batch runner now builds the prefix from the detected shell instead of hardcoding POSIX syntax.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

- Added unit coverage for POSIX, PowerShell, and cmd `NODE_OPTIONS` prefix formatting.
- Verified the updated bundled server locally by starting `server.bundle.mjs` with `SHELL` set to Windows PowerShell and calling `ctx_batch_execute`; the batch command output was indexed and returned.
- Ran `npm run typecheck`.
- Ran `npx vitest run tests/core/server.test.ts -t "buildBatchNodeOptionsPrefix"`.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>