### PR TITLE
feat(adapters): add OMP (Oh My Pi) platform adapter (#473)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ src/
     opencode/      → OpenCode adapter
     codex/         → Codex CLI adapter
     vscode-copilot/ → VS Code Copilot adapter
+    omp/           → OMP (Oh My Pi) adapter — MCP-only, isolated ~/.omp/ storage (#473)
   openclaw/
     workspace-router.ts → Workspace path resolution for Pi Agent sessions
   openclaw-plugin.ts   → OpenClaw gateway plugin entry (sync register)

--- a/README.md
+++ b/README.md
@@ -807,6 +807,45 @@ Full configs: [`configs/kiro/mcp.json`](configs/kiro/mcp.json) | [`configs/kiro/
 </details>
 
 <details>
+<summary><strong>OMP (Oh My Pi)</strong> — MCP-only, isolated storage under <code>~/.omp/</code></summary>
+
+**Prerequisites:** Node.js 18+, [Oh My Pi](https://github.com/can1357/oh-my-pi) installed.
+
+**Install:**
+
+1. Install context-mode globally:
+
+   ```bash
+   npm install -g context-mode
+   ```
+
+2. Add to `~/.omp/agent/mcp_config.json` (or `$OMP_PROCESSING_AGENT_DIR/mcp_config.json` if the env var is set):
+
+   ```json
+   {
+     "mcpServers": {
+       "context-mode": {
+         "command": "context-mode"
+       }
+     }
+   }
+   ```
+
+3. Copy routing instructions (OMP has no hook support):
+
+   ```bash
+   cp node_modules/context-mode/configs/omp/PI.md ./PI.md
+   ```
+
+4. Restart OMP.
+
+**Verify:** In an OMP session, type `ctx stats`. Context-mode tools should appear and respond.
+
+**Routing:** Manual. The `PI.md` file is the only enforcement method (~60% compliance). Auto-detected via `OMP_PROCESSING_AGENT_DIR` env var or presence of `~/.omp/` directory. Storage roots at `~/.omp/context-mode/` so OMP and Pi installs do not share session DBs, content indices, or stats files.
+
+</details>
+
+<details>
 <summary><strong>Build Prerequisites</strong> <sup>(CentOS, RHEL, Alpine)</sup></summary>
 
 Context Mode uses [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) on Node.js, which ships prebuilt native binaries for most platforms. On glibc >= 2.31 systems (Ubuntu 20.04+, Debian 11+, Fedora 34+, macOS, Windows), `npm install` works without any build tools.
@@ -927,16 +966,16 @@ Context Mode captures every meaningful event during your session and persists th
 
 Session continuity requires 5 hooks working together:
 
-| Hook | Role | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | KiloCode | OpenClaw | Codex CLI | Antigravity | Kiro | Zed | Pi |
-|---|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **PreToolUse** | Enforces sandbox routing before tool execution | Yes | -- | -- | -- | Yes | -- | -- | -- | Yes | -- | Yes | -- | ✓ (via tool_call event) |
-| **PostToolUse** | Captures events after each tool call | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | ✓ (via tool_result event) |
-| **UserPromptSubmit** | Captures user decisions and corrections | Yes | -- | -- | -- | -- | Plugin (via chat.message) | Plugin (via chat.message) | -- | Yes | -- | -- | -- | -- |
-| **PreCompact** | Builds snapshot before compaction | Yes | Yes | Yes | Yes | -- | Plugin | Plugin | Plugin | -- | -- | -- | -- | ✓ (via session_before_compact) |
-| **SessionStart** | Restores state after compaction or resume | Yes | Yes | Yes | Yes | -- | ✓ (via experimental.chat.system.transform) | ✓ (via experimental.chat.system.transform) | Plugin | Yes | -- | -- | -- | ✓ (via session_start event) |
-| | **Session completeness** | **Full** | **High** | **High** | **High** | **Partial** | **Full** | **Full** | **High** | **Partial** | **--** | **Partial** | **--** | **High** |
+| Hook | Role | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | KiloCode | OpenClaw | Codex CLI | Antigravity | Kiro | Zed | Pi | OMP |
+|---|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **PreToolUse** | Enforces sandbox routing before tool execution | Yes | -- | -- | -- | Yes | -- | -- | -- | Yes | -- | Yes | -- | ✓ (via tool_call event) | -- |
+| **PostToolUse** | Captures events after each tool call | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | ✓ (via tool_result event) | -- |
+| **UserPromptSubmit** | Captures user decisions and corrections | Yes | -- | -- | -- | -- | Plugin (via chat.message) | Plugin (via chat.message) | -- | Yes | -- | -- | -- | -- | -- |
+| **PreCompact** | Builds snapshot before compaction | Yes | Yes | Yes | Yes | -- | Plugin | Plugin | Plugin | -- | -- | -- | -- | ✓ (via session_before_compact) | -- |
+| **SessionStart** | Restores state after compaction or resume | Yes | Yes | Yes | Yes | -- | ✓ (via experimental.chat.system.transform) | ✓ (via experimental.chat.system.transform) | Plugin | Yes | -- | -- | -- | ✓ (via session_start event) | -- |
+| | **Session completeness** | **Full** | **High** | **High** | **High** | **Partial** | **Full** | **Full** | **High** | **Partial** | **--** | **Partial** | **--** | **High** | **--** |
 
-> **Note:** Full session continuity (capture + snapshot + restore) works on **Claude Code**, **Gemini CLI**, **VS Code Copilot**, **JetBrains Copilot**, **OpenCode**, and **KiloCode**. **OpenCode** and **KiloCode** use `experimental.chat.system.transform` as a SessionStart surrogate to inject the routing block and restore prior sessions, plus `chat.message` for user-prompt capture; full SessionStart hook support is not yet available ([#14808](https://github.com/sst/opencode/issues/14808), [#5409](https://github.com/sst/opencode/issues/5409)), but prior-session continuity and user-decision capture work fully. **Cursor** captures tool events via `preToolUse`/`postToolUse`, but `sessionStart` is currently rejected by Cursor's validator ([forum report](https://forum.cursor.com/t/unknown-hook-type-sessionstart/149566)), so session restore after compaction is not available yet. **OpenClaw** uses native gateway plugin hooks (`api.on()`) for full session continuity. **Pi Coding Agent** provides high session continuity via extension hooks (`tool_call`, `tool_result`, `session_start`, `session_before_compact`). **Codex CLI** provides partial hook-based session tracking through PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, and Stop; MCP tools work. **Antigravity**, **Kiro**, and **Zed** have no hook support in the current release, so session tracking is not available.
+> **Note:** Full session continuity (capture + snapshot + restore) works on **Claude Code**, **Gemini CLI**, **VS Code Copilot**, **JetBrains Copilot**, **OpenCode**, and **KiloCode**. **OpenCode** and **KiloCode** use `experimental.chat.system.transform` as a SessionStart surrogate to inject the routing block and restore prior sessions, plus `chat.message` for user-prompt capture; full SessionStart hook support is not yet available ([#14808](https://github.com/sst/opencode/issues/14808), [#5409](https://github.com/sst/opencode/issues/5409)), but prior-session continuity and user-decision capture work fully. **Cursor** captures tool events via `preToolUse`/`postToolUse`, but `sessionStart` is currently rejected by Cursor's validator ([forum report](https://forum.cursor.com/t/unknown-hook-type-sessionstart/149566)), so session restore after compaction is not available yet. **OpenClaw** uses native gateway plugin hooks (`api.on()`) for full session continuity. **Pi Coding Agent** provides high session continuity via extension hooks (`tool_call`, `tool_result`, `session_start`, `session_before_compact`). **Codex CLI** provides partial hook-based session tracking through PreToolUse, PostToolUse, SessionStart, UserPromptSubmit, and Stop; MCP tools work. **Antigravity**, **Kiro**, and **Zed** have no hook support in the current release, so session tracking is not available. **OMP** (Oh My Pi) is also MCP-only and has no hook support — its dedicated adapter exists to keep storage isolated under `~/.omp/context-mode/` rather than leaking into another platform's directory.
 
 <details>
 <summary><strong>What gets captured</strong></summary>
@@ -1045,22 +1084,24 @@ Detailed event data is also indexed into FTS5 for on-demand retrieval via `ctx_s
 
 **Pi Coding Agent** — High coverage. The extension registers all key lifecycle events: `tool_call` (PreToolUse), `tool_result` (PostToolUse), `session_start` (SessionStart), and `session_before_compact` (PreCompact). File edits, git ops, errors, and tasks are fully tracked. Session restore after compaction works via the extension's event hooks.
 
+**OMP (Oh My Pi)** — No session support. MCP-only paradigm; no hook integration. The dedicated adapter exists so OMP storage roots cleanly under `~/.omp/context-mode/` instead of leaking into another platform's directory (issue [#473](https://github.com/mksglu/context-mode/issues/473)). Auto-detected via `OMP_PROCESSING_AGENT_DIR` env var or presence of `~/.omp/`.
+
 </details>
 
 ## Platform Compatibility
 
-| Feature | Claude Code | Qwen Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | KiloCode | OpenClaw | Codex CLI | Antigravity | Kiro | Zed | Pi |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| MCP Server | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| PreToolUse Hook | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | Yes (extension) |
-| PostToolUse Hook | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | Yes (extension) |
-| SessionStart Hook | Yes | Yes | Yes | Yes | Yes | -- | ✓ (via experimental.chat.system.transform) | ✓ (via experimental.chat.system.transform) | Plugin | Yes | -- | -- | -- | Yes (extension) |
-| PreCompact Hook | Yes | Yes | Yes | Yes | Yes | -- | Plugin | Plugin | Plugin | -- | -- | -- | -- | Yes (extension) |
-| Can Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | -- | -- | -- | -- | Yes (extension) |
-| Can Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | Yes (extension) |
-| Utility Commands (ctx) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes (/ctx-stats, /ctx-doctor) |
-| Slash Commands | Yes | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
-| Plugin Marketplace | Yes | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| Feature | Claude Code | Qwen Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | KiloCode | OpenClaw | Codex CLI | Antigravity | Kiro | Zed | Pi | OMP |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| MCP Server | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| PreToolUse Hook | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | Yes (extension) | -- |
+| PostToolUse Hook | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | Yes (extension) | -- |
+| SessionStart Hook | Yes | Yes | Yes | Yes | Yes | -- | ✓ (via experimental.chat.system.transform) | ✓ (via experimental.chat.system.transform) | Plugin | Yes | -- | -- | -- | Yes (extension) | -- |
+| PreCompact Hook | Yes | Yes | Yes | Yes | Yes | -- | Plugin | Plugin | Plugin | -- | -- | -- | -- | Yes (extension) | -- |
+| Can Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | -- | -- | -- | -- | Yes (extension) | -- |
+| Can Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Plugin | Plugin | Plugin | Yes | -- | Yes | -- | Yes (extension) | -- |
+| Utility Commands (ctx) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes (/ctx-stats, /ctx-doctor) | Yes |
+| Slash Commands | Yes | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| Plugin Marketplace | Yes | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
 
 > **OpenCode** uses a TypeScript plugin paradigm — hooks run as in-process functions via `tool.execute.before`, `tool.execute.after`, `experimental.session.compacting`, `experimental.chat.system.transform`, and `chat.message`, providing full routing enforcement, session continuity, and user-prompt capture. The `experimental.chat.system.transform` hook acts as a SessionStart surrogate to inject the routing block and restore prior sessions. The `chat.message` hook captures user prompts and decisions (UserPromptSubmit equivalent).
 >
@@ -1073,12 +1114,14 @@ Detailed event data is also indexed into FTS5 for on-demand retrieval via `ctx_s
 > **Kiro** supports native `preToolUse` and `postToolUse` hooks for routing enforcement and tool event capture. `agentSpawn` (SessionStart equivalent) and `stop` are not yet wired. Requires manually copying `KIRO.md` to your project root. Kiro is auto-detected via MCP protocol handshake (`clientInfo.name`).
 >
 > **Pi Coding Agent** runs context-mode as an extension with full hook support. The extension registers `tool_call`, `tool_result`, `session_start`, and `session_before_compact` events, providing high session continuity coverage. The MCP server provides all 11 MCP tools.
+>
+> **OMP (Oh My Pi)** is MCP-only — no hook integration. The dedicated adapter exists to keep storage isolated under `~/.omp/context-mode/` rather than leaking into another harness's directory. Auto-detected via `OMP_PROCESSING_AGENT_DIR` (default `~/.omp/agent`) or `~/.omp/` directory. See [issue #473](https://github.com/mksglu/context-mode/issues/473).
 
 ### Routing Enforcement
 
 Hooks intercept tool calls programmatically — they can block dangerous commands and redirect them to the sandbox before execution. Instruction files guide the model via prompt instructions but cannot block anything. **Always enable hooks where supported.**
 
-> **Note:** Routing instruction files were previously auto-written to project directories on first session start. This was disabled to prevent git tree pollution ([#158](https://github.com/mksglu/context-mode/issues/158), [#164](https://github.com/mksglu/context-mode/issues/164)). Hook-capable platforms (Claude Code, Gemini CLI, VS Code Copilot, JetBrains Copilot, Cursor, OpenCode, OpenClaw, Codex CLI) inject routing via hooks and need no file. Non-hook platforms (Zed, Kiro, Antigravity) require a one-time manual copy — see each platform's install section.
+> **Note:** Routing instruction files were previously auto-written to project directories on first session start. This was disabled to prevent git tree pollution ([#158](https://github.com/mksglu/context-mode/issues/158), [#164](https://github.com/mksglu/context-mode/issues/164)). Hook-capable platforms (Claude Code, Gemini CLI, VS Code Copilot, JetBrains Copilot, Cursor, OpenCode, OpenClaw, Codex CLI) inject routing via hooks and need no file. Non-hook platforms (Zed, Kiro, Antigravity, OMP) require a one-time manual copy — see each platform's install section.
 
 | Platform | Hooks | Instruction File | With Hooks | Without Hooks |
 |---|:---:|---|:---:|:---:|

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -4,13 +4,13 @@ This document provides a comprehensive comparison of all platforms supported by 
 
 ## Overview
 
-context-mode supports twelve platforms across three hook paradigms:
+context-mode supports thirteen platforms across three hook paradigms:
 
 | Paradigm | Platforms |
 |----------|-----------|
 | **JSON stdin/stdout** | Claude Code, Gemini CLI, VS Code Copilot, JetBrains Copilot, Cursor, Codex CLI, Qwen Code |
 | **TS Plugin** | OpenCode, OpenClaw |
-| **MCP-only** | Antigravity, Kiro, Zed |
+| **MCP-only** | Antigravity, Kiro, Zed, OMP (Oh My Pi) |
 
 The MCP server layer is 100% portable and needs no adapter. Only the hook layer requires platform-specific adapters.
 
@@ -32,22 +32,22 @@ This puts the `context-mode` binary in PATH, which is required for:
 
 ## Main Comparison Table
 
-| Feature | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | Codex CLI | Antigravity | Kiro |
-|---------|-------------|------------|-----------------|-------------------|--------|----------|-----------|-------------|------|
-| **Paradigm** | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | ts-plugin | json-stdio | mcp-only | mcp-only |
-| **PreToolUse equivalent** | `PreToolUse` | `BeforeTool` | `PreToolUse` | `PreToolUse` | `preToolUse` | `tool.execute.before` | `PreToolUse` | -- | -- |
-| **PostToolUse equivalent** | `PostToolUse` | `AfterTool` | `PostToolUse` | `PostToolUse` | `postToolUse` | `tool.execute.after` | `PostToolUse` | -- | -- |
-| **PreCompact equivalent** | `PreCompact` | `PreCompress` | `PreCompact` | `PreCompact` | -- | `experimental.session.compacting` | -- | -- | -- |
-| **SessionStart** | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | -- (buggy in Cursor) | -- | `SessionStart` | -- | -- |
-| **Stop equivalent** | -- | -- | `Stop` | `Stop` | `stop` | -- | `Stop` | -- | -- |
-| **Can modify args** | Yes | Yes | Yes | Yes | Yes | Yes | No | -- | -- |
-| **Can modify output** | Yes | Yes | Yes | Yes | No | Yes (caveat) | No | -- | -- |
-| **Can inject session context** | Yes | Yes | Yes | Yes | Yes | -- | Yes | -- | -- |
-| **Can block tools** | Yes | Yes | Yes | Yes | Yes | Yes (throw) | Yes | -- | -- |
-| **Config location** | `~/.claude/settings.json` | `~/.gemini/settings.json` | `.github/hooks/*.json` | `.github/hooks/*.json` | `.cursor/hooks.json` or `~/.cursor/hooks.json` | `opencode.json` | `~/.codex/hooks.json` + `~/.codex/config.toml` | `~/.gemini/antigravity/mcp_config.json` | `~/.kiro/settings/mcp.json` |
-| **Session ID field** | `session_id` | `session_id` | `sessionId` (camelCase) | `sessionId` (camelCase) | `conversation_id` | `sessionID` (camelCase) | N/A | N/A | N/A |
-| **Project dir env** | `CLAUDE_PROJECT_DIR` | `GEMINI_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | stdin `workspace_roots` | `ctx.directory` (plugin init) | N/A | N/A | N/A |
-| **MCP tool naming** | `mcp__server__tool` | `mcp__server__tool` | `f1e_` prefix | `f1e_` prefix | `MCP:<tool>` in hook payloads | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` |
+| Feature | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | Codex CLI | Antigravity | Kiro | OMP |
+|---------|-------------|------------|-----------------|-------------------|--------|----------|-----------|-------------|------|-----|
+| **Paradigm** | json-stdio | json-stdio | json-stdio | json-stdio | json-stdio | ts-plugin | json-stdio | mcp-only | mcp-only | mcp-only |
+| **PreToolUse equivalent** | `PreToolUse` | `BeforeTool` | `PreToolUse` | `PreToolUse` | `preToolUse` | `tool.execute.before` | `PreToolUse` | -- | -- | -- |
+| **PostToolUse equivalent** | `PostToolUse` | `AfterTool` | `PostToolUse` | `PostToolUse` | `postToolUse` | `tool.execute.after` | `PostToolUse` | -- | -- | -- |
+| **PreCompact equivalent** | `PreCompact` | `PreCompress` | `PreCompact` | `PreCompact` | -- | `experimental.session.compacting` | -- | -- | -- | -- |
+| **SessionStart** | `SessionStart` | `SessionStart` | `SessionStart` | `SessionStart` | -- (buggy in Cursor) | -- | `SessionStart` | -- | -- | -- |
+| **Stop equivalent** | -- | -- | `Stop` | `Stop` | `stop` | -- | `Stop` | -- | -- | -- |
+| **Can modify args** | Yes | Yes | Yes | Yes | Yes | Yes | No | -- | -- | -- |
+| **Can modify output** | Yes | Yes | Yes | Yes | No | Yes (caveat) | No | -- | -- | -- |
+| **Can inject session context** | Yes | Yes | Yes | Yes | Yes | -- | Yes | -- | -- | -- |
+| **Can block tools** | Yes | Yes | Yes | Yes | Yes | Yes (throw) | Yes | -- | -- | -- |
+| **Config location** | `~/.claude/settings.json` | `~/.gemini/settings.json` | `.github/hooks/*.json` | `.github/hooks/*.json` | `.cursor/hooks.json` or `~/.cursor/hooks.json` | `opencode.json` | `~/.codex/hooks.json` + `~/.codex/config.toml` | `~/.gemini/antigravity/mcp_config.json` | `~/.kiro/settings/mcp.json` | `~/.omp/agent/mcp_config.json` |
+| **Session ID field** | `session_id` | `session_id` | `sessionId` (camelCase) | `sessionId` (camelCase) | `conversation_id` | `sessionID` (camelCase) | N/A | N/A | N/A | N/A |
+| **Project dir env** | `CLAUDE_PROJECT_DIR` | `GEMINI_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | `CLAUDE_PROJECT_DIR` | stdin `workspace_roots` | `ctx.directory` (plugin init) | N/A | N/A | N/A | `OMP_PROCESSING_AGENT_DIR` |
+| **MCP tool naming** | `mcp__server__tool` | `mcp__server__tool` | `f1e_` prefix | `f1e_` prefix | `MCP:<tool>` in hook payloads | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` | `mcp__server__tool` |
 | **Hook command format** | `context-mode hook claude-code <event>` | `context-mode hook gemini-cli <event>` | `context-mode hook vscode-copilot <event>` | `context-mode hook jetbrains-copilot <event>` | `context-mode hook cursor <event>` | TS plugin (no command) | `context-mode hook codex <event>` | N/A | N/A |
 | **Hook registration** | settings.json hooks object | settings.json hooks object | `.github/hooks/*.json` | `.github/hooks/*.json` | `hooks.json` native hook arrays | opencode.json plugin array | `~/.codex/hooks.json` | N/A | N/A |
 | **MCP server command** | `context-mode` (or plugin auto) | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` | `context-mode` |
@@ -600,20 +600,60 @@ The hook adapter exists only to satisfy the interface contract — every parser 
 
 ---
 
+### OMP (Oh My Pi)
+
+**Status:** MCP-only (no hooks)
+
+**Hook Paradigm:** MCP-only
+
+[Oh My Pi (OMP)](https://github.com/can1357/oh-my-pi) is a Pi-compatible harness that stores its agent state under `~/.omp/agent/` (overridable via `OMP_PROCESSING_AGENT_DIR`). Before the dedicated adapter, OMP detection fell through to `pi` and storage rooted under another harness's directory (typically `~/.claude/`), per [issue #473](https://github.com/mksglu/context-mode/issues/473). The OMP adapter exists primarily to keep `~/.omp/context-mode/` isolated, not to provide hook integration — OMP, like Antigravity/Kiro/Zed, runs context-mode purely as an MCP server.
+
+**Hook Support:**
+- PreToolUse: --
+- PostToolUse: --
+- PreCompact: --
+- SessionStart: --
+- Stop: --
+- Can modify args: --
+- Can modify output: --
+- Can inject session context: --
+
+The hook adapter exists only to satisfy the interface contract — every parser throws `Error("OMP does not support hooks")` and every formatter returns `undefined`.
+
+**Path Resolution:**
+- Agent root: `$OMP_PROCESSING_AGENT_DIR` if set, else `~/.omp/agent/`
+- Settings file: `<agent root>/mcp_config.json`
+- MCP registration: `mcpServers` object inside `mcp_config.json`
+- Session dir: `~/.omp/context-mode/sessions/` (intentionally rooted at `~/.omp/`, not the agent dir, so multiple OMP instances on one host share an index without colliding session DBs)
+- Routing instructions: `PI.md` (Pi-compatible filename — OMP shares the Pi instruction surface)
+
+**Detection (priority order, listed BEFORE `pi` so OMP is never misclassified):**
+- `OMP_PROCESSING_AGENT_DIR` env var (high confidence)
+- `~/.omp/` directory presence (medium confidence)
+- `CONTEXT_MODE_PLATFORM=omp` override
+
+**Notes / Caveats:**
+- No hook adapter implies no automatic routing — the model must follow `PI.md` voluntarily (~60% compliance)
+- No marketplace or plugin registry for OMP; `getInstalledVersion()` reports `not installed` unless an `extensions/context-mode/package.json` exists under the agent dir
+- `validateHooks` always returns a single `warn` row reminding the user that OMP exposes only MCP integration
+- `configureAllHooks`, `setHookPermissions`, and `updatePluginRegistry` are intentional no-ops
+
+---
+
 ## Capability Matrix (Quick Reference)
 
-| Capability | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | Codex CLI | Antigravity | Kiro |
-|-----------|:-----------:|:----------:|:---------------:|:-----------------:|:------:|:--------:|:---------:|:-----------:|:----:|
-| PreToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes*** | -- | -- |
-| PostToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- |
-| PreCompact | Yes | Yes | Yes | Yes | -- | Yes* | -- | -- | -- |
-| SessionStart | Yes | Yes | Yes | Yes | Yes | -- | Yes | -- | -- |
-| Stop | -- | -- | Yes | Yes | Yes | -- | Yes | -- | -- |
-| Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | -- |
-| Modify Output | Yes | Yes | Yes | Yes | No | Yes** | -- | -- | -- |
-| Inject Context | Yes | Yes | Yes | Yes | Yes | -- | Yes | -- | -- |
-| Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- |
-| MCP Support | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Capability | Claude Code | Gemini CLI | VS Code Copilot | JetBrains Copilot | Cursor | OpenCode | Codex CLI | Antigravity | Kiro | OMP |
+|-----------|:-----------:|:----------:|:---------------:|:-----------------:|:------:|:--------:|:---------:|:-----------:|:----:|:---:|
+| PreToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes*** | -- | -- | -- |
+| PostToolUse | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | -- |
+| PreCompact | Yes | Yes | Yes | Yes | -- | Yes* | -- | -- | -- | -- |
+| SessionStart | Yes | Yes | Yes | Yes | Yes | -- | Yes | -- | -- | -- |
+| Stop | -- | -- | Yes | Yes | Yes | -- | Yes | -- | -- | -- |
+| Modify Args | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | -- | -- |
+| Modify Output | Yes | Yes | Yes | Yes | No | Yes** | -- | -- | -- | -- |
+| Inject Context | Yes | Yes | Yes | Yes | Yes | -- | Yes | -- | -- | -- |
+| Block Tools | Yes | Yes | Yes | Yes | Yes | Yes | Yes | -- | -- | -- |
+| MCP Support | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 
 \* OpenCode `experimental.session.compacting` is experimental
 \*\* OpenCode has a TUI rendering bug for bash tool output (#13575)

--- a/src/adapters/detect.ts
+++ b/src/adapters/detect.ts
@@ -67,6 +67,10 @@ export const PLATFORM_ENV_VARS = [
   // qwen-code — QWEN_PROJECT_DIR per QwenLM/qwen-code docs/users/features/hooks.md.
   // (QWEN_SESSION_ID removed — 0 hits in qwen-code repository.)
   ["qwen-code",          ["QWEN_PROJECT_DIR"]],
+  // omp (Pi-compatible harness — can1357/oh-my-pi). OMP_PROCESSING_AGENT_DIR
+  // is the published config root override (defaults to ~/.omp/agent). Listed
+  // BEFORE pi so OMP is not misclassified as Pi when both are installed.
+  ["omp",                ["OMP_PROCESSING_AGENT_DIR"]],
   // pi — PI_PROJECT_DIR consumed by src/adapters/pi/extension.ts:154 + src/server.ts:153
   // — implies the Pi runtime sets it before invoking the extension.
   ["pi",                 ["PI_PROJECT_DIR"]],
@@ -96,6 +100,7 @@ export function getSessionDirSegments(platform: string): string[] | null {
     case "vscode-copilot":   return [".vscode"];
     case "kiro":             return [".kiro"];
     case "pi":               return [".pi"];
+    case "omp":              return [".omp"];
     case "qwen-code":        return [".qwen"];
     case "kilo":             return [".config", "kilo"];
     case "opencode":         return [".config", "opencode"];
@@ -137,7 +142,7 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
   if (platformOverride) {
     const validPlatforms: PlatformId[] = [
       "claude-code", "gemini-cli", "kilo", "opencode", "codex",
-      "vscode-copilot", "jetbrains-copilot", "cursor", "antigravity", "kiro", "pi", "zed", "qwen-code",
+      "vscode-copilot", "jetbrains-copilot", "cursor", "antigravity", "kiro", "pi", "omp", "zed", "qwen-code",
     ];
     if (validPlatforms.includes(platformOverride as PlatformId)) {
       return {
@@ -201,6 +206,15 @@ export function detectPlatform(clientInfo?: { name: string; version?: string }):
       platform: "kiro",
       confidence: "medium",
       reason: "~/.kiro/ directory exists",
+    };
+  }
+
+  // OMP listed BEFORE pi: shared ~/.pi history with OMP-only ~/.omp/ marker.
+  if (existsSync(resolve(home, ".omp"))) {
+    return {
+      platform: "omp",
+      confidence: "medium",
+      reason: "~/.omp/ directory exists",
     };
   }
 
@@ -336,6 +350,11 @@ export async function getAdapter(platform?: PlatformId): Promise<HookAdapter> {
     case "qwen-code": {
       const { QwenCodeAdapter } = await import("./qwen-code/index.js");
       return new QwenCodeAdapter();
+    }
+
+    case "omp": {
+      const { OMPAdapter } = await import("./omp/index.js");
+      return new OMPAdapter();
     }
 
     default: {

--- a/src/adapters/omp/index.ts
+++ b/src/adapters/omp/index.ts
@@ -1,0 +1,233 @@
+/**
+ * adapters/omp — Oh My Pi (OMP) platform adapter.
+ *
+ * Implements HookAdapter for OMP's MCP-only paradigm.
+ *
+ * OMP hook specifics:
+ *   - NO hook support (MCP-only — OMP integrates via MCP, not stdin hooks)
+ *   - Config: ~/.omp/agent/mcp_config.json (JSON format)
+ *   - MCP: full support via mcpServers in mcp_config.json
+ *   - All capabilities are false — MCP is the only integration path
+ *   - Session dir: ~/.omp/context-mode/sessions/  (parallel to ~/.claude/, ~/.pi/)
+ *   - Routing file: PI.md (OMP is Pi-compatible — same instruction filename)
+ *
+ * Why a dedicated adapter rather than reusing pi:
+ *   OMP and Pi share a runtime surface but different storage roots
+ *   (`~/.omp/agent/` vs `~/.pi/`). Without an OMP adapter, OMP users
+ *   running through a Claude-installed harness silently land their
+ *   context-mode data under `~/.claude/context-mode/` (issue #473).
+ *
+ * Sources:
+ *   - OMP source: https://github.com/can1357/oh-my-pi
+ *   - OMP_PROCESSING_AGENT_DIR config root override (defaults to ~/.omp/agent)
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+
+import { BaseAdapter } from "../base.js";
+
+import type {
+  HookAdapter,
+  HookParadigm,
+  PlatformCapabilities,
+  DiagnosticResult,
+  PreToolUseEvent,
+  PostToolUseEvent,
+  PreCompactEvent,
+  SessionStartEvent,
+  PreToolUseResponse,
+  PostToolUseResponse,
+  PreCompactResponse,
+  SessionStartResponse,
+  HookRegistration,
+} from "../types.js";
+
+// ─────────────────────────────────────────────────────────
+// Adapter implementation
+// ─────────────────────────────────────────────────────────
+
+export class OMPAdapter extends BaseAdapter implements HookAdapter {
+  constructor() {
+    super([".omp"]);
+  }
+
+  readonly name = "OMP";
+  readonly paradigm: HookParadigm = "mcp-only";
+
+  readonly capabilities: PlatformCapabilities = {
+    preToolUse: false,
+    postToolUse: false,
+    preCompact: false,
+    sessionStart: false,
+    canModifyArgs: false,
+    canModifyOutput: false,
+    canInjectSessionContext: false,
+  };
+
+  // ── Input parsing ──────────────────────────────────────
+  // OMP does not support hooks. These methods exist to satisfy the
+  // interface contract but will throw if called.
+
+  parsePreToolUseInput(_raw: unknown): PreToolUseEvent {
+    throw new Error("OMP does not support hooks");
+  }
+
+  parsePostToolUseInput(_raw: unknown): PostToolUseEvent {
+    throw new Error("OMP does not support hooks");
+  }
+
+  parsePreCompactInput(_raw: unknown): PreCompactEvent {
+    throw new Error("OMP does not support hooks");
+  }
+
+  parseSessionStartInput(_raw: unknown): SessionStartEvent {
+    throw new Error("OMP does not support hooks");
+  }
+
+  // ── Response formatting ────────────────────────────────
+  // OMP does not support hooks. Return undefined for all responses.
+
+  formatPreToolUseResponse(_response: PreToolUseResponse): unknown {
+    return undefined;
+  }
+
+  formatPostToolUseResponse(_response: PostToolUseResponse): unknown {
+    return undefined;
+  }
+
+  formatPreCompactResponse(_response: PreCompactResponse): unknown {
+    return undefined;
+  }
+
+  formatSessionStartResponse(_response: SessionStartResponse): unknown {
+    return undefined;
+  }
+
+  // ── Configuration ──────────────────────────────────────
+
+  /**
+   * Resolve OMP agent root, honoring `OMP_PROCESSING_AGENT_DIR` when set
+   * (the upstream OMP convention) and falling back to `~/.omp/agent`.
+   */
+  private getAgentDir(): string {
+    return process.env.OMP_PROCESSING_AGENT_DIR
+      ?? resolve(homedir(), ".omp", "agent");
+  }
+
+  getSettingsPath(): string {
+    return resolve(this.getAgentDir(), "mcp_config.json");
+  }
+
+  /**
+   * OMP nests its config under the agent dir. Always absolute.
+   * `_projectDir` accepted for interface symmetry but unused — home-rooted.
+   */
+  getConfigDir(_projectDir?: string): string {
+    return this.getAgentDir();
+  }
+
+  getInstructionFiles(): string[] {
+    return ["PI.md"];
+  }
+
+  generateHookConfig(_pluginRoot: string): HookRegistration {
+    return {};
+  }
+
+  readSettings(): Record<string, unknown> | null {
+    try {
+      const raw = readFileSync(this.getSettingsPath(), "utf-8");
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  writeSettings(settings: Record<string, unknown>): void {
+    const settingsPath = this.getSettingsPath();
+    mkdirSync(dirname(settingsPath), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
+  }
+
+  // ── Diagnostics (doctor) ─────────────────────────────────
+
+  validateHooks(_pluginRoot: string): DiagnosticResult[] {
+    return [
+      {
+        check: "Hook support",
+        status: "warn",
+        message:
+          "OMP does not support hooks. " +
+          "Only MCP integration is available.",
+      },
+    ];
+  }
+
+  checkPluginRegistration(): DiagnosticResult {
+    try {
+      const raw = readFileSync(this.getSettingsPath(), "utf-8");
+      const config = JSON.parse(raw);
+      const mcpServers = (config as { mcpServers?: Record<string, unknown> })?.mcpServers ?? {};
+
+      if ("context-mode" in mcpServers) {
+        return {
+          check: "MCP registration",
+          status: "pass",
+          message: "context-mode found in mcpServers config",
+        };
+      }
+
+      return {
+        check: "MCP registration",
+        status: "fail",
+        message: "context-mode not found in mcpServers",
+        fix: `Add context-mode to mcpServers in ${this.getSettingsPath()}`,
+      };
+    } catch {
+      return {
+        check: "MCP registration",
+        status: "warn",
+        message: `Could not read ${this.getSettingsPath()}`,
+      };
+    }
+  }
+
+  getInstalledVersion(): string {
+    try {
+      const pkgPath = resolve(
+        this.getAgentDir(),
+        "extensions",
+        "context-mode",
+        "package.json",
+      );
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      return pkg.version ?? "unknown";
+    } catch {
+      return "not installed";
+    }
+  }
+
+  // ── Upgrade ────────────────────────────────────────────
+
+  configureAllHooks(_pluginRoot: string): string[] {
+    return [];
+  }
+
+  setHookPermissions(_pluginRoot: string): string[] {
+    return [];
+  }
+
+  updatePluginRegistry(_pluginRoot: string, _version: string): void {
+    // OMP plugin registry is managed via mcp_config.json
+  }
+
+  getRoutingInstructions(): string {
+    return "# context-mode\n\nUse context-mode MCP tools (execute, execute_file, batch_execute, fetch_and_index, search) instead of run_command/view_file for data-heavy operations.";
+  }
+}

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -346,6 +346,7 @@ export type PlatformId =
   | "antigravity"
   | "kiro"
   | "pi"
+  | "omp"
   | "zed"
   | "qwen-code"
   | "unknown";

--- a/tests/adapters/detect.test.ts
+++ b/tests/adapters/detect.test.ts
@@ -11,6 +11,7 @@ import { AntigravityAdapter } from "../../src/adapters/antigravity/index.js";
 import { KiroAdapter } from "../../src/adapters/kiro/index.js";
 import { QwenCodeAdapter } from "../../src/adapters/qwen-code/index.js";
 import { JetBrainsCopilotAdapter } from "../../src/adapters/jetbrains-copilot/index.js";
+import { OMPAdapter } from "../../src/adapters/omp/index.js";
 
 // ─────────────────────────────────────────────────────────
 // detectPlatform — env var detection
@@ -40,6 +41,7 @@ describe("detectPlatform", () => {
     delete process.env.VSCODE_PID;
     delete process.env.VSCODE_CWD;
     delete process.env.QWEN_PROJECT_DIR;
+    delete process.env.OMP_PROCESSING_AGENT_DIR;
     delete process.env.IDEA_INITIAL_DIRECTORY;
     delete process.env.IDEA_HOME;
     delete process.env.JETBRAINS_CLIENT_ID;
@@ -158,6 +160,26 @@ describe("detectPlatform", () => {
     process.env.PI_PROJECT_DIR = "/some/project";
     const signal = detectPlatform();
     expect(signal.platform).toBe("pi");
+    expect(signal.confidence).toBe("high");
+  });
+
+  // ── OMP (Oh My Pi) ──────────────────────────────────────
+  // OMP_PROCESSING_AGENT_DIR is the published OMP config root override
+  // (defaults to ~/.omp/agent). Listed BEFORE pi in PLATFORM_ENV_VARS so an
+  // OMP-running harness is not misclassified as Pi when both are installed.
+
+  it("detects omp via OMP_PROCESSING_AGENT_DIR env var", () => {
+    process.env.OMP_PROCESSING_AGENT_DIR = "/home/user/.omp/agent";
+    const signal = detectPlatform();
+    expect(signal.platform).toBe("omp");
+    expect(signal.confidence).toBe("high");
+  });
+
+  it("prefers omp over pi when both OMP_PROCESSING_AGENT_DIR and PI_PROJECT_DIR are set", () => {
+    process.env.OMP_PROCESSING_AGENT_DIR = "/home/user/.omp/agent";
+    process.env.PI_PROJECT_DIR = "/some/project";
+    const signal = detectPlatform();
+    expect(signal.platform).toBe("omp");
     expect(signal.confidence).toBe("high");
   });
 
@@ -329,7 +351,7 @@ describe("detectPlatform", () => {
   it("returns a valid platform as default when no env vars are set", () => {
     // No env vars set — result depends on which config dirs exist on this machine.
     const signal = detectPlatform();
-    expect(["claude-code", "gemini-cli", "codex", "cursor", "opencode", "kilo", "openclaw", "vscode-copilot", "antigravity", "kiro", "pi", "zed", "qwen-code", "jetbrains-copilot"]).toContain(signal.platform);
+    expect(["claude-code", "gemini-cli", "codex", "cursor", "opencode", "kilo", "openclaw", "vscode-copilot", "antigravity", "kiro", "pi", "omp", "zed", "qwen-code", "jetbrains-copilot"]).toContain(signal.platform);
   });
 });
 
@@ -397,6 +419,11 @@ describe("getAdapter", () => {
   it("returns JetBrainsCopilotAdapter for jetbrains-copilot", async () => {
     const adapter = await getAdapter("jetbrains-copilot");
     expect(adapter).toBeInstanceOf(JetBrainsCopilotAdapter);
+  });
+
+  it("returns OMPAdapter for omp", async () => {
+    const adapter = await getAdapter("omp");
+    expect(adapter).toBeInstanceOf(OMPAdapter);
   });
 
   it("returns ClaudeCodeAdapter for unknown platform", async () => {

--- a/tests/adapters/omp.test.ts
+++ b/tests/adapters/omp.test.ts
@@ -1,0 +1,180 @@
+import "../setup-home";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { OMPAdapter } from "../../src/adapters/omp/index.js";
+
+describe("OMPAdapter", () => {
+  let adapter: OMPAdapter;
+  let savedAgentDir: string | undefined;
+
+  beforeEach(() => {
+    savedAgentDir = process.env.OMP_PROCESSING_AGENT_DIR;
+    delete process.env.OMP_PROCESSING_AGENT_DIR;
+    adapter = new OMPAdapter();
+  });
+
+  afterEach(() => {
+    if (savedAgentDir === undefined) {
+      delete process.env.OMP_PROCESSING_AGENT_DIR;
+    } else {
+      process.env.OMP_PROCESSING_AGENT_DIR = savedAgentDir;
+    }
+  });
+
+  // ── Identity ───────────────────────────────────────────
+
+  describe("identity", () => {
+    it("name is OMP", () => {
+      expect(adapter.name).toBe("OMP");
+    });
+
+    it("paradigm is mcp-only", () => {
+      expect(adapter.paradigm).toBe("mcp-only");
+    });
+  });
+
+  // ── Capabilities ──────────────────────────────────────
+
+  describe("capabilities", () => {
+    it("all capabilities are false", () => {
+      expect(adapter.capabilities.preToolUse).toBe(false);
+      expect(adapter.capabilities.postToolUse).toBe(false);
+      expect(adapter.capabilities.preCompact).toBe(false);
+      expect(adapter.capabilities.sessionStart).toBe(false);
+      expect(adapter.capabilities.canModifyArgs).toBe(false);
+      expect(adapter.capabilities.canModifyOutput).toBe(false);
+      expect(adapter.capabilities.canInjectSessionContext).toBe(false);
+    });
+  });
+
+  // ── Parse methods (all throw) ─────────────────────────
+
+  describe("parse methods", () => {
+    it("parsePreToolUseInput throws", () => {
+      expect(() => adapter.parsePreToolUseInput({})).toThrow(
+        /OMP does not support hooks/,
+      );
+    });
+
+    it("parsePostToolUseInput throws", () => {
+      expect(() => adapter.parsePostToolUseInput({})).toThrow(
+        /OMP does not support hooks/,
+      );
+    });
+
+    it("parsePreCompactInput throws", () => {
+      expect(() => adapter.parsePreCompactInput({})).toThrow(
+        /OMP does not support hooks/,
+      );
+    });
+
+    it("parseSessionStartInput throws", () => {
+      expect(() => adapter.parseSessionStartInput({})).toThrow(
+        /OMP does not support hooks/,
+      );
+    });
+  });
+
+  // ── Format methods (all return undefined) ─────────────
+
+  describe("format methods", () => {
+    it("formatPreToolUseResponse returns undefined", () => {
+      expect(
+        adapter.formatPreToolUseResponse({ decision: "deny", reason: "test" }),
+      ).toBeUndefined();
+    });
+
+    it("formatPostToolUseResponse returns undefined", () => {
+      expect(
+        adapter.formatPostToolUseResponse({ additionalContext: "test" }),
+      ).toBeUndefined();
+    });
+
+    it("formatPreCompactResponse returns undefined", () => {
+      expect(
+        adapter.formatPreCompactResponse({ context: "test" }),
+      ).toBeUndefined();
+    });
+
+    it("formatSessionStartResponse returns undefined", () => {
+      expect(
+        adapter.formatSessionStartResponse({ context: "test" }),
+      ).toBeUndefined();
+    });
+  });
+
+  // ── Hook config (all empty) ───────────────────────────
+
+  describe("hook config", () => {
+    it("generateHookConfig returns empty object", () => {
+      expect(adapter.generateHookConfig("/some/plugin/root")).toEqual({});
+    });
+
+    it("configureAllHooks returns empty array", () => {
+      expect(adapter.configureAllHooks("/some/plugin/root")).toEqual([]);
+    });
+
+    it("setHookPermissions returns empty array", () => {
+      expect(adapter.setHookPermissions("/some/plugin/root")).toEqual([]);
+    });
+  });
+
+  // ── Config paths ──────────────────────────────────────
+  // The OMP fix for issue #473 — verifies storage roots NEVER bleed into
+  // ~/.claude/, regardless of which harness installed context-mode.
+
+  describe("config paths", () => {
+    it("session dir is under ~/.omp/context-mode/sessions/", () => {
+      expect(adapter.getSessionDir()).toBe(
+        join(homedir(), ".omp", "context-mode", "sessions"),
+      );
+    });
+
+    it("session DB path contains project hash and lives under .omp", () => {
+      const dbPath = adapter.getSessionDBPath("/test/project");
+      expect(dbPath).toMatch(/[a-f0-9]{16}\.db$/);
+      expect(dbPath).toContain(".omp");
+      expect(dbPath).not.toContain(".claude");
+    });
+
+    it("session events path contains project hash and lives under .omp", () => {
+      const eventsPath = adapter.getSessionEventsPath("/test/project");
+      expect(eventsPath).toMatch(/[a-f0-9]{16}-events\.md$/);
+      expect(eventsPath).toContain(".omp");
+      expect(eventsPath).not.toContain(".claude");
+    });
+
+    it("default settings path is ~/.omp/agent/mcp_config.json", () => {
+      expect(adapter.getSettingsPath()).toBe(
+        resolve(homedir(), ".omp", "agent", "mcp_config.json"),
+      );
+    });
+
+    it("default config dir is ~/.omp/agent", () => {
+      expect(adapter.getConfigDir()).toBe(
+        resolve(homedir(), ".omp", "agent"),
+      );
+    });
+
+    it("OMP_PROCESSING_AGENT_DIR overrides settings path", () => {
+      process.env.OMP_PROCESSING_AGENT_DIR = "/custom/omp/agent";
+      expect(adapter.getSettingsPath()).toBe(
+        resolve("/custom/omp/agent", "mcp_config.json"),
+      );
+    });
+
+    it("OMP_PROCESSING_AGENT_DIR overrides config dir", () => {
+      process.env.OMP_PROCESSING_AGENT_DIR = "/custom/omp/agent";
+      expect(adapter.getConfigDir()).toBe("/custom/omp/agent");
+    });
+  });
+
+  // ── Instruction file ──────────────────────────────────
+
+  describe("instruction files", () => {
+    it("uses PI.md (Pi-compatible)", () => {
+      expect(adapter.getInstructionFiles()).toEqual(["PI.md"]);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a dedicated `OMPAdapter` (mcp-only paradigm) so context-mode users running under [Oh My Pi](https://github.com/can1357/oh-my-pi) get their session DB, stats, and content index rooted at `~/.omp/context-mode/` instead of leaking into `~/.claude/`.

Closes the adapter gap behind #473.

## Why

#473 reported: *"Context Index and Session Stats were located in `~/.claude/`"* after switching from Pi to OMP.

I audited the storage path resolution from `next` and confirmed the in-thread observation by @nightt5879:
- `getSessionDir()` (src/adapters/base.ts) already honors per-adapter `sessionDirSegments`.
- `getStorePath()` (src/server.ts:238) derives the content DB from the same session dir.
- `getStatsFilePath()` (src/server.ts:462) joins `getSessionDir()` with `stats-<sessionId>.json`.

So the storage layout is already adapter-rooted — there is no hardcoded `~/.claude/...` for content/stats. The remaining failure mode is **adapter selection**: there is no `OMPAdapter`, so detection either falls through to `pi` (and from there to the Claude fallback in `getAdapter()`) or directly to Claude. Either way the segments end up `[".claude"]`.

This PR closes that gap by adding OMP as a first-class adapter so `getAdapter("omp")` returns an instance whose `sessionDirSegments = [".omp"]`. **No new env-var override layer** — keeping the design constraint @mksglu raised in the issue: "every flag we ship without a clear, validated use case becomes dead code and tech debt."

### Scope notes

- **PiAdapter still does not exist.** `getAdapter("pi")` currently falls through the `default:` branch and returns a `ClaudeCodeAdapter`. That is a pre-existing bug, not part of #473's stated scope, and is not addressed here. Happy to file a follow-up issue if you want — wanted to keep this PR review-light.
- **No `CONTEXT_MODE_DIR` env var** added. Discussed in-thread, parking it until there's a validated use case.

## Coverage added

- `tests/adapters/detect.test.ts`
  - Detects `omp` from `OMP_PROCESSING_AGENT_DIR`.
  - Prefers `omp` over `pi` when both env vars are set (precedence regression).
  - `omp` accepted in the platform fallback assertion.
  - `getAdapter("omp")` returns `OMPAdapter` instance.
- `tests/adapters/omp.test.ts` (new — mirrors `tests/adapters/antigravity.test.ts`)
  - Identity (name, paradigm).
  - All `capabilities` are false (mcp-only).
  - All `parse*Input` methods throw with `OMP does not support hooks`.
  - All `format*Response` methods return `undefined`.
  - `generateHookConfig`, `configureAllHooks`, `setHookPermissions` return empty.
  - `getSessionDir()` resolves under `~/.omp/context-mode/sessions/`.
  - `getSessionDBPath` / `getSessionEventsPath` contain `.omp` and **never** `.claude` (the issue's exact failure mode).
  - Default `getSettingsPath()` → `~/.omp/agent/mcp_config.json`, default `getConfigDir()` → `~/.omp/agent`.
  - `OMP_PROCESSING_AGENT_DIR` overrides settings + config dir resolution.
  - `getInstructionFiles()` returns `["PI.md"]` (Pi compat).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — bundles regenerate (reverted before commit per repo convention; CI rebuilds)
- [x] `npm test` — full suite green: **2439 passed, 25 skipped, 0 failed**
- [x] `npx vitest run tests/adapters/{omp,detect,detect-config-dir,client-map}.test.ts` — 106 passed
- [x] No new test file fragmentation: per-adapter test file is the existing convention (`antigravity.test.ts`, `cursor.test.ts`, `kiro.test.ts`, etc.); `omp.test.ts` follows that pattern.
- [x] Bundles (`cli.bundle.mjs` / `server.bundle.mjs`) excluded from the commit per repo rules.