### PR TITLE
fix(pi): use correct extension lifecycle events

### DIFF
--- a/src/pi-extension.ts
+++ b/src/pi-extension.ts
@@ -199,7 +199,7 @@ export default function piExtension(pi: any): void {
 
   // ── 1. session_start — Initialize session ──────────────
 
-  pi.on("session_start", (ctx: any) => {
+  pi.on("session_start", (_event: any, ctx: any) => {
     try {
       _sessionId = deriveSessionId(ctx ?? {});
       db.ensureSession(_sessionId, projectDir);

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -17,6 +17,7 @@ import "./setup-home";
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -295,6 +296,26 @@ describe("Pi Extension", () => {
       });
     });
 
+    it("session_start uses Pi context arg for stable session ID", async () => {
+      await registerPiExtension(api);
+      const sessionFile = join(tempDir, "stable-session.jsonl");
+      const expectedSessionId = createHash("sha256")
+        .update(sessionFile)
+        .digest("hex")
+        .slice(0, 8);
+
+      await api._trigger(
+        "session_start",
+        { type: "session_start", reason: "startup" },
+        { sessionManager: { getSessionFile: () => sessionFile } },
+      );
+
+      const result = await api._getCommand("ctx-stats")!.handler!({});
+      expect((result as { text: string }).text).toContain(
+        `Session: \`${expectedSessionId}`,
+      );
+    });
+
     it("session_before_compact builds resume snapshot", async () => {
       await registerPiExtension(api);
 
@@ -522,7 +543,7 @@ describe("Pi Extension", () => {
   describe("Slice 7: Routing block injection", () => {
     it("injects <context_window_protection> on first before_agent_start", async () => {
       await registerPiExtension(api);
-      await api._trigger("session_start", {
+      await api._trigger("session_start", {}, {
         sessionManager: { getSessionFile: () => `routing-1-${Date.now()}-${Math.random()}` },
       });
 
@@ -536,7 +557,7 @@ describe("Pi Extension", () => {
 
     it("does not re-inject the routing block on subsequent calls", async () => {
       await registerPiExtension(api);
-      await api._trigger("session_start", {
+      await api._trigger("session_start", {}, {
         sessionManager: { getSessionFile: () => `routing-2-${Date.now()}-${Math.random()}` },
       });
 


### PR DESCRIPTION
   ## What / Why / How

   Fixes Pi extension session continuity.

   `session_start` now uses Pi's actual extension handler signature `(event, ctx)`, so the extension can read `ctx.sessionManager.getSessionFile()` and derive stable session IDs instead of timestamp fallback IDs
 like `pi-...`.

   Previously, the handler treated the first argument as `ctx`, but Pi passes the event first and context second. That made `ctx.sessionManager` unavailable and caused fragmented context-mode session records
 across Pi restarts/resumes.

   No issue opened; small bug fix found while verifying Pi session continuity.

   ## Affected platforms

   - [ ] Claude Code
   - [ ] Cursor
   - [ ] VS Code Copilot (GitHub Copilot)
   - [ ] JetBrains Copilot
   - [ ] Gemini CLI
   - [ ] Qwen Code
   - [ ] OpenCode
   - [ ] KiloCode
   - [ ] Codex CLI
   - [ ] OpenClaw (Pi Agent)
   - [x] Pi
   - [ ] Kiro
   - [ ] Antigravity
   - [ ] Zed
   - [ ] All platforms

   ## Test plan

   - Added focused regression coverage in `tests/pi-extension.test.ts` for Pi's `(event, ctx)` session_start signature and stable session ID derivation.
   - Updated existing routing-block tests that pass `sessionManager` so they use Pi's real `(event, ctx)` argument order.
   - Ran targeted Pi extension test:
     - `npm test -- --run tests/pi-extension.test.ts` → 37 passed
   - Ran full test suite after rebasing onto `next`:
     - `npm test` → 73 files passed, 2364 passed, 6 skipped
   - Ran typecheck:
     - `npm run typecheck` → passed
   - Live Pi smoke test:
     - Temporarily removed packaged `npm:context-mode`.
     - Started Pi with local extension: `pi -e ~/dev/context-mode/build/pi-extension.js`.
     - Verified latest `session_meta` row used stable hash ID (`a0c10175ed3d6d49`) with no matching `pi-...` fallback row at the same timestamp.

   ## Checklist

   - [x] Tests added/updated (TDD: red → green)
   - [x] `npm test` passes
   - [x] `npm run typecheck` passes
   - [x] Docs updated if needed (README, platform-support.md)
   - [x] No Windows path regressions (forward slashes only)
   - [x] Targets `next` branch (unless hotfix)

   <details>
   <summary><strong>Cross-platform notes</strong></summary>

   No path or hook path changes. This change only updates the Pi extension `session_start` handler signature and related test calls.

   </details>
