### PR TITLE
fix(hooks): robust rmSync for Windows + non-ASCII tmpdir paths (#454)

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -16,7 +16,7 @@ import {
 } from "../routing-block.mjs";
 import { createToolNamer } from "./tool-naming.mjs";
 import { isMCPReady } from "./mcp-ready.mjs";
-import { existsSync, mkdirSync, rmSync, openSync, closeSync, constants as fsConstants } from "node:fs";
+import { existsSync, mkdirSync, rmSync, rmdirSync, readdirSync, unlinkSync, openSync, closeSync, constants as fsConstants } from "node:fs";
 
 /**
  * Guard for actions that redirect to MCP tools (#230).
@@ -84,12 +84,30 @@ function guidanceOnce(type, content, sessionId) {
   return { action: "context", additionalContext: content };
 }
 
+/**
+ * Robust recursive delete. On Windows, `fs.rmSync` on directories under a
+ * tmpdir whose path contains non-ASCII characters (e.g. a Chinese / Japanese /
+ * Korean username) silently no-ops without throwing — see #454. Fall back to a
+ * manual unlink + rmdir walk so the marker dir actually goes away.
+ */
+function rmSyncRobust(dir) {
+  try { rmSync(dir, { recursive: true, force: true }); } catch {}
+  if (!existsSync(dir)) return;
+  // Manual fallback for Windows + non-ASCII tmpdir paths
+  try {
+    for (const name of readdirSync(dir)) {
+      try { unlinkSync(resolve(dir, name)); } catch {}
+    }
+    rmdirSync(dir);
+  } catch {}
+}
+
 export function resetGuidanceThrottle(sessionId) {
   _guidanceShown.clear();
   // Clear ppid-based dir (legacy / fallback callers) and the sessionId dir if given
-  try { rmSync(guidanceDirFor(), { recursive: true, force: true }); } catch {}
+  rmSyncRobust(guidanceDirFor());
   if (sessionId) {
-    try { rmSync(guidanceDirFor(sessionId), { recursive: true, force: true }); } catch {}
+    rmSyncRobust(guidanceDirFor(sessionId));
   }
 }
 

--- a/tests/guidance-throttle.test.ts
+++ b/tests/guidance-throttle.test.ts
@@ -141,7 +141,17 @@ describe("guidance throttle", () => {
     }
 
     function clearSessionDir(sessionId: string) {
-      try { fs.rmSync(sessionDir(sessionId), { recursive: true, force: true }); } catch {}
+      const dir = sessionDir(sessionId);
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+      // Windows + non-ASCII tmpdir: rmSync silently no-ops (#454). Manual fallback.
+      if (fs.existsSync(dir)) {
+        try {
+          for (const name of fs.readdirSync(dir)) {
+            try { fs.unlinkSync(path.resolve(dir, name)); } catch {}
+          }
+          fs.rmdirSync(dir);
+        } catch {}
+      }
     }
 
     beforeEach(() => {

--- a/tests/hooks/integration.test.ts
+++ b/tests/hooks/integration.test.ts
@@ -16,9 +16,24 @@ import {
   writeFileSync,
   readFileSync,
   rmSync,
+  rmdirSync,
+  readdirSync,
   existsSync,
   unlinkSync,
 } from "node:fs";
+
+// Robust recursive delete — fs.rmSync silently no-ops on Windows when the
+// target path lives under a tmpdir whose name contains non-ASCII chars (#454).
+function rmSyncRobust(dir: string) {
+  try { rmSync(dir, { recursive: true, force: true }); } catch {}
+  if (!existsSync(dir)) return;
+  try {
+    for (const name of readdirSync(dir)) {
+      try { unlinkSync(resolve(dir, name)); } catch {}
+    }
+    rmdirSync(dir);
+  } catch {}
+}
 import { tmpdir } from "node:os";
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -47,8 +62,8 @@ const mcpSentinelDir = process.platform === "win32" ? tmpdir() : "/tmp";
 const mcpSentinel = resolve(mcpSentinelDir, `context-mode-mcp-ready-${process.pid}`);
 
 beforeEach(() => {
-  try { rmSync(_guidanceDir, { recursive: true, force: true }); } catch {}
-  try { rmSync(_sessionGuidanceDir, { recursive: true, force: true }); } catch {}
+  rmSyncRobust(_guidanceDir);
+  rmSyncRobust(_sessionGuidanceDir);
   writeFileSync(mcpSentinel, String(process.pid));
 });
 

--- a/tests/hooks/vscode-hooks.test.ts
+++ b/tests/hooks/vscode-hooks.test.ts
@@ -10,7 +10,7 @@ import { describe, test, expect, beforeAll, beforeEach, afterAll, afterEach } fr
 import { spawnSync } from "node:child_process";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mkdtempSync, rmSync, existsSync, unlinkSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, rmdirSync, readdirSync, existsSync, unlinkSync, readFileSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir, homedir } from "node:os";
 
@@ -126,8 +126,19 @@ describe("VS Code Copilot hooks", () => {
     const suffix = wid ? `${process.pid}-w${wid}` : String(process.pid);
     const legacyDir = resolve(tmpdir(), `context-mode-guidance-${suffix}`);
     const sessionDir = resolve(tmpdir(), `context-mode-guidance-s-pid-${process.pid}`);
-    try { rmSync(legacyDir, { recursive: true, force: true }); } catch { /* best effort */ }
-    try { rmSync(sessionDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    // fs.rmSync silently no-ops on Windows when tmpdir contains non-ASCII chars (#454).
+    const rmRobust = (dir: string) => {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+      if (!existsSync(dir)) return;
+      try {
+        for (const name of readdirSync(dir)) {
+          try { unlinkSync(resolve(dir, name)); } catch {}
+        }
+        rmdirSync(dir);
+      } catch {}
+    };
+    rmRobust(legacyDir);
+    rmRobust(sessionDir);
     writeFileSync(mcpSentinel, String(process.pid));
   });
 


### PR DESCRIPTION
fs.rmSync silently no-ops on Windows when the target lives under a tmpdir whose name contains non-ASCII characters (e.g. C:\Users\<chinese-name>\AppData\Local\Temp). resetGuidanceThrottle could not clear stale markers, so guidanceOnce hit EEXIST on the next O_EXCL openSync and routePreToolUse returned null permanently — Bash/Read/Grep guidance was suppressed for any user with a non-ASCII Windows username.

Adds an rmSyncRobust helper that falls back to manual unlinkSync + rmdirSync when rmSync silently fails. Same fallback applied to the affected test cleanup hooks (guidance-throttle, integration, vscode-hooks). Unblocks 18 previously-failing tests on Windows i18n setups.

## What / Why / How

<!-- Brief: what changed, why, and implementation approach. Link issue: Fixes #000 -->

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
