### PR TITLE
fix(upgrade): copy package files in inline fallback

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2675,14 +2675,11 @@ server.registerTool(
       // Inline fallback: neither CLI file exists (e.g. marketplace installs).
       // Generate a self-contained node -e script that performs the upgrade.
       const repoUrl = "https://github.com/mksglu/context-mode.git";
-      const copyDirs = ["build", "hooks", "skills", "scripts", ".claude-plugin"];
-      const copyFiles = ["start.mjs", "server.bundle.mjs", "cli.bundle.mjs", "package.json"];
-
       // Write inline script to a temp .mjs file — avoids quote-escaping issues
       // across cmd.exe, PowerShell, and bash (node -e '...' breaks on Windows).
       const scriptLines = [
         `import{execFileSync}from"node:child_process";`,
-        `import{cpSync,rmSync,existsSync,mkdtempSync}from"node:fs";`,
+        `import{cpSync,rmSync,existsSync,mkdtempSync,readFileSync,writeFileSync}from"node:fs";`,
         `import{join}from"node:path";`,
         `import{tmpdir}from"node:os";`,
         `const P=${JSON.stringify(pluginRoot)};`,
@@ -2694,15 +2691,11 @@ server.registerTool(
         `execFileSync(process.platform==="win32"?"npm.cmd":"npm",["install"],{cwd:T,stdio:"inherit",shell:process.platform==="win32"});`,
         `execFileSync(process.platform==="win32"?"npm.cmd":"npm",["run","build"],{cwd:T,stdio:"inherit",shell:process.platform==="win32"});`,
         `console.log("- [x] Built from source");`,
-        ...copyDirs.map(
-          (d) =>
-            `if(existsSync(join(T,${JSON.stringify(d)})))cpSync(join(T,${JSON.stringify(d)}),join(P,${JSON.stringify(d)}),{recursive:true,force:true});`,
-        ),
-        ...copyFiles.map(
-          (f) =>
-            `if(existsSync(join(T,${JSON.stringify(f)})))cpSync(join(T,${JSON.stringify(f)}),join(P,${JSON.stringify(f)}),{force:true});`,
-        ),
-        `console.log("- [x] Copied build artifacts");`,
+        `const pkg=JSON.parse(readFileSync(join(T,"package.json"),"utf8"));`,
+        `const items=[...(Array.isArray(pkg.files)?pkg.files:[]),"src","package.json"];`,
+        `for(const item of items){const from=join(T,item);const to=join(P,item);if(existsSync(from)){rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true,force:true});}}`,
+        `writeFileSync(join(P,".mcp.json"),JSON.stringify({mcpServers:{"context-mode":{command:"node",args:["\${CLAUDE_PLUGIN_ROOT}/start.mjs"]}}},null,2)+"\\n");`,
+        `console.log("- [x] Copied package files");`,
         `execFileSync(process.platform==="win32"?"npm.cmd":"npm",["install","--production"],{cwd:P,stdio:"inherit",shell:process.platform==="win32"});`,
         `console.log("- [x] Installed production dependencies");`,
         `console.log("## context-mode upgrade complete");`,

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -27,6 +27,11 @@ describe("cli.bundle.mjs — marketplace install support", () => {
     expect(pkg.files).toContain("cli.bundle.mjs");
   });
 
+  it("package.json files field includes statusline bin", () => {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8"));
+    expect(pkg.files).toContain("bin");
+  });
+
   it("package.json bundle script builds cli.bundle.mjs", () => {
     const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8"));
     expect(pkg.scripts.bundle).toContain("cli.bundle.mjs");
@@ -1116,6 +1121,21 @@ describe("Shell-free upgrade (#185)", () => {
     // Generated script lines must import execFileSync
     expect(inlineSection).toContain("execFileSync");
     expect(inlineSection).not.toMatch(/(?<!File)execSync/);
+  });
+
+  test("server.ts inline fallback copies package files including bin", () => {
+    const inlineStart = SERVER_SOURCE.indexOf("Inline fallback");
+    expect(inlineStart).toBeGreaterThan(-1);
+    const inlineSection = SERVER_SOURCE.slice(inlineStart, SERVER_SOURCE.indexOf("cmd =", inlineStart + 500));
+
+    expect(inlineSection).toContain('readFileSync(join(T,"package.json"),"utf8")');
+    expect(inlineSection).toContain("pkg.files");
+    expect(inlineSection).toContain("Array.isArray(pkg.files)");
+    expect(inlineSection).toContain("for(const item of items)");
+    expect(inlineSection).toContain('writeFileSync(join(P,".mcp.json")');
+    expect(inlineSection).toContain("\\${CLAUDE_PLUGIN_ROOT}/start.mjs");
+    expect(inlineSection).not.toContain("copyDirs");
+    expect(inlineSection).not.toContain("copyFiles");
   });
 });
 

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -1632,6 +1632,9 @@ describe("ctx_upgrade tool: inline fallback for missing CLI", () => {
     resolve(__dirname, "../../src/server.ts"),
     "utf-8",
   );
+  const packageJson = JSON.parse(
+    readFileSync(resolve(__dirname, "../../package.json"), "utf-8"),
+  );
 
   test("tries cli.bundle.mjs first", () => {
     expect(serverSrc).toContain("cli.bundle.mjs");
@@ -1650,10 +1653,16 @@ describe("ctx_upgrade tool: inline fallback for missing CLI", () => {
     expect(serverSrc).toMatch(/\.ctx-upgrade-inline\.mjs/);
   });
 
-  test("inline fallback copies key files to plugin root", () => {
-    // The inline script must copy build artifacts back
-    expect(serverSrc).toMatch(/server\.bundle\.mjs/);
-    expect(serverSrc).toMatch(/cli\.bundle\.mjs/);
+  test("inline fallback copies package files to plugin root", () => {
+    // The inline script must copy the published package payload back, including
+    // newly added files such as the statusline bin directory.
+    expect(packageJson.files).toEqual(
+      expect.arrayContaining(["server.bundle.mjs", "cli.bundle.mjs", "bin"]),
+    );
+    expect(serverSrc).toContain('readFileSync(join(T,"package.json"),"utf8")');
+    expect(serverSrc).toContain("pkg.files");
+    expect(serverSrc).toContain("Array.isArray(pkg.files)");
+    expect(serverSrc).toContain("cpSync(from,to,{recursive:true,force:true})");
     expect(serverSrc).toMatch(/npm.*install/);
   });
 


### PR DESCRIPTION
## Summary
- make the `ctx_upgrade` inline fallback read the cloned `package.json#files` list instead of copying a hard-coded subset
- keep the `.mcp.json` placeholder write in the inline fallback so upgraded plugin caches retain `${CLAUDE_PLUGIN_ROOT}`
- add regression coverage for keeping the statusline `bin` payload in upgrade copies

Fixes #429

## Test plan
- [x] `pnpm exec vitest run tests/core/cli.test.ts -t "statusline bin|inline fallback copies package files"`
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [ ] `pnpm exec vitest run tests/core/cli.test.ts` — local Windows/pnpm run reaches 114 passing tests, then SQLite adapter tests fail because `better-sqlite3` native bindings are unavailable after pnpm ignored build scripts (`better-sqlite3`, `esbuild`).