### PR TITLE
fix: add required description frontmatter to UPSTREAM-CREDITS.md

### DIFF
--- a/skills/UPSTREAM-CREDITS.md
+++ b/skills/UPSTREAM-CREDITS.md
@@ -1,3 +1,8 @@
+---
+description: |
+  Documentation about upstream skills vendored from mattpocock/skills. Lists source repo, license, vendored skill paths, and refresh instructions.
+---
+
 # Upstream Skill Credits
 
 context-mode vendors a small set of operating-discipline skills authored

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "134.9k+",
+  "message": "138.8k+",
   "color": "brightgreen",
-  "npm": "108.9k+",
+  "npm": "112.7k+",
   "marketplace": "26k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "144.7k+",
+  "message": "147k+",
   "color": "brightgreen",
-  "npm": "115.5k+",
+  "npm": "117.8k+",
   "marketplace": "29.2k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "127.7k+",
+  "message": "132.7k+",
   "color": "brightgreen",
-  "npm": "103.9k+",
+  "npm": "108.9k+",
   "marketplace": "23.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "138.8k+",
+  "message": "141.1k+",
   "color": "brightgreen",
   "npm": "112.7k+",
-  "marketplace": "26k+"
+  "marketplace": "28.3k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "132.7k+",
+  "message": "134.9k+",
   "color": "brightgreen",
   "npm": "108.9k+",
-  "marketplace": "23.7k+"
+  "marketplace": "26k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "141.1k+",
+  "message": "143.9k+",
   "color": "brightgreen",
-  "npm": "112.7k+",
+  "npm": "115.5k+",
   "marketplace": "28.3k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "143.9k+",
+  "message": "144.7k+",
   "color": "brightgreen",
   "npm": "115.5k+",
-  "marketplace": "28.3k+"
+  "marketplace": "29.2k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "125.4k+",
+  "message": "127.7k+",
   "color": "brightgreen",
   "npm": "103.9k+",
-  "marketplace": "21.4k+"
+  "marketplace": "23.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "147k+",
+  "message": "125.4k+",
   "color": "brightgreen",
-  "npm": "117.8k+",
-  "marketplace": "29.2k+"
+  "npm": "103.9k+",
+  "marketplace": "21.4k+"
 }


### PR DESCRIPTION
## What / Why / How

Pi.dev requires all .md files in the `skills/` directory to have a description frontmatter field. The `UPSTREAM-CREDITS.md` file is documentation about upstream skills vendored from mattpocock/skills, not a skill itself, but was being picked up as a skill file and causing the following error in Pi on startup:

```
[Skill conflicts]
  ~/.nvm/versions/node/vX.X.X/lib/node_modules/context-mode/skills/UPSTREAM-CREDITS.md
    description is required
```

Fix: Added the required description frontmatter to the file. The file is referenced by other vendored skills (diagnose, tdd, grill-me, grill-with-docs, improve-codebase-architecture) which point to it for refresh instructions, so renaming was not a viable option.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [X] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Testing: Local Pi instance no longer shows the skill conflict error on startup.

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
