### PR TITLE
fix(routing): skip Bash nudge for structurally-bounded commands (#463)

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -161,13 +161,17 @@ const SAFE_COMMAND_PATTERNS = [
   /^readlink(?:\s+.+)?$/,
   /^basename(?:\s+.+)?$/,
   /^dirname(?:\s+.+)?$/,
-  // Filesystem ops (silent on success, errors on stderr only)
+  // Filesystem ops (silent on success, errors on stderr only).
+  // For cp / mv / rm we explicitly refuse `-v` / `--verbose`: verbose
+  // mode prints one line per file and can flood on big trees
+  // (recursive copy of /etc, mass rename, etc.). The "silent on
+  // success" invariant only holds without -v.
   /^cd(?:\s+.+)?$/,
   /^mkdir(?:\s+.+)?$/,
   /^touch\s+.+$/,
-  /^mv\s+.+$/,
-  /^cp\s+.+$/,
-  /^rm\s+.+$/,
+  /^mv(?!\s+-[a-zA-Z]*v\b)(?!\s+--verbose\b)\s+.+$/,
+  /^cp(?!\s+-[a-zA-Z]*v\b)(?!\s+--verbose\b)\s+.+$/,
+  /^rm(?!\s+-[a-zA-Z]*v\b)(?!\s+--verbose\b)\s+.+$/,
   // ls — refuse recursive (-R / --recursive) to keep output bounded.
   /^ls(?!\s+-[a-zA-Z]*R)(?!\s+--recursive)(?:\s+.+)?$/,
   // git read-only / status subcommands
@@ -187,7 +191,14 @@ const SAFE_COMMAND_PATTERNS = [
   /^\S+\s+-V(?:\s|$)/,
 ];
 
-const SHELL_CONTROL_OPERATORS = /[|`]|\$\(|>>|>|<(?!<)|&&|\|\||;/;
+// Bash shell control operators that can compose a safe command with an
+// unbounded sink. Any match disqualifies the command from the allowlist.
+//
+// Note `&` (single — background + sequence): listed BEFORE `&&` in the
+// alternation so the regex engine doesn't accidentally short-match `&&`
+// when `&` is itself a separator (`date & cat huge.log`). Without this,
+// `^date(?:\s+.+)?$` would match the whole string and bypass the gate.
+const SHELL_CONTROL_OPERATORS = /[|`]|\$\(|>>|>|<(?!<)|&(?!&)|&&|\|\||;/;
 
 /**
  * @param {string} command Raw Bash command string from the hook payload.

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -130,6 +130,78 @@ function stripQuotedContent(cmd) {
     .replace(/"[^"]*"/g, '""');                   // double-quoted strings
 }
 
+/**
+ * Built-in allowlist of structurally-bounded Bash commands (#463).
+ *
+ * The PreToolUse Bash nudge ("May produce large output. Use ctx_…") is
+ * tuned for unbounded commands like `find /` or `cat large-file`. On
+ * commands whose stdout is structurally bounded (system probes, version
+ * checks, simple git read subcommands), the nudge is pure noise — a
+ * recurring ~85 tokens that trains the agent to ignore the warning.
+ *
+ * isStructurallyBounded() returns true ONLY when the command:
+ *   1. Has no shell control operators (pipe, redirect, command
+ *      substitution, &&, ||, ;) — any of those can compose with an
+ *      unbounded command and re-introduce flooding.
+ *   2. Matches one of the conservative patterns below.
+ *
+ * Unknown commands are treated as unbounded (false) — fail-safe default.
+ */
+const SAFE_COMMAND_PATTERNS = [
+  // System probes (no stdout, or one short line)
+  /^pwd$/,
+  /^whoami$/,
+  /^hostname(?:\s+-[a-zA-Z]+)?$/,
+  /^date(?:\s+.+)?$/,
+  /^echo\s/,
+  /^printf\s/,
+  /^which\s+\S+(?:\s+\S+)*$/,
+  /^type\s+\S+(?:\s+\S+)*$/,
+  /^command\s+-v\s+\S+(?:\s+\S+)*$/,
+  /^readlink(?:\s+.+)?$/,
+  /^basename(?:\s+.+)?$/,
+  /^dirname(?:\s+.+)?$/,
+  // Filesystem ops (silent on success, errors on stderr only)
+  /^cd(?:\s+.+)?$/,
+  /^mkdir(?:\s+.+)?$/,
+  /^touch\s+.+$/,
+  /^mv\s+.+$/,
+  /^cp\s+.+$/,
+  /^rm\s+.+$/,
+  // ls — refuse recursive (-R / --recursive) to keep output bounded.
+  /^ls(?!\s+-[a-zA-Z]*R)(?!\s+--recursive)(?:\s+.+)?$/,
+  // git read-only / status subcommands
+  /^git\s+status(?:\s+.+)?$/,
+  /^git\s+rev-parse(?:\s+.+)?$/,
+  /^git\s+remote(?:\s+-v|\s+show\s+\S+)?$/,
+  /^git\s+branch(?:\s+.+)?$/,
+  /^git\s+config\s+--get(?:\s+.+)?$/,
+  /^git\s+diff\s+--stat(?:\s+.+)?$/,
+  /^git\s+diff\s+--name-only(?:\s+.+)?$/,
+  /^git\s+stash\s+list$/,
+  /^git\s+tag(?:\s+-l(?:\s+.+)?)?$/,
+  // git log only when explicitly bounded by -<N> with N up to two digits
+  /^git\s+log\s+-\d{1,2}(?:\s+.+)?$/,
+  // Version probes (--version anywhere, or `cmd -V`)
+  /(?:^|\s)--version(?:\s|$)/,
+  /^\S+\s+-V(?:\s|$)/,
+];
+
+const SHELL_CONTROL_OPERATORS = /[|`]|\$\(|>>|>|<(?!<)|&&|\|\||;/;
+
+/**
+ * @param {string} command Raw Bash command string from the hook payload.
+ * @returns {boolean} true when the command's output is bounded enough that
+ *   the routing nudge would be noise. Conservative — unknown commands
+ *   return false.
+ */
+export function isStructurallyBounded(command) {
+  if (!command) return false;
+  const trimmed = command.trim();
+  if (SHELL_CONTROL_OPERATORS.test(trimmed)) return false;
+  return SAFE_COMMAND_PATTERNS.some(rx => rx.test(trimmed));
+}
+
 // Try to import security module — may not exist
 let security = null;
 let securityInitFailed = false;
@@ -366,6 +438,14 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
           command: `echo "context-mode: Build tool redirected. Think in Code — use ${t("ctx_execute")}(language: \\"shell\\", code: \\"${safeCmd} 2>&1 | tail -30\\") to run and print only errors/summary. Do NOT retry with Bash."`,
         },
       });
+    }
+
+    // Skip the routing nudge for commands whose output is structurally
+    // bounded (#463) — pwd, whoami, git status, --version probes, etc.
+    // Conservative: any pipe/redirect/chain disqualifies, unknown commands
+    // still get the nudge.
+    if (isStructurallyBounded(command)) {
+      return null;
     }
 
     // allow all other Bash commands, but inject routing nudge (once per session)

--- a/tests/core/routing.test.ts
+++ b/tests/core/routing.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { routePreToolUse } from "../../hooks/core/routing.mjs";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  routePreToolUse,
+  resetGuidanceThrottle,
+  isStructurallyBounded,
+} from "../../hooks/core/routing.mjs";
 import { createRoutingBlock } from "../../hooks/routing-block.mjs";
 import { createToolNamer } from "../../hooks/core/tool-naming.mjs";
 
@@ -78,5 +82,137 @@ describe("Routing: Subagents (Agent only — Task removed per #241)", () => {
   it("TaskUpdate is NOT routed — returns null (passthrough)", () => {
     const decision = routePreToolUse("TaskUpdate", { id: "123", status: "done" }, "/test");
     expect(decision).toBeNull();
+  });
+});
+
+describe("Bash structurally-bounded allowlist (#463)", () => {
+  // Each test resets the guidance throttle so the per-session marker doesn't
+  // bleed across tests. The throttle is global to the routing module — without
+  // the reset, only the first bash test in the file would observe the nudge.
+  const SID = "issue-463-tests";
+  beforeEach(() => resetGuidanceThrottle(SID));
+
+  it("pwd / whoami / hostname / date — no nudge", () => {
+    for (const command of ["pwd", "whoami", "hostname", "hostname -f", "date", "date -Iseconds"]) {
+      resetGuidanceThrottle(SID);
+      const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
+      expect(decision, `expected null for ${command}`).toBeNull();
+    }
+  });
+
+  it("echo / printf / which / type / command -v — no nudge", () => {
+    for (const command of [
+      "echo hello",
+      "printf '%s' x",
+      "which node",
+      "type git",
+      "command -v gh",
+    ]) {
+      resetGuidanceThrottle(SID);
+      const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
+      expect(decision, `expected null for ${command}`).toBeNull();
+    }
+  });
+
+  it("git read-only subcommands — no nudge", () => {
+    for (const command of [
+      "git status",
+      "git status --short",
+      "git rev-parse HEAD",
+      "git remote -v",
+      "git remote show origin",
+      "git branch",
+      "git branch -vv",
+      "git config --get user.email",
+      "git diff --stat",
+      "git diff --name-only",
+      "git stash list",
+      "git tag",
+      "git tag -l 'v1.*'",
+      "git log -5",
+      "git log -10 --oneline",
+    ]) {
+      resetGuidanceThrottle(SID);
+      const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
+      expect(decision, `expected null for ${command}`).toBeNull();
+    }
+  });
+
+  it("--version / -V probes — no nudge", () => {
+    for (const command of [
+      "node --version",
+      "npm --version",
+      "git --version",
+      "node -V",
+    ]) {
+      resetGuidanceThrottle(SID);
+      const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
+      expect(decision, `expected null for ${command}`).toBeNull();
+    }
+  });
+
+  it("ls without -R is bounded; ls -R is unbounded", () => {
+    resetGuidanceThrottle(SID);
+    expect(routePreToolUse("Bash", { command: "ls" }, "/test", "claude-code", SID)).toBeNull();
+    resetGuidanceThrottle(SID);
+    expect(routePreToolUse("Bash", { command: "ls -la /etc" }, "/test", "claude-code", SID)).toBeNull();
+    resetGuidanceThrottle(SID);
+    // ls -R could flood — must still nudge
+    const lsR = routePreToolUse("Bash", { command: "ls -R /" }, "/test", "claude-code", SID);
+    expect(lsR?.action).toBe("context");
+    resetGuidanceThrottle(SID);
+    const lsLong = routePreToolUse("Bash", { command: "ls --recursive" }, "/test", "claude-code", SID);
+    expect(lsLong?.action).toBe("context");
+  });
+
+  it("unbounded commands still get the nudge", () => {
+    for (const command of [
+      "find /",
+      "cat /var/log/syslog",
+      "grep -r foo /etc",
+      "ps aux",
+      "git log",      // no -<N> bound
+      "git diff",     // raw diff can be huge
+    ]) {
+      resetGuidanceThrottle(SID);
+      const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
+      expect(decision?.action, `expected nudge for ${command}`).toBe("context");
+    }
+  });
+
+  it("safe command + shell control operator → still nudged (composition risk)", () => {
+    // A pipe, redirect, command substitution, or chain can attach an
+    // unbounded sink to an otherwise-safe command. The allowlist must
+    // refuse to short-circuit these — otherwise users can wrap floods
+    // behind a `pwd && cat huge`.
+    const cases = [
+      "pwd | xargs cat",
+      "pwd > /tmp/out",
+      "pwd >> /tmp/out",
+      "echo $(find /)",
+      "echo `find /`",
+      "git status && cat huge.log",
+      "git status || tail -F /var/log/syslog",
+      "whoami; find /",
+    ];
+    for (const command of cases) {
+      resetGuidanceThrottle(SID);
+      const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
+      expect(decision?.action, `expected nudge for ${command}`).toBe("context");
+    }
+  });
+
+  it("isStructurallyBounded — direct unit checks", () => {
+    expect(isStructurallyBounded("pwd")).toBe(true);
+    expect(isStructurallyBounded("git status")).toBe(true);
+    expect(isStructurallyBounded("node --version")).toBe(true);
+    expect(isStructurallyBounded("ls")).toBe(true);
+    expect(isStructurallyBounded("ls -R")).toBe(false);
+    expect(isStructurallyBounded("find /")).toBe(false);
+    expect(isStructurallyBounded("git log")).toBe(false);
+    expect(isStructurallyBounded("git log -5")).toBe(true);
+    expect(isStructurallyBounded("pwd | cat")).toBe(false);
+    expect(isStructurallyBounded("")).toBe(false);
+    expect(isStructurallyBounded(undefined as unknown as string)).toBe(false);
   });
 });

--- a/tests/core/routing.test.ts
+++ b/tests/core/routing.test.ts
@@ -194,11 +194,55 @@ describe("Bash structurally-bounded allowlist (#463)", () => {
       "git status && cat huge.log",
       "git status || tail -F /var/log/syslog",
       "whoami; find /",
+      // Single `&` (background + sequence) — distinct from `&&` and easy to
+      // miss in the operator regex. `date & cat huge.log` runs date in the
+      // background and immediately tails the unbounded sink.
+      "date & cat /var/log/syslog",
+      "whoami & find /",
+      "pwd & tail -F huge.log",
     ];
     for (const command of cases) {
       resetGuidanceThrottle(SID);
       const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
       expect(decision?.action, `expected nudge for ${command}`).toBe("context");
+    }
+  });
+
+  it("cp / mv / rm with -v / --verbose → still nudged (verbose floods on big trees)", () => {
+    // The "silent on success" invariant of cp/mv/rm only holds without -v.
+    // Verbose flag prints one line per file, which can flood on big trees
+    // (recursive copy of /etc, mass rename, etc.).
+    const cases = [
+      "cp -v /a /b",
+      "cp -rv /a /b",
+      "cp -v -r /etc /tmp",
+      "cp --verbose /a /b",
+      "mv -v /a /b",
+      "mv --verbose /a /b",
+      "rm -v /tmp/foo",
+      "rm -rv /tmp/foo",
+      "rm --verbose /tmp/foo",
+    ];
+    for (const command of cases) {
+      resetGuidanceThrottle(SID);
+      const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
+      expect(decision?.action, `expected nudge for ${command}`).toBe("context");
+    }
+  });
+
+  it("cp / mv / rm without -v → still allowlisted", () => {
+    // Sanity: the verbose carve-out must not regress the silent-success
+    // case, which is the whole reason these are in the allowlist.
+    for (const command of [
+      "cp /a /b",
+      "cp -r /a /b",
+      "mv /a /b",
+      "rm /tmp/foo",
+      "rm -rf /tmp/foo",
+    ]) {
+      resetGuidanceThrottle(SID);
+      const decision = routePreToolUse("Bash", { command }, "/test", "claude-code", SID);
+      expect(decision, `expected null for ${command}`).toBeNull();
     }
   });
 

--- a/tests/guidance-throttle.test.ts
+++ b/tests/guidance-throttle.test.ts
@@ -32,8 +32,11 @@ describe("guidance throttle", () => {
   });
 
   it("Bash: first call returns guidance, second returns null", () => {
-    const r1 = routePreToolUse("Bash", { command: "ls" }, PROJECT_DIR);
-    const r2 = routePreToolUse("Bash", { command: "pwd" }, PROJECT_DIR);
+    // npm install / find are unbounded — the structurally-bounded allowlist
+    // (#463) does NOT short-circuit them, so the throttle semantics still
+    // apply: guidance once, then null.
+    const r1 = routePreToolUse("Bash", { command: "npm install" }, PROJECT_DIR);
+    const r2 = routePreToolUse("Bash", { command: "find /" }, PROJECT_DIR);
 
     expect(r1?.action).toBe("context");
     expect(r2).toBeNull();
@@ -49,7 +52,10 @@ describe("guidance throttle", () => {
 
   it("throttle is per-type: Read throttle does not affect Bash or Grep", () => {
     const read1 = routePreToolUse("Read", { file_path: "/tmp/a.ts" }, PROJECT_DIR);
-    const bash1 = routePreToolUse("Bash", { command: "ls" }, PROJECT_DIR);
+    // Use unbounded commands so the #463 allowlist does not short-circuit
+    // the bash branch — we are validating per-type throttle independence,
+    // not the allowlist itself.
+    const bash1 = routePreToolUse("Bash", { command: "npm install" }, PROJECT_DIR);
     const grep1 = routePreToolUse("Grep", { pattern: "foo" }, PROJECT_DIR);
 
     // All first calls return guidance
@@ -59,7 +65,7 @@ describe("guidance throttle", () => {
 
     // All second calls return null
     const read2 = routePreToolUse("Read", { file_path: "/tmp/b.ts" }, PROJECT_DIR);
-    const bash2 = routePreToolUse("Bash", { command: "pwd" }, PROJECT_DIR);
+    const bash2 = routePreToolUse("Bash", { command: "find /" }, PROJECT_DIR);
     const grep2 = routePreToolUse("Grep", { pattern: "bar" }, PROJECT_DIR);
 
     expect(read2).toBeNull();
@@ -114,12 +120,12 @@ describe("guidance throttle", () => {
   });
 
   it("Bash passthrough returns null after guidance throttled (not context)", () => {
-    // First Bash fires guidance
-    const r1 = routePreToolUse("Bash", { command: "ls" }, PROJECT_DIR);
+    // Use unbounded commands so the #463 allowlist does not interfere —
+    // this test pins post-throttle null-vs-context, not allowlist behavior.
+    const r1 = routePreToolUse("Bash", { command: "npm install" }, PROJECT_DIR);
     expect(r1?.action).toBe("context");
 
-    // Second Bash should be null passthrough, not another context
-    const r2 = routePreToolUse("Bash", { command: "pwd" }, PROJECT_DIR);
+    const r2 = routePreToolUse("Bash", { command: "find /" }, PROJECT_DIR);
     expect(r2).toBeNull();
   });
 
@@ -203,7 +209,8 @@ describe("guidance throttle", () => {
       try { fs.writeFileSync(path.resolve(ppidDir, "bash"), "", "utf-8"); } catch {}
 
       // A sessionId-scoped call should NOT see the ppid marker — different namespace.
-      const r = routePreToolUse("Bash", { command: "ls" }, PROJECT_DIR, "claude-code", SESSION_A);
+      // Use an unbounded command so the #463 allowlist does not short-circuit it.
+      const r = routePreToolUse("Bash", { command: "npm install" }, PROJECT_DIR, "claude-code", SESSION_A);
       expect(r?.action).toBe("context");
     });
 

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -190,19 +190,19 @@ describe("routePreToolUse", () => {
       );
     });
 
-    it("allows git status with BASH_GUIDANCE context", () => {
+    it("git status — bypassed by structurally-bounded allowlist (#463)", () => {
+      // Pre-#463: this returned BASH_GUIDANCE context. The #463 allowlist
+      // now short-circuits the nudge for read-only git subcommands so the
+      // guidance reads as signal, not noise.
       const result = routePreToolUse("Bash", { command: "git status" });
-      expect(result).not.toBeNull();
-      expect(result!.action).toBe("context");
-      expect(result!.additionalContext).toBeDefined();
+      expect(result).toBeNull();
     });
 
-    it("allows mkdir with BASH_GUIDANCE context", () => {
+    it("mkdir — bypassed by structurally-bounded allowlist (#463)", () => {
       const result = routePreToolUse("Bash", {
         command: "mkdir -p /tmp/test-dir",
       });
-      expect(result).not.toBeNull();
-      expect(result!.action).toBe("context");
+      expect(result).toBeNull();
     });
 
     it("allows npm install with BASH_GUIDANCE context", () => {
@@ -247,8 +247,12 @@ describe("routePreToolUse", () => {
     });
 
     it("does not false-positive on gradle in quoted text", () => {
+      // Use a command whose first word is NOT in the #463 structurally-bounded
+      // allowlist (`echo` is allowlisted), so we still exercise the
+      // strip-quotes-then-match-gradle path. The intent is to prove the
+      // gradle build-tool redirect doesn't fire on quoted occurrences.
       const result = routePreToolUse("Bash", {
-        command: 'echo "run gradle build to compile"',
+        command: 'find . -name "run gradle build to compile"',
       });
       expect(result).not.toBeNull();
       // stripped version removes quoted content → no gradle match → context

--- a/tests/hooks/integration.test.ts
+++ b/tests/hooks/integration.test.ts
@@ -184,10 +184,14 @@ describe("Bash: Redirected Commands", () => {
 });
 
 describe("Bash: Allowed Commands", () => {
-  test("Bash + git status: additionalContext with BASH_GUIDANCE", () => {
+  // After #463 the Bash routing nudge is short-circuited for structurally-
+  // bounded commands (pwd, whoami, git status, mkdir, --version probes,
+  // etc.) — those return null. Use unbounded commands here so we still pin
+  // the "normal Bash command → context guidance" path end-to-end.
+  test("Bash + npm install: additionalContext with BASH_GUIDANCE", () => {
     const result = runHook({
       tool_name: "Bash",
-      tool_input: { command: "git status" },
+      tool_input: { command: "npm install" },
     });
     assert.equal(result.exitCode, 0);
     const parsed = JSON.parse(result.stdout);
@@ -198,10 +202,10 @@ describe("Bash: Allowed Commands", () => {
     );
   });
 
-  test("Bash + mkdir /tmp/test: additionalContext with BASH_GUIDANCE", () => {
+  test("Bash + find /: additionalContext with BASH_GUIDANCE", () => {
     const result = runHook({
       tool_name: "Bash",
-      tool_input: { command: "mkdir /tmp/test" },
+      tool_input: { command: "find /etc -name '*.conf'" },
     });
     assert.equal(result.exitCode, 0);
     const parsed = JSON.parse(result.stdout);
@@ -210,6 +214,17 @@ describe("Bash: Allowed Commands", () => {
       parsed.hookSpecificOutput.additionalContext.includes("<context_guidance>"),
       "Expected <context_guidance> in Bash additionalContext",
     );
+  });
+
+  test("Bash + git status: short-circuited by #463 allowlist (no nudge)", () => {
+    // Pre-#463 this returned BASH_GUIDANCE context. Now it short-circuits
+    // before the throttle: result is null and the hook emits nothing.
+    const result = runHook({
+      tool_name: "Bash",
+      tool_input: { command: "git status" },
+    });
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout.trim(), "", "Expected empty stdout — null decision should not emit a hook payload");
   });
 });
 
@@ -417,12 +432,16 @@ describe("Security Policy Enforcement", () => {
   });
 
   test("Security: Bash + git allowed, falls through to Stage 2", () => {
+    // Use an unbounded command — `git status` now short-circuits via the
+    // #463 allowlist before reaching the guidance branch, so it would no
+    // longer exercise "falls through to Stage 2 routing → context guidance".
     const result = runHook(
-      { tool_name: "Bash", tool_input: { command: "git status" } },
+      { tool_name: "Bash", tool_input: { command: "git diff" } },
       secEnv,
     );
     // git is in allow list -> falls through to Stage 2 routing
-    // Stage 2: git is not curl/wget/fetch -> additionalContext with BASH_GUIDANCE
+    // Stage 2: git diff is not in the structurally-bounded allowlist
+    // (raw diff can be huge) -> additionalContext with BASH_GUIDANCE
     assert.equal(result.exitCode, 0);
     const parsed = JSON.parse(result.stdout);
     assert.ok(parsed.hookSpecificOutput.additionalContext, "Allowed Bash command should get additionalContext");

--- a/tests/hooks/tool-naming.test.ts
+++ b/tests/hooks/tool-naming.test.ts
@@ -308,7 +308,10 @@ describe("routePreToolUse with platform parameter", () => {
   });
 
   it("Bash guidance uses openclaw bare names when platform=openclaw", () => {
-    const result = routePreToolUse("Bash", { command: "ls" }, "/tmp", "openclaw");
+    // Use an unbounded command so the #463 structurally-bounded allowlist
+    // does not short-circuit the guidance — this test is about platform
+    // tool-naming inside the guidance, not allowlist behavior.
+    const result = routePreToolUse("Bash", { command: "npm install" }, "/tmp", "openclaw");
     expect(result).not.toBeNull();
     expect(result!.action).toBe("context");
     expect(result!.additionalContext).toContain("ctx_batch_execute");
@@ -317,7 +320,7 @@ describe("routePreToolUse with platform parameter", () => {
   });
 
   it("OpenClaw lowercase native tools route through canonical aliases", () => {
-    const exec = routePreToolUse("exec", { command: "ls" }, "/tmp", "openclaw");
+    const exec = routePreToolUse("exec", { command: "npm install" }, "/tmp", "openclaw");
     expect(exec).not.toBeNull();
     expect(exec!.action).toBe("context");
     expect(exec!.additionalContext).toContain("ctx_batch_execute");

--- a/tests/hooks/vscode-hooks.test.ts
+++ b/tests/hooks/vscode-hooks.test.ts
@@ -175,9 +175,11 @@ describe("VS Code Copilot hooks", () => {
     });
 
     test("run_in_terminal: safe short command passes through with guidance", () => {
+      // Use an unbounded command — `git status` is now in the #463
+      // structurally-bounded allowlist and short-circuits the nudge.
       const result = runHook("pretooluse.mjs", {
         tool_name: "run_in_terminal",
-        tool_input: { command: "git status" },
+        tool_input: { command: "npm install" },
       }, vscodeEnv());
 
       expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## What

Fixes #463.

The PreToolUse Bash routing nudge ("May produce large output. Use ctx_…") fires on every Bash invocation that isn't otherwise redirected. Useful for `find /` or `cat huge-log` — pure noise for `pwd`, `whoami`, `git status`, or `--version` probes. ~85 tokens per nudge, and it trains the agent to ignore the warning where it actually matters.

This adds a built-in allowlist of structurally-bounded commands. When the command's first token matches a safe pattern AND no shell control operator is present (pipe, redirect, command substitution, `&&`, `||`, `;`), the nudge is short-circuited and routing returns null. Unknown commands still get the nudge — fail-safe default.

## Why

`isStructurallyBounded()` requires both:
1. Match against a conservative pattern list (per the issue's proposal).
2. No shell control operator anywhere — `pwd | xargs cat`, `git status && tail -F log`, `echo $(find /)` all bypass the short-circuit.

The shell-operator gate is the load-bearing safety net: any operator can compose a safe command with an unbounded sink, so the allowlist refuses to short-circuit them.

The user-extensible config tier (issue's second paragraph) is deferred to a follow-up to keep this PR scope tight to the structural-allowlist mechanism.

## Allowlist

- System probes: `pwd`, `whoami`, `hostname`, `date`, `echo`, `printf`, `which`, `type`, `command -v`, `readlink`, `basename`, `dirname`
- Silent fs ops: `cd`, `mkdir`, `touch`, `mv`, `cp`, `rm`
- `ls` (rejects `-R` / `--recursive`)
- Git read-only: `status`, `rev-parse`, `remote`, `branch`, `config --get`, `diff --stat`, `diff --name-only`, `stash list`, `tag`
- `git log -<N>` (digit-bounded only — raw `git log` still nudges)
- `--version` anywhere, `cmd -V`

## Coverage added (`tests/core/routing.test.ts`)

8 new test cases under `Bash structurally-bounded allowlist (#463)`:
- Each allowlist group (system probes / git read-only / version probes)
- `ls` without `-R` allowed; `ls -R` and `ls --recursive` still nudge
- Unbounded commands (`find /`, `cat`, `grep -r`, `ps aux`, `git log`, `git diff`) still nudge
- Composition guard — `pwd | cat`, `git status && cat huge.log`, `echo $(find /)` etc. all still nudge
- Direct unit checks of `isStructurallyBounded()`

Regression updates to existing tests that used now-allowlisted commands as proxies for "any non-routed Bash command":
- `tests/guidance-throttle.test.ts` — bash-throttle proxies switched from `ls` / `pwd` to `npm install` / `find /` so they keep exercising the throttle, not the new allowlist.
- `tests/hooks/core-routing.test.ts` — `git status` / `mkdir` cases flipped to the new "allowlisted → null" behavior; gradle-in-quotes test rewritten to use `find` so it still exercises the strip-quotes-then-no-match path.
- `tests/hooks/integration.test.ts` — `Bash + git status` / `Bash + mkdir` end-to-end tests replaced with `npm install` / `find` (unbounded) and a new positive test pinning that `git status` now emits empty stdout.
- `tests/hooks/tool-naming.test.ts` — openclaw bash-guidance proxies switched from `ls` to `npm install`.
- `tests/hooks/vscode-hooks.test.ts` — `run_in_terminal` probe switched from `git status` to `npm install`.

## Test plan

- [x] `npm run build`
- [x] `npm run typecheck` — clean
- [x] `npm test` — 73 files, **2408 pass / 25 skipped / 0 fail**
- [x] `npx vitest run tests/core/routing.test.ts` — 16 pass (8 pre-existing + 8 new)
- [x] `see-real-bug` repro: `pwd`, `whoami`, `git status`, `ls -la`, `echo hello`, `node --version` all fired the nudge on `next` @ `1f70bee`; after the fix all six return null. Repro artifact saved locally.

## Notes

- Targets `next` per CONTRIBUTING.md.
- No bundles committed (regenerated bundles reverted before commit).
- No new dependencies, no new test files.
