### PR TITLE
chore: ignore temporary checkout dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ packages/*/dist/
 *.tsbuildinfo
 .DS_Store
 /tmp/
+tmp.*/
 *.db
 server.bundle.mjs
 cli.bundle.mjs


### PR DESCRIPTION
## Summary
- Adds ignore coverage for temporary checkout directories created during local plugin work.

## Verification
- Git branch was pushed and local status is clean.