### PR TITLE
fix(skills): add frontmatter to UPSTREAM-CREDITS.md to suppress skill-scanner warning

### DIFF
--- a/skills/UPSTREAM-CREDITS.md
+++ b/skills/UPSTREAM-CREDITS.md
@@ -1,3 +1,8 @@
+---
+name: UPSTREAM-CREDITS
+description: Attribution document for vendored skills from mattpocock/skills. Not an executable skill.
+---
+
 # Upstream Skill Credits
 
 context-mode vendors a small set of operating-discipline skills authored


### PR DESCRIPTION
When I start my pi sessions I see this error:

```
[Skill conflicts]
  ~/.nvm/versions/node/v24.4.1/lib/node_modules/context-mode/skills/UPSTREAM-CREDITS.md
    description is required
```

The skill scanner picks up every `.md` in `skills/` and requires a `description` field in the frontmatter. `UPSTREAM-CREDITS.md` is a documentation file with no frontmatter, so it trips the validator on every startup.

Added a `name`/`description` frontmatter block (same format as the vendored skills alongside it) with a description that signals it's attribution-only. I searched the issue tracker before filing and found no existing issue.