### PR TITLE
feat(plugin): add context injection support for additionalContext

### DIFF
--- a/src/opencode-plugin.ts
+++ b/src/opencode-plugin.ts
@@ -304,7 +304,10 @@ async function createContextModePlugin(ctx: PluginContext) {
         Object.assign(output.args, decision.updatedInput);
       }
 
-      // "context" action → no-op (OpenCode doesn't support context injection)
+      if (decision.action === "context" && decision.additionalContext) {
+        // Mutate output.args — OpenCode reads the mutated output object
+        output.args.additionalContext = decision.additionalContext;
+      }
     },
 
     // ── PostToolUse: Session event capture ──────────────

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -142,6 +142,19 @@ describe("ContextModePlugin", () => {
       );
       expect(result).toBeUndefined();
     });
+
+    it("injects guidance for allowed grep commands", async () => {
+      const plugin = await createTestPlugin(join(tempDir, "before-guidance"));
+
+      const input = { tool: "grep", sessionID: "test-session", callID: "call-4" };
+      const output = { args: { command: "grep hello", additionalContext: undefined } };
+
+      await plugin["tool.execute.before"](input, output);
+
+      // Guidance should be injected as additionalContext in args
+      expect(output.args).toHaveProperty("additionalContext");
+      expect(output.args.additionalContext).toContain("<context_guidance>");
+    });
   });
 
   // ── tool.execute.after ────────────────────────────────


### PR DESCRIPTION
Previously, context actions were no-ops in the OpenCode plugin. Now, when a context action includes additionalContext, it gets injected into the output args for OpenCode to consume.

## What / Why / How

<!-- Brief: what changed, why, and implementation approach. Link issue: Fixes #000 -->

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [x] OpenCode
- [x] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Adds test case to verify guidance injection for allowed commands.

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
