### PR TITLE
Fix/missing toolname prefix

### DIFF
--- a/hooks/routing-block.mjs
+++ b/hooks/routing-block.mjs
@@ -36,11 +36,11 @@ export function createRoutingBlock(t, options = {}) {
 
   <forbidden_actions>
     - NO Bash for commands producing >20 lines output.
-    - NO Read for analysis — use execute_file. Read IS correct for files you intend to Edit.
+    - NO Read for analysis — use ${t("ctx_execute_file")}. Read IS correct for files you intend to Edit.
     - NO WebFetch — use ${t("ctx_fetch_and_index")}.
     - Bash ONLY for git/mkdir/rm/mv/navigation.
     - NO ${t("ctx_execute")} or ${t("ctx_execute_file")} for file creation/modification.
-      ctx_execute is for analysis, processing, computation only.
+      ${t("ctx_execute")} is for analysis, processing, computation only.
   </forbidden_actions>
 
   <file_writing_policy>


### PR DESCRIPTION
## What / Why / How

I think these should also have toolname prefix in instructions


## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
