### PR TITLE
fix(opencode-plugin):add structured logging, remove per-session dedup sets, tighten plugin types

### DIFF
--- a/hooks/routing-block.mjs
+++ b/hooks/routing-block.mjs
@@ -86,7 +86,6 @@ ${includeCommands ? `
     → Call purge MCP tool with confirm: true. Warn: irreversible.
 
     After /clear or /compact: knowledge base preserved. Tell user: "context-mode knowledge base preserved. Use \`ctx purge\` to start fresh."
-    **NEVER** summarize any command output. **ALWAYS display it verbatim**.    
   </ctx_commands>
 ` : ''}
 </context_window_protection>`;

--- a/hooks/routing-block.mjs
+++ b/hooks/routing-block.mjs
@@ -86,6 +86,7 @@ ${includeCommands ? `
     → Call purge MCP tool with confirm: true. Warn: irreversible.
 
     After /clear or /compact: knowledge base preserved. Tell user: "context-mode knowledge base preserved. Use \`ctx purge\` to start fresh."
+    **NEVER** summarize any command output. **ALWAYS display it verbatim**.    
   </ctx_commands>
 ` : ''}
 </context_window_protection>`;

--- a/src/opencode-plugin.ts
+++ b/src/opencode-plugin.ts
@@ -50,10 +50,34 @@ const VERSION: string = (() => {
 // ── Types ─────────────────────────────────────────────────
 
 /** KiloCode/OpenCode plugin input — both platforms pass at least `directory`. */
-interface PluginContext {
+type PluginClientAppLogBodyExtra = {
+  sessionId?: string;
+  source?: string;
+};
+
+type PluginClientAppLogBody = {
+  service: string;
+  level: "info" | "warn" | "error" | "debug"; // Strict union for log levels
+  message: string;
+  extra?: PluginClientAppLogBodyExtra;
+};
+
+type PluginClientAppLogOptions = {
+  body: PluginClientAppLogBody;
+};
+
+type PluginClientApp = {
+  log: (options: PluginClientAppLogOptions) => Promise<void>;
+};
+
+type PluginClient = {
+  app: PluginClientApp;
+};
+
+type PluginContext = {
+  client: PluginClient;
   directory: string;
-  [key: string]: unknown;
-}
+};
 
 /** OpenCode tool.execute.before — first parameter */
 interface BeforeHookInput {
@@ -191,7 +215,7 @@ function getPlatform(): AdapterPlatformType {
  * Plugin factory. Called once when KiloCode/OpenCode loads the plugin.
  * Returns an object mapping hook event names to async handler functions.
  *
- * KiloCode expects: export default { server: (input) => Promise<Hooks> }
+ * KiloCode expects: export default { id: string, server: (input) => Promise<Hooks> }
  * OpenCode expects: export const ContextModePlugin = (ctx) => Promise<Hooks>
  */
 async function createContextModePlugin(ctx: PluginContext) {
@@ -225,7 +249,7 @@ async function createContextModePlugin(ctx: PluginContext) {
   // OpenCode/Kilo provide the real `input.sessionID` on every hook, and a
   // process-global UUID would (a) never match prior-session resume rows and
   // (b) collide across multi-session reuse (Mickey / PR #376 root cause).
-  const projectDir = ctx.directory;
+  const projectDir = ctx?.directory ?? process.cwd();
   const db = new SessionDB({ dbPath: adapter.getSessionDBPath(projectDir) });
 
   // Clean up old sessions on startup (no SessionStart hook to do this).
@@ -276,6 +300,19 @@ async function createContextModePlugin(ctx: PluginContext) {
         // file missing or unreadable — skip silently
       }
     }
+  }
+
+  function logger(
+    message = "context-mode debug log", extra?: PluginClientAppLogBodyExtra
+  ): Promise<void> {
+    return ctx.client.app.log({
+      body: {
+        service: "context-mode-logger",
+        level: "info",
+        message,
+        extra
+      },
+    });
   }
 
   return {
@@ -396,6 +433,13 @@ async function createContextModePlugin(ctx: PluginContext) {
         // Mutate output.context to inject the snapshot
         output.context.push(snapshot);
 
+        if (process.env.OPENCODE_DEBUG) {
+          await logger(snapshot, {
+            sessionId,
+            source: "on compaction - snapshot",
+          });
+        }
+
         // OC-3 / Z3: Add budget-capped auto-injection (P1 role / P2 rules /
         // P3 skills / P4 intent — ≤500 tokens / ~2000 chars per
         // hooks/auto-injection.mjs). Pushed as a separate context entry so
@@ -404,6 +448,13 @@ async function createContextModePlugin(ctx: PluginContext) {
           const autoBlock: string = autoInjectionMod.buildAutoInjection(events);
           if (autoBlock && autoBlock.length > 0) {
             output.context.push(autoBlock);
+          }
+          
+          if (process.env.OPENCODE_DEBUG) {
+            await logger(autoBlock, {
+              sessionId,
+              source: "on compaction - autoBlock",
+            });
           }
         } catch {
           // Auto-injection failure must NOT break the snapshot path.
@@ -436,26 +487,36 @@ async function createContextModePlugin(ctx: PluginContext) {
       // resume snapshot path below — routing block must fire even when
       // no prior session row exists. Splice at index 1 (NOT unshift) for
       // the same OpenCode llm.ts:117-128 cache-fold reason as resume.
-      if (!routingInjected.has(sessionId) && Array.isArray(output?.system)) {
+      if (Array.isArray(output?.system)) {
         try {
           // Visible marker — mirror the resume-snapshot pattern below so
           // users can grep OPENCODE_DEBUG logs to confirm the routing block
           // reached the model (Mickey-class verification path).
           const marker = `<!-- context-mode v${VERSION}: routing block injected (sessionID=${sessionId.slice(0, 8)}) -->\n`;
           output.system.splice(1, 0, marker + routingBlock);
-          routingInjected.add(sessionId);
         } catch {
           // Never break the chat turn on routing-block injection failure.
         }
+        
+        if (process.env.OPENCODE_DEBUG) {
+          await logger(output.system[1], {sessionId, source: 'on routing block injection'});
+        }
       }
 
-      if (resumeInjected.has(sessionId)) return;
       try {
         // Pass current sessionId so SQL excludes self-injection (v1.0.106 — Mickey #376
         // follow-up): if Session B compacts mid-flight and produces its own row,
         // B's next system.transform must NOT claim that row back into B's prompt.
         const row = db.claimLatestUnconsumedResume(sessionId);
         if (!row || !row.snapshot) return;        // no row → leave `resumeInjected` unset → retry on next turn
+
+        if (process.env.OPENCODE_DEBUG) {
+          await logger(row.snapshot, {
+            sessionId,
+            source: "on resume - snapshot",
+          });
+        }
+        
         if (Array.isArray(output?.system)) {
           // Visible signal — without this, the injection is silent and users
           // cannot tell the feature is active (Mickey: "I can't find use case
@@ -478,7 +539,9 @@ async function createContextModePlugin(ctx: PluginContext) {
           // snapshot ride along inside the cached body block.
           output.system.splice(1, 0, marker + row.snapshot);
           // Mark consumed only AFTER successful splice so failed paths can retry
-          resumeInjected.add(sessionId);
+          if (process.env.OPENCODE_DEBUG) {
+            await logger(output.system[1], { sessionId, source: "on resume" });
+          }
         }
       } catch {
         // Silent — never break the chat turn
@@ -490,5 +553,5 @@ async function createContextModePlugin(ctx: PluginContext) {
 // ── Exports ──────────────────────────────────────────────
 // KiloCode PluginModule: default export with { server } shape
 // OpenCode compat: named export for direct import("context-mode/plugin")
-export default { server: createContextModePlugin };
+export default { id:"context-mode", server: createContextModePlugin };
 export { createContextModePlugin as ContextModePlugin };

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -26,7 +26,14 @@ async function createTestPlugin(tempDir: string) {
   // Monkey-patch the session dir to use temp directory
   // The plugin uses homedir() internally, but we can control the DB path
   // by creating the plugin with a unique directory that produces a unique hash
-  return ContextModePlugin({ directory: tempDir });
+  return ContextModePlugin({
+    directory: tempDir,
+    client: {
+      app: {
+        log: async () => {},
+      },
+    },
+  });
 }
 
 // ── Tests ─────────────────────────────────────────────────
@@ -380,7 +387,7 @@ describe("ContextModePlugin", () => {
       expect(middle).toContain("<context_window_protection>");
     });
 
-    it("does NOT re-inject on second call with the same sessionID (multi-turn)", async () => {
+    it("does NOT re-inject resume snapshot on second call with the same sessionID (multi-turn)", async () => {
       const projectDir = join(tempDir, "sysxform-once-per-session");
       const plugin = await createTestPlugin(projectDir);
 
@@ -407,8 +414,10 @@ describe("ContextModePlugin", () => {
         { sessionID: "turn-X", model: {} } as any,
         out2,
       );
-      // Same session — already injected this process — silent (header only).
-      expect(out2.system).toEqual(["HEADER"]);
+      // Same session — resume snapshot consumed from DB. Routing block re-injects (no dedup).
+      expect(out2.system.length).toBe(2); // HEADER + routing block
+      expect(out2.system[1]).toContain("<context_window_protection>");
+      expect(out2.system.join("\n")).not.toContain("session_resume");
     });
 
     // v1.0.106 — Mickey #376 follow-up: self-injection guard
@@ -469,15 +478,16 @@ describe("ContextModePlugin", () => {
         { context: [] as string[], prompt: undefined },
       );
 
-      // C's next turn — routing already injected this session, but resume
-      // gate not consumed yet (no premature gate). Should pick up donor row.
+      // C's next turn — routing block re-injects (every turn), plus resume
+      // snapshot from donor (no premature gate — DB claim still available).
       const out2 = { system: ["HEADER"] };
       await plugin["experimental.chat.system.transform"](
         { sessionID: "C", model: {} } as any,
         out2,
       );
-      expect(out2.system.length).toBe(2); // HEADER + snapshot (no re-routing)
+      expect(out2.system.length).toBe(3); // HEADER + snapshot + routing
       expect(out2.system[1]).toContain("session_resume");
+      expect(out2.system[2]).toContain("<context_window_protection>");
     });
 
     // v1.0.106 — prefer next session over self-injection
@@ -595,8 +605,8 @@ describe("ContextModePlugin", () => {
       expect(joined).toContain("context-mode_ctx_search");
     });
 
-    it("OC-1: does NOT re-inject routing block on second turn per session", async () => {
-      const plugin = await createTestPlugin(join(tempDir, "oc1-once"));
+    it("OC-1: re-injects routing block on every turn (per-turn reliability)", async () => {
+      const plugin = await createTestPlugin(join(tempDir, "oc1-every-turn"));
       const out1 = { system: ["HEADER"] };
       await plugin["experimental.chat.system.transform"](
         { sessionID: "oc1-twice", model: {} } as any,
@@ -609,8 +619,9 @@ describe("ContextModePlugin", () => {
         { sessionID: "oc1-twice", model: {} } as any,
         out2,
       );
-      // Second turn — routing block already injected this process; silent.
-      expect(out2.system).toEqual(["HEADER"]);
+      // Routing block injects every turn for reliability (no dedup set).
+      expect(out2.system.join("\n")).toContain("<context_window_protection>");
+      expect(out2.system.length).toBe(2);
     });
   });
 


### PR DESCRIPTION

## What / Why / How

Identified the problem about `experimental.chat.system.transform` hook. `output.system` array does not keep injections, so we need to do injection with every prompt. As setting OPENCODE_DEBUG=1 does not do anything in log, added logger to plugin and appropriate logs so we can track behavior with OPENCODE_DEBUG env variable.  

- Replace loose PluginContext with typed client/log interfaces matching the OpenCode plugin contract (client.app.log)
- Add OPENCODE_DEBUG-gated logger() at key injection points: routing block, compaction snapshot, auto-injection block, and resume snapshot
- Remove routingInjected/resumeInjected per-session Sets — routing block now injects on every chat.system.transform turn for reliability; resume snapshot dedup is handled by DB claim consumption
- Add `id` field to default export for plugin identification
- Defensive fallback to process.cwd() when ctx.directory is undefined
- Add verbatim-display instruction to ctx_commands in routing block

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [x] OpenCode
- [x] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Update tests to match new behavior: routing block re-injects every turn, resume snapshot gated by DB consumption only

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
