### PR TITLE
feat(ci): tier-2 E2E smoke scaffolding (#477)

### DIFF
--- a/.github/workflows/tier2-e2e-smoke.yml
+++ b/.github/workflows/tier2-e2e-smoke.yml
@@ -12,6 +12,10 @@
 #   - workflow_dispatch only for now (no cron until all hosts are stable)
 #   - ANTHROPIC_API_KEY must have a monthly spend cap configured at
 #     https://console.anthropic.com/settings/limits
+#   - Pinned to claude-haiku-4-5 — same family as Sonnet/Opus so tool-calling
+#     behavior tracks what real users hit, but ~5-10x cheaper per smoke run.
+#     Do NOT swap for Gemini/DeepSeek: tier-2 must test the model that ships,
+#     otherwise a passing smoke can hide a tool-routing regression in Claude.
 #   - max-tokens is capped per fixture run
 #   - concurrency cancels in-progress runs so reruns don't double-bill
 #   - 15 minute timeout per host
@@ -38,6 +42,10 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  # Pin Haiku 4.5 for tier-2: cheap enough for weekly cron without changing
+  # tool-call behavior vs. Sonnet/Opus. Override via workflow_dispatch input
+  # if a regression needs to be reproduced on a larger model.
+  ANTHROPIC_MODEL: "claude-haiku-4-5-20251001"
 
 jobs:
   pi:
@@ -84,6 +92,8 @@ jobs:
       - name: Run tier-2 smoke
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_MODEL: ${{ env.ANTHROPIC_MODEL }}
+          PI_MODEL: ${{ env.ANTHROPIC_MODEL }}
           PI_MAX_TOKENS: "2000"
         run: bash scripts/tier2-smoke/run-pi-smoke.sh
 

--- a/.github/workflows/tier2-e2e-smoke.yml
+++ b/.github/workflows/tier2-e2e-smoke.yml
@@ -1,0 +1,120 @@
+# Tier-2 E2E smoke for context-mode hosts (Pi / Claude Code / OpenCode).
+#
+# Tier-1 (mock harness, no LLM, free) lives in tests/pi-extension.test.ts and
+# runs on every PR via ci.yml. It catches "tools not registered", schema
+# regressions, MCP bridge framing bugs, and the #426 wiring gap.
+#
+# Tier-2 (this workflow) runs a REAL host binary against a REAL LLM with the
+# context-mode plugin installed, then asserts that ctx_* tools are actually
+# invoked and that ctx-stats reports a positive token saving.
+#
+# Costs money. Strict guard rails:
+#   - workflow_dispatch only for now (no cron until all hosts are stable)
+#   - ANTHROPIC_API_KEY must have a monthly spend cap configured at
+#     https://console.anthropic.com/settings/limits
+#   - max-tokens is capped per fixture run
+#   - concurrency cancels in-progress runs so reruns don't double-bill
+#   - 15 minute timeout per host
+#
+# See issue #477 for the full design.
+
+name: Tier-2 E2E Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      host:
+        description: "Which host(s) to smoke (comma-separated: pi, claude-code, opencode, all)"
+        required: false
+        default: "pi"
+  # Weekly cron will be enabled once all hosts are stable for two consecutive
+  # workflow_dispatch runs. Tracked in #477.
+  # schedule:
+  #   - cron: "0 6 * * 1"
+
+concurrency:
+  group: tier2-e2e-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  pi:
+    if: contains(github.event.inputs.host, 'pi') || github.event.inputs.host == 'all' || github.event.inputs.host == ''
+    runs-on: ubuntu-latest
+    name: tier2-smoke (pi)
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install dependencies and build
+        run: |
+          npm ci
+          npm run build
+          npm rebuild better-sqlite3
+
+      - name: Install Pi
+        run: |
+          # TODO(#477): pin a Pi version via env (e.g. PI_VERSION) once Pi
+          # publishes a stable installer matrix. For now we install latest
+          # and capture the version into the run log.
+          npm install -g pi-cli || true
+          if ! command -v pi >/dev/null 2>&1; then
+            echo "FATAL  Pi binary not on PATH after install" >&2
+            exit 2
+          fi
+          pi --version
+
+      - name: Install context-mode plugin into Pi
+        run: |
+          # Pi loads extensions from a per-user dir. The exact path depends
+          # on Pi's install layout; we follow the same pattern as the
+          # OpenClaw E2E (scripts/install-openclaw-plugin.sh). When Pi
+          # ships a documented install command this step becomes a one-liner.
+          PI_EXT_DIR="${HOME}/.pi/extensions/context-mode"
+          mkdir -p "$PI_EXT_DIR"
+          cp -r build/pi-extension.* "$PI_EXT_DIR/"
+
+      - name: Run tier-2 smoke
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PI_MAX_TOKENS: "2000"
+        run: bash scripts/tier2-smoke/run-pi-smoke.sh
+
+      - name: Upload Pi logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tier2-pi-logs
+          path: ${{ runner.temp }}/tier2-smoke-pi/
+          if-no-files-found: ignore
+
+  claude-code:
+    if: contains(github.event.inputs.host, 'claude-code') || github.event.inputs.host == 'all'
+    runs-on: ubuntu-latest
+    name: tier2-smoke (claude-code)
+    timeout-minutes: 15
+    steps:
+      - name: Placeholder
+        run: |
+          echo "Claude Code tier-2 smoke not yet implemented." >&2
+          echo "Tracked in #477. Land Pi first." >&2
+          exit 0
+
+  opencode:
+    if: contains(github.event.inputs.host, 'opencode') || github.event.inputs.host == 'all'
+    runs-on: ubuntu-latest
+    name: tier2-smoke (opencode)
+    timeout-minutes: 15
+    steps:
+      - name: Placeholder
+        run: |
+          echo "OpenCode tier-2 smoke not yet implemented." >&2
+          echo "Tracked in #477. Land Pi first." >&2
+          exit 0

--- a/scripts/tier2-smoke/assert-stats.mjs
+++ b/scripts/tier2-smoke/assert-stats.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Tier-2 smoke assertion.
+ *
+ * Reads a JSON `ctx-stats` payload from STDIN (or from $1) and asserts:
+ *   - At least one ctx_* tool was actually invoked (calls > 0)
+ *   - tokens_saved is a positive integer
+ *   - No tool reported an error
+ *
+ * Designed to be host-agnostic: Pi, Claude Code, OpenCode all emit
+ * `ctx-stats` JSON via the same MCP/extension surface, so the same
+ * assertion runs unchanged across the matrix.
+ *
+ * Exit code 0 on pass, 1 on fail. Output is plain text + the parsed
+ * payload, suitable for `tee` into the workflow log.
+ */
+
+import { readFileSync } from "node:fs";
+
+const REQUIRED_TOOLS = ["ctx_search", "ctx_execute", "ctx_index"];
+
+function loadPayload() {
+  const path = process.argv[2];
+  if (path && path !== "-") {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  }
+  const buf = readFileSync(0, "utf-8");
+  if (!buf.trim()) {
+    throw new Error("ctx-stats payload is empty (no stdin, no path)");
+  }
+  return JSON.parse(buf);
+}
+
+function assert(label, cond, detail) {
+  if (cond) {
+    console.log(`  PASS  ${label}`);
+    return 0;
+  }
+  console.error(`  FAIL  ${label}${detail ? " — " + detail : ""}`);
+  return 1;
+}
+
+function main() {
+  let payload;
+  try {
+    payload = loadPayload();
+  } catch (err) {
+    console.error(`FATAL  could not parse ctx-stats payload: ${err.message}`);
+    process.exit(2);
+  }
+
+  console.log("=== ctx-stats payload ===");
+  console.log(JSON.stringify(payload, null, 2));
+  console.log("=========================\n");
+
+  let failed = 0;
+  const tools = payload.tools ?? {};
+  const totalCalls = Object.values(tools).reduce(
+    (sum, t) => sum + (Number(t?.calls) || 0),
+    0,
+  );
+
+  failed += assert(
+    "at least one ctx_* tool invocation recorded",
+    totalCalls > 0,
+    `total calls = ${totalCalls}`,
+  );
+
+  for (const name of REQUIRED_TOOLS) {
+    const calls = Number(tools[name]?.calls) || 0;
+    failed += assert(
+      `${name} invoked at least once`,
+      calls > 0,
+      `calls = ${calls}`,
+    );
+  }
+
+  const tokensSaved = Number(payload.tokens_saved);
+  failed += assert(
+    "tokens_saved is a positive integer",
+    Number.isFinite(tokensSaved) && tokensSaved > 0,
+    `tokens_saved = ${payload.tokens_saved}`,
+  );
+
+  const errors = Number(payload.errors) || 0;
+  failed += assert(
+    "no tool reported an error",
+    errors === 0,
+    `errors = ${errors}`,
+  );
+
+  if (failed > 0) {
+    console.error(`\nTier-2 smoke FAILED (${failed} assertion(s)).`);
+    process.exit(1);
+  }
+  console.log("\nTier-2 smoke PASSED.");
+}
+
+main();

--- a/scripts/tier2-smoke/fixtures/search-corpus.txt
+++ b/scripts/tier2-smoke/fixtures/search-corpus.txt
@@ -1,6 +1,54 @@
-Index the README of this repository, then search the indexed corpus for the
-term "context-mode" and summarise the three top-ranked chunks. You MUST use
-the `ctx_index` tool to index the README, the `ctx_search` tool to retrieve
-the chunks, and `ctx_execute` to render the summary as JSON. Do not use any
-other tool for these steps. When done, print the result of `/ctx-stats` so
-the harness can verify token savings.
+You are running inside a tier-2 E2E smoke test for the context-mode plugin.
+The harness will read /ctx-stats afterwards and assert that ctx_index,
+ctx_search, and ctx_execute were each invoked at least once and that
+tokens_saved is strictly positive. The corpus below is intentionally large
+enough that a real indexing + search round-trip produces a measurable saving;
+do not skip steps and do not paraphrase the corpus from memory.
+
+Step 1 — Index the following project files in this exact order using the
+ctx_index tool. Each file MUST go through ctx_index, not Read:
+  - README.md
+  - CLAUDE.md
+  - package.json
+  - src/ (every TypeScript file under src/, recursive)
+  - tests/ (every test file under tests/, recursive)
+  - .github/workflows/ci.yml
+  - .github/workflows/tier2-e2e-smoke.yml
+
+Step 2 — Run the ctx_search tool with ALL of the following queries in a
+single batched call (queries array). Do not run them one-by-one:
+  1. "MCP tool registration for ctx_search ctx_execute ctx_index"
+  2. "tier-2 smoke workflow guard rails and spend cap"
+  3. "session-start hook context-mode initialization"
+  4. "tokens_saved calculation in ctx-stats payload"
+  5. "fixture corpus and assert-stats gating logic"
+  6. "Pi extension headless mode and prompt channel"
+  7. "concurrency cancel-in-progress and double-billing"
+
+Step 3 — Use the ctx_execute tool (language: javascript) to compute and
+print, as a single JSON object on stdout, the following fields derived from
+the search results above:
+  {
+    "queries_run": <integer count of distinct queries from step 2>,
+    "files_indexed": <integer count of distinct sources cited across results>,
+    "top_chunk_titles": <array of the top 5 chunk titles, deduplicated>,
+    "mentions_tier2": <boolean — true iff at least one result mentions tier-2>,
+    "mentions_ctx_search": <boolean — true iff ctx_search appears in any chunk>
+  }
+The JSON must be valid and parseable; do not wrap it in prose.
+
+Step 4 — Briefly summarise (max 3 sentences) what context-mode does, citing
+which indexed source each claim came from. Use only the search results, not
+prior knowledge of the codebase.
+
+Step 5 — Print the result of /ctx-stats so the harness can verify token
+savings. Do not modify, filter, or paraphrase the JSON payload — emit it
+verbatim on stdout.
+
+Hard constraints for this run:
+  - Do NOT use Read, Bash, WebFetch, or any non-ctx_* tool to satisfy
+    steps 1–3. Every file access MUST go through ctx_index/ctx_search.
+  - Do NOT shortcut step 2 by running fewer than 7 queries; the assertion
+    on tokens_saved depends on the indexed corpus being exercised.
+  - Do NOT skip step 3 even if step 2 returned the answer directly; the
+    smoke must observe a real ctx_execute call.

--- a/scripts/tier2-smoke/fixtures/search-corpus.txt
+++ b/scripts/tier2-smoke/fixtures/search-corpus.txt
@@ -1,0 +1,6 @@
+Index the README of this repository, then search the indexed corpus for the
+term "context-mode" and summarise the three top-ranked chunks. You MUST use
+the `ctx_index` tool to index the README, the `ctx_search` tool to retrieve
+the chunks, and `ctx_execute` to render the summary as JSON. Do not use any
+other tool for these steps. When done, print the result of `/ctx-stats` so
+the harness can verify token savings.

--- a/scripts/tier2-smoke/run-pi-smoke.sh
+++ b/scripts/tier2-smoke/run-pi-smoke.sh
@@ -24,10 +24,15 @@ PI_HEADLESS_FLAGS="${PI_HEADLESS_FLAGS:---headless}"
 FIXTURE="${FIXTURE:-$SMOKE_DIR/fixtures/search-corpus.txt}"
 STATS_OUT="$LOG_DIR/ctx-stats.json"
 PI_LOG="$LOG_DIR/pi.log"
+# Model is pinned in the workflow env (claude-haiku-4-5) and forwarded here
+# via PI_MODEL / ANTHROPIC_MODEL. We surface it in the log so a flaky run is
+# auditable against the exact model that produced it.
+PI_MODEL="${PI_MODEL:-${ANTHROPIC_MODEL:-}}"
 
 echo "=== Tier-2 smoke (Pi) ==="
 echo "Repo:    $REPO_ROOT"
 echo "Pi bin:  ${PI_BIN:-<not found>}"
+echo "Model:   ${PI_MODEL:-<provider default>}"
 echo "Fixture: $FIXTURE"
 echo "Logs:    $LOG_DIR"
 echo
@@ -57,7 +62,12 @@ echo
 # accidental over-spending if the model misbehaves.
 echo "--- Running fixture prompt ---"
 PROMPT="$(cat "$FIXTURE")"
+PI_MODEL_ARGS=()
+if [ -n "$PI_MODEL" ]; then
+  PI_MODEL_ARGS=(--model "$PI_MODEL")
+fi
 "$PI_BIN" $PI_HEADLESS_FLAGS \
+  "${PI_MODEL_ARGS[@]}" \
   --max-tokens "${PI_MAX_TOKENS:-2000}" \
   --prompt "$PROMPT" \
   2>&1 | tee -a "$PI_LOG"
@@ -68,12 +78,20 @@ echo
 # callable via the same `--prompt` channel with a `/ctx-stats --json` hint,
 # but we also fall back to invoking the bundled CLI directly if Pi cannot
 # emit JSON.
+#
+# IMPORTANT — the fallback is only valid because Pi and the bundled CLI both
+# read the same on-disk SQLite store under $HOME/.context-mode/. If a future
+# Pi release sandboxes its state to a per-extension directory, this fallback
+# will silently return an empty/zero payload and the assertion will fail in
+# a confusing way. If you change the Pi state path, either keep the bundled
+# CLI pointed at it via $CTX_STATE_DIR, or delete this fallback and fail
+# hard with "Pi /ctx-stats unsupported, skip" instead of masking.
 echo "--- Capturing ctx-stats ---"
 if "$PI_BIN" $PI_HEADLESS_FLAGS --prompt "/ctx-stats --json" \
    > "$STATS_OUT" 2>>"$PI_LOG"; then
   echo "ctx-stats captured via Pi /ctx-stats command"
 else
-  echo "Pi /ctx-stats failed — falling back to bundled CLI"
+  echo "Pi /ctx-stats failed — falling back to bundled CLI (shared state assumed)"
   node "$REPO_ROOT/cli.bundle.mjs" stats --json > "$STATS_OUT"
 fi
 echo

--- a/scripts/tier2-smoke/run-pi-smoke.sh
+++ b/scripts/tier2-smoke/run-pi-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Tier-2 smoke runner — Pi host.
+#
+# Boots a real Pi binary in headless mode, feeds it a fixture prompt that
+# forces use of ctx_search / ctx_execute / ctx_index, then captures the
+# `/ctx-stats` JSON payload and pipes it into assert-stats.mjs.
+#
+# Requires:
+#   - PI_BIN              path to the pi executable (default: $(which pi))
+#   - ANTHROPIC_API_KEY   model provider key, capped on the Anthropic console
+#   - PI_HEADLESS_FLAGS   any extra flags to pass to pi (default: --headless)
+#   - FIXTURE             prompt fixture path (default: fixtures/search-corpus.txt)
+#
+# Exit code 0 on pass, non-zero on fail.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SMOKE_DIR="$REPO_ROOT/scripts/tier2-smoke"
+LOG_DIR="${RUNNER_TEMP:-/tmp}/tier2-smoke-pi"
+mkdir -p "$LOG_DIR"
+
+PI_BIN="${PI_BIN:-$(command -v pi || true)}"
+PI_HEADLESS_FLAGS="${PI_HEADLESS_FLAGS:---headless}"
+FIXTURE="${FIXTURE:-$SMOKE_DIR/fixtures/search-corpus.txt}"
+STATS_OUT="$LOG_DIR/ctx-stats.json"
+PI_LOG="$LOG_DIR/pi.log"
+
+echo "=== Tier-2 smoke (Pi) ==="
+echo "Repo:    $REPO_ROOT"
+echo "Pi bin:  ${PI_BIN:-<not found>}"
+echo "Fixture: $FIXTURE"
+echo "Logs:    $LOG_DIR"
+echo
+
+if [ -z "${PI_BIN:-}" ] || [ ! -x "$PI_BIN" ]; then
+  echo "FATAL  Pi binary not found. Install Pi and set PI_BIN, or add it to PATH." >&2
+  exit 2
+fi
+
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "FATAL  ANTHROPIC_API_KEY not set. Configure it as a repo secret." >&2
+  exit 2
+fi
+
+if [ ! -f "$FIXTURE" ]; then
+  echo "FATAL  Fixture not found at $FIXTURE" >&2
+  exit 2
+fi
+
+# Sanity check: context-mode plugin must already be registered with Pi.
+# The workflow installs it via scripts/install-* before invoking this script.
+echo "--- Pi version ---"
+"$PI_BIN" --version 2>&1 | tee -a "$PI_LOG"
+echo
+
+# Run Pi headless on the fixture prompt. We force a hard token cap to avoid
+# accidental over-spending if the model misbehaves.
+echo "--- Running fixture prompt ---"
+PROMPT="$(cat "$FIXTURE")"
+"$PI_BIN" $PI_HEADLESS_FLAGS \
+  --max-tokens "${PI_MAX_TOKENS:-2000}" \
+  --prompt "$PROMPT" \
+  2>&1 | tee -a "$PI_LOG"
+echo
+
+# Ask Pi for the structured ctx-stats payload. The Pi extension exposes
+# /ctx-stats as a registered command; in headless mode it should be
+# callable via the same `--prompt` channel with a `/ctx-stats --json` hint,
+# but we also fall back to invoking the bundled CLI directly if Pi cannot
+# emit JSON.
+echo "--- Capturing ctx-stats ---"
+if "$PI_BIN" $PI_HEADLESS_FLAGS --prompt "/ctx-stats --json" \
+   > "$STATS_OUT" 2>>"$PI_LOG"; then
+  echo "ctx-stats captured via Pi /ctx-stats command"
+else
+  echo "Pi /ctx-stats failed — falling back to bundled CLI"
+  node "$REPO_ROOT/cli.bundle.mjs" stats --json > "$STATS_OUT"
+fi
+echo
+
+# Assert.
+echo "--- Assertions ---"
+node "$SMOKE_DIR/assert-stats.mjs" "$STATS_OUT"

--- a/tests/tier2-smoke-assert.test.ts
+++ b/tests/tier2-smoke-assert.test.ts
@@ -1,0 +1,115 @@
+import "./setup-home";
+/**
+ * Tier-2 smoke assertion script — unit coverage.
+ *
+ * The assert-stats.mjs script is the gating logic for the tier-2 workflow:
+ * if it accepts a payload that does not actually prove ctx_* usage, the
+ * weekly smoke goes green on a regression. We therefore exercise it as a
+ * black-box CLI with synthetic ctx-stats payloads.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const SCRIPT = join(here, "..", "scripts", "tier2-smoke", "assert-stats.mjs");
+
+function runAssert(payload: unknown): { code: number; stdout: string; stderr: string } {
+  const dir = mkdtempSync(join(tmpdir(), "tier2-assert-"));
+  const path = join(dir, "stats.json");
+  writeFileSync(path, JSON.stringify(payload), "utf-8");
+  const r = spawnSync("node", [SCRIPT, path], { encoding: "utf-8" });
+  return {
+    code: r.status ?? -1,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? "",
+  };
+}
+
+describe("tier-2 assert-stats.mjs", () => {
+  beforeAll(() => {
+    // Sanity: script must exist before we try to spawn it.
+    const probe = spawnSync("node", [SCRIPT, "--help"], { encoding: "utf-8" });
+    // The script does not implement --help, but the spawn itself should
+    // succeed (exit non-zero, but not ENOENT).
+    expect(probe.error).toBeUndefined();
+  });
+
+  it("passes on a healthy payload with all required tools used", () => {
+    const r = runAssert({
+      tokens_saved: 1234,
+      errors: 0,
+      tools: {
+        ctx_search: { calls: 3 },
+        ctx_execute: { calls: 1 },
+        ctx_index: { calls: 2 },
+      },
+    });
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Tier-2 smoke PASSED");
+  });
+
+  it("fails when no ctx_* tool was invoked", () => {
+    const r = runAssert({
+      tokens_saved: 0,
+      errors: 0,
+      tools: {},
+    });
+    expect(r.code).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/at least one ctx_\* tool invocation/);
+  });
+
+  it("fails when tokens_saved is zero or missing", () => {
+    const r = runAssert({
+      // tokens_saved omitted on purpose
+      errors: 0,
+      tools: {
+        ctx_search: { calls: 1 },
+        ctx_execute: { calls: 1 },
+        ctx_index: { calls: 1 },
+      },
+    });
+    expect(r.code).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/tokens_saved/);
+  });
+
+  it("fails when ctx_search was never called even if other tools ran", () => {
+    const r = runAssert({
+      tokens_saved: 100,
+      errors: 0,
+      tools: {
+        ctx_execute: { calls: 5 },
+        ctx_index: { calls: 5 },
+      },
+    });
+    expect(r.code).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/ctx_search invoked at least once/);
+  });
+
+  it("fails when the host reported tool errors", () => {
+    const r = runAssert({
+      tokens_saved: 500,
+      errors: 2,
+      tools: {
+        ctx_search: { calls: 1 },
+        ctx_execute: { calls: 1 },
+        ctx_index: { calls: 1 },
+      },
+    });
+    expect(r.code).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/no tool reported an error/);
+  });
+
+  it("exits with code 2 on malformed JSON instead of silently passing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "tier2-assert-bad-"));
+    const path = join(dir, "bad.json");
+    writeFileSync(path, "{not json", "utf-8");
+    const r = spawnSync("node", [SCRIPT, path], { encoding: "utf-8" });
+    expect(r.status).toBe(2);
+    expect(r.stderr).toMatch(/could not parse/);
+  });
+});


### PR DESCRIPTION
## Summary

Lands the scaffolding for the tier-2 E2E smoke workflow proposed in #477. Tier-1 mock harness (no LLM, no API key) is already in place via `tests/pi-extension.test.ts`. This PR adds the missing tier-2 layer: a real host binary running a real LLM with the context-mode plugin installed, with strict cost guard rails.

Closes #477 once Pi goes green twice in a row.

## What this PR does

- `.github/workflows/tier2-e2e-smoke.yml` — `workflow_dispatch`-only matrix (`pi`, `claude-code`, `opencode`). Concurrency cancels in-progress runs so reruns don't double-bill. 15-minute timeout per host. Max-tokens cap on every fixture run. Cron stays commented out until all three hosts are stable for two consecutive manual runs.
- `scripts/tier2-smoke/run-pi-smoke.sh` — boots Pi headless on a fixture prompt that forces `ctx_index` + `ctx_search` + `ctx_execute` usage, captures the `ctx-stats` JSON, falls back to the bundled CLI if Pi cannot emit JSON directly.
- `scripts/tier2-smoke/assert-stats.mjs` — host-agnostic assertion CLI. Same script gates Pi, Claude Code, and OpenCode. Fails if any required `ctx_*` tool was not invoked, if `tokens_saved` is not positive, or if any tool reported an error.
- `scripts/tier2-smoke/fixtures/search-corpus.txt` — the prompt, pinned in-repo so a future change to the fixture is reviewable.
- `tests/tier2-smoke-assert.test.ts` — black-box vitest coverage for the assertion script (6 tests: healthy payload, no tool calls, missing `tokens_saved`, missing `ctx_search`, reported errors, malformed JSON). Runs as part of tier-1 CI on every PR, so a regression in the gating logic is caught before any tier-2 run is scheduled.

## Why this PR is intentionally narrow

Pi lands first to validate the architecture. The `claude-code` and `opencode` jobs are placeholders that exit 0 with a pointer to #477. They become real jobs in follow-up PRs once Pi is stable.

The federated-fork canary network discussed in #477 (each maintainer running tier-2 with their own key, posting back to a central issue) is **not** part of this PR. We only escalate to that design if the centralised free-tier minutes budget is not enough — measure first, federate later.

## Cost guard rails

- `workflow_dispatch` only — no automatic runs until #477 declares the matrix stable
- `ANTHROPIC_API_KEY` repo secret with monthly spend cap configured at https://console.anthropic.com/settings/limits (linked from the workflow header)
- `PI_MAX_TOKENS=2000` per fixture run
- `concurrency.cancel-in-progress: true`
- `timeout-minutes: 15` per host

## Test plan

- [x] `npx vitest run tests/tier2-smoke-assert.test.ts` — 6/6 passing locally
- [x] YAML syntax validated (`python3 -c yaml.safe_load`)
- [x] Scripts marked executable
- [ ] After merge: maintainer triggers `Tier-2 E2E Smoke` via `workflow_dispatch` with `host=pi` and a valid `ANTHROPIC_API_KEY` secret
- [ ] After two consecutive green Pi runs: enable cron and remove the `claude-code` / `opencode` placeholders by following up with their respective PRs

## Related

- Refs #426 (Pi `pi.registerTool()` bridge — the bug tier-1 already covers)
- Refs #45 (manual QA gap that motivates tier-2)
- Closes #477 once the matrix is fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)