### PR TITLE
fix(runtime): filter Windows MS Store Python stubs and verify runnabi…

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -67,6 +67,42 @@ function commandExists(cmd: string): boolean {
   }
 }
 
+/**
+ * Stricter probe than commandExists() — also verifies the resolved binary
+ * actually runs. On Windows, `where python3` matches the Microsoft Store
+ * App Execution Alias stub at C:\Users\<u>\AppData\Local\Microsoft\WindowsApps\
+ * even when no real Python is installed; the stub exits non-zero (9009) and
+ * pops the Store. Filter those entries out and require `<cmd> --version` to
+ * exit 0 before declaring the runtime available (#455).
+ */
+function runnableExists(cmd: string): boolean {
+  if (isWindows) {
+    // Reject if every `where` hit lives under Microsoft\WindowsApps (Store stubs).
+    try {
+      const out = execSync(`where ${cmd}`, { encoding: "utf-8", stdio: "pipe" });
+      const hits = out.trim().split(/\r?\n/).map(p => p.trim()).filter(Boolean);
+      if (hits.length === 0) return false;
+      const realHits = hits.filter(p => !/\\Microsoft\\WindowsApps\\/i.test(p));
+      if (realHits.length === 0) return false;
+    } catch {
+      return false;
+    }
+  } else if (!commandExists(cmd)) {
+    return false;
+  }
+  // Probe with --version (5s timeout). Exit 0 means it really runs.
+  try {
+    execFileSync(cmd, ["--version"], {
+      shell: isWindows,
+      stdio: "pipe",
+      timeout: 5000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function bunExists(): boolean {
   if (commandExists("bun")) return true;
   for (const p of bunFallbackPaths()) {
@@ -171,11 +207,13 @@ export function detectRuntimes(): RuntimeMap {
         : commandExists("ts-node")
           ? "ts-node"
           : null,
-    python: commandExists("python3")
+    python: runnableExists("python3")
       ? "python3"
-      : commandExists("python")
+      : runnableExists("python")
         ? "python"
-        : null,
+        : runnableExists("py")
+          ? "py"
+          : null,
     shell: shellOverride ?? (isWin
       ? (resolveWindowsBash() ?? (commandExists("sh") ? "sh" : commandExists("powershell") ? "powershell" : "cmd.exe"))
       : commandExists("bash") ? "bash" : "sh"),


### PR DESCRIPTION
…lity (#455)

On Windows, `where python` and `where python3` match the Microsoft Store App Execution Alias stubs under %LOCALAPPDATA%\Microsoft\WindowsApps\ even when no real Python is installed. Those stubs exit 9009 and pop the Microsoft Store, so detectRuntimes() reported python as available but every spawn failed.

Add runnableExists() helper that (1) on Windows filters `where` results under \Microsoft\WindowsApps\ and (2) on all platforms verifies `<cmd> --version` exits 0 within 5s. Use it for python/python3 detection and add `py` (Windows Python launcher) as a final fallback.

Verified locally: 12 Python executor tests in tests/executor.test.ts that previously failed on Windows now pass.

## What / Why / How

<!-- Brief: what changed, why, and implementation approach. Link issue: Fixes #000 -->

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
