### PR TITLE
fix(opencode): remove duplicate routing block injection and AGENTS.md capture

### DIFF
--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -1,9 +1,9 @@
 /**
  * OpenCode / KiloCode TypeScript plugin entry point for context-mode.
  *
- * Provides five hooks (v1.0.107 — Mickey OC-1..OC-4 follow-up):
+ * Provides five hooks (v1.0.107 — Mickey OC-1..OC-3 follow-up):
  *   - tool.execute.before  — Routing enforcement (deny/modify/passthrough)
- *   - tool.execute.after   — Session event capture + first-fire AGENTS.md scan (OC-4)
+ *   - tool.execute.after   — Session event capture
  *   - experimental.session.compacting — Compaction snapshot + budget-capped auto-injection (OC-3)
  *   - experimental.chat.system.transform — ROUTING_BLOCK + resume snapshot injection (OC-1)
  *   - chat.message         — User-prompt capture w/ CCv2 inline filter (OC-2)
@@ -21,7 +21,7 @@
  *   - Session cleanup happens at plugin init (no SessionStart)
  */
 
-import { dirname, resolve, join } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { existsSync, readFileSync } from "node:fs";
 
@@ -186,6 +186,14 @@ function isSyntheticMessage(text: string): boolean {
 }
 
 // ── Helpers ───────────────────────────────────────────────
+
+const ROUTING_MARKERS = ["ctx_execute", "ctx_batch_execute", "ctx_fetch_and_index"];
+
+function systemHasRoutingInstructions(system: string[]): boolean {
+  const text = system.join("\n");
+  return ROUTING_MARKERS.filter((m) => text.includes(m)).length >= 2;
+}
+
 /**
  * Detect whether the plugin is running under KiloCode or OpenCode.
  *
@@ -262,62 +270,16 @@ async function createContextModePlugin(ctx: PluginContext) {
   // Clean up old sessions on startup (no SessionStart hook to do this).
   db.cleanupOldSessions(7);
 
-  // Track per-session resume injection: persistent plugin process can host
-  // many sessions, so the gate must be keyed by sessionID — NOT a single
-  // boolean closure flag (Mickey #2 root cause).
-  const resumeInjected = new Set<string>();
-  // OC-1: Routing block first-fire gate per session. Distinct from
-  // resumeInjected because routing block must always inject (regardless of
-  // whether a resume row exists), but resume only on rows present.
-  const routingInjected = new Set<string>();
-  // OC-4: AGENTS.md/CLAUDE.md captured-once-per-projectDir gate. Idempotent
-  // across many sessions reusing the same plugin process + project tree.
-  const agentsCaptured = new Set<string>();
-
-  /**
-   * OC-4: Read AGENTS.md (and CLAUDE.md fallback if both exist) from the
-   * project directory and persist as `rule` + `rule_content` events. Mirrors
-   * the CC SessionStart pattern at hooks/sessionstart.mjs:121-132. Idempotent
-   * via `agentsCaptured` Set keyed by projectDir.
-   */
-  function captureAgentsMd(sessionId: string): void {
-    if (agentsCaptured.has(projectDir)) return;
-    agentsCaptured.add(projectDir);
-    // Mirror OpenCode's instruction.ts FILES order: AGENTS.md, CLAUDE.md, CONTEXT.md.
-    const candidates = ["AGENTS.md", "CLAUDE.md", "CONTEXT.md"];
-    for (const name of candidates) {
-      try {
-        const p = join(projectDir, name);
-        if (!existsSync(p)) continue;
-        const content = readFileSync(p, "utf-8");
-        if (!content.trim()) continue;
-        db.insertEvent(sessionId, {
-          type: "rule",
-          category: "rule",
-          data: p,
-          priority: 1,
-        } as SessionEvent, "PluginInit");
-        db.insertEvent(sessionId, {
-          type: "rule_content",
-          category: "rule",
-          data: content,
-          priority: 1,
-        } as SessionEvent, "PluginInit");
-      } catch {
-        // file missing or unreadable — skip silently
-      }
-    }
-  }
-
   function logger(
-    message = "context-mode debug log", extra?: PluginClientAppLogBodyExtra
+    message = "context-mode debug log",
+    extra?: PluginClientAppLogBodyExtra,
   ): Promise<void> {
     return ctx.client.app.log({
       body: {
         service: "context-mode-logger",
         level: "info",
         message,
-        extra
+        extra,
       },
     });
   }
@@ -361,9 +323,6 @@ async function createContextModePlugin(ctx: PluginContext) {
       if (!sessionId) return;
       try {
         db.ensureSession(sessionId, projectDir);
-        // OC-4: Capture AGENTS.md/CLAUDE.md as rule events on first hook
-        // fire per projectDir. Idempotent via `agentsCaptured` Set.
-        captureAgentsMd(sessionId);
 
         const hookInput: HookInput = {
           tool_name: input.tool ?? "",
@@ -399,8 +358,7 @@ async function createContextModePlugin(ctx: PluginContext) {
         if (isSyntheticMessage(message)) return;
 
         db.ensureSession(sessionId, projectDir);
-        captureAgentsMd(sessionId);
-
+        
         // 1. Always save the raw prompt
         db.insertEvent(sessionId, {
           type: "user_prompt",
@@ -456,7 +414,7 @@ async function createContextModePlugin(ctx: PluginContext) {
           if (autoBlock && autoBlock.length > 0) {
             output.context.push(autoBlock);
           }
-          
+
           if (process.env.OPENCODE_DEBUG) {
             await logger(autoBlock, {
               sessionId,
@@ -480,7 +438,6 @@ async function createContextModePlugin(ctx: PluginContext) {
     //   output: { system: string[] }
     // We claim the most-recent unconsumed resume snapshot atomically (race-
     // safe across concurrent processes) and prepend it to the system prompt.
-    // First-injection-per-session is enforced by `resumeInjected` Set.
     "experimental.chat.system.transform": async (
       input: SystemTransformHookInput,
       output: SystemTransformHookOutput,
@@ -494,19 +451,26 @@ async function createContextModePlugin(ctx: PluginContext) {
       // resume snapshot path below — routing block must fire even when
       // no prior session row exists. Splice at index 1 (NOT unshift) for
       // the same OpenCode llm.ts:117-128 cache-fold reason as resume.
+      //
+      // Skip injection when system prompt already contains context-mode
+      // routing rules (e.g. via AGENTS.md / CLAUDE.md loaded by the host).
+      // Detect by checking for a quorum of distinctive tool names — any two
+      // of ctx_execute, ctx_batch_execute, ctx_fetch_and_index confirms the
+      // instructions are present and avoids ~2K chars of duplication.
       if (Array.isArray(output?.system)) {
-        try {
-          // Visible marker — mirror the resume-snapshot pattern below so
-          // users can grep OPENCODE_DEBUG logs to confirm the routing block
-          // reached the model (Mickey-class verification path).
-          const marker = `<!-- context-mode v${VERSION}: routing block injected (sessionID=${sessionId.slice(0, 8)}) -->\n`;
-          output.system.splice(1, 0, marker + routingBlock);
-        } catch {
-          // Never break the chat turn on routing-block injection failure.
-        }
-        
-        if (process.env.OPENCODE_DEBUG) {
-          await logger(output.system[1], {sessionId, source: 'on routing block injection'});
+        if (!systemHasRoutingInstructions(output.system)) {
+          try {
+            const marker = `<!-- context-mode v${VERSION}: routing block injected (sessionID=${sessionId.slice(0, 8)}) -->\n`;
+            output.system.splice(1, 0, marker + routingBlock);
+          } catch {
+            // Never break the chat turn on routing-block injection failure.
+          }
+
+          if (process.env.OPENCODE_DEBUG) {
+            await logger(output.system[1], {sessionId, source: 'on routing block injection'});
+          }
+        } else if (process.env.OPENCODE_DEBUG) {
+          await logger(`routing block skipped — system prompt already contains context-mode instructions`, {sessionId, source: 'on routing block injection'});
         }
       }
 
@@ -515,7 +479,7 @@ async function createContextModePlugin(ctx: PluginContext) {
         // follow-up): if Session B compacts mid-flight and produces its own row,
         // B's next system.transform must NOT claim that row back into B's prompt.
         const row = db.claimLatestUnconsumedResume(sessionId);
-        if (!row || !row.snapshot) return;        // no row → leave `resumeInjected` unset → retry on next turn
+        if (!row || !row.snapshot) return;        // no row → retry on next turn
 
         if (process.env.OPENCODE_DEBUG) {
           await logger(row.snapshot, {
@@ -523,7 +487,7 @@ async function createContextModePlugin(ctx: PluginContext) {
             source: "on resume - snapshot",
           });
         }
-        
+
         if (Array.isArray(output?.system)) {
           // Visible signal — without this, the injection is silent and users
           // cannot tell the feature is active (Mickey: "I can't find use case

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -623,6 +623,40 @@ describe("ContextModePlugin", () => {
       expect(out2.system.join("\n")).toContain("<context_window_protection>");
       expect(out2.system.length).toBe(2);
     });
+
+    it("OC-1: skips routing block when system prompt already contains context-mode instructions", async () => {
+      const plugin = await createTestPlugin(join(tempDir, "oc1-dedup"));
+      // Simulate AGENTS.md already loaded by the host — contains routing markers
+      const agentsContent = [
+        "# context-mode rules",
+        "Use ctx_execute for analysis",
+        "Use ctx_batch_execute for commands",
+        "Use ctx_fetch_and_index for URLs",
+      ].join("\n");
+      const out = { system: ["HEADER", agentsContent] };
+      await plugin["experimental.chat.system.transform"](
+        { sessionID: "oc1-dedup-sess", model: {} } as any,
+        out,
+      );
+      // system unchanged — no routing block injected (2+ markers detected)
+      expect(out.system.length).toBe(2);
+      expect(out.system[0]).toBe("HEADER");
+      expect(out.system[1]).toBe(agentsContent);
+      expect(out.system.join("\n")).not.toContain("<context_window_protection>");
+    });
+
+    it("OC-1: injects routing block when only one marker present (below quorum)", async () => {
+      const plugin = await createTestPlugin(join(tempDir, "oc1-below-quorum"));
+      // Only one marker — below the 2-of-3 quorum — routing block still injects
+      const partialContent = "Some text mentioning ctx_execute but nothing else";
+      const out = { system: ["HEADER", partialContent] };
+      await plugin["experimental.chat.system.transform"](
+        { sessionID: "oc1-quorum-sess", model: {} } as any,
+        out,
+      );
+      expect(out.system.length).toBe(3); // HEADER + routing + partialContent
+      expect(out.system[1]).toContain("<context_window_protection>");
+    });
   });
 
   // ── OC-2: chat.message hook (Z2) ──────────────────────────
@@ -718,55 +752,6 @@ describe("ContextModePlugin", () => {
       const autoBlock = output.context.find((c) => c.includes("<session_state source=\"compaction\">"));
       expect(autoBlock).toBeDefined();
       expect(autoBlock!.length).toBeLessThanOrEqual(2000);
-    });
-  });
-
-  // ── OC-4: AGENTS.md / CLAUDE.md rule capture (Z4) ─────────
-  // Capture the project AGENTS.md (OpenCode's CLAUDE.md equivalent) on
-  // first hook fire per projectDir, as rule + rule_content events.
-
-  describe("AGENTS.md rule capture (OC-4)", () => {
-    it("OC-4: captures AGENTS.md as rule + rule_content events on first tool.execute.after", async () => {
-      const projectDir = join(tempDir, "oc4-agents-md");
-      mkdirSync(projectDir, { recursive: true });
-      writeFileSync(join(projectDir, "AGENTS.md"), "# project rules\n- never push without approval");
-
-      const plugin = await createTestPlugin(projectDir);
-      await plugin["tool.execute.after"](
-        { tool: "Read", sessionID: "oc4-sess", callID: "c1", args: { file_path: "/x.ts" } },
-        { title: "Read", output: "x", metadata: {} },
-      );
-
-      const { SessionDB } = await import("../src/session/db.js");
-      const { OpenCodeAdapter } = await import("../src/adapters/opencode/index.js");
-      const adapter = new OpenCodeAdapter("opencode");
-      const db = new SessionDB({ dbPath: adapter.getSessionDBPath(projectDir) });
-      const events = db.getEvents("oc4-sess") as any[];
-      db.close();
-      const rule = events.find((e: any) => e.type === "rule");
-      const ruleContent = events.find((e: any) => e.type === "rule_content");
-      expect(rule).toBeDefined();
-      expect(rule.data).toContain("AGENTS.md");
-      expect(ruleContent).toBeDefined();
-      expect(ruleContent.data).toContain("never push without approval");
-    });
-
-    it("OC-4: skips capture when AGENTS.md missing", async () => {
-      const projectDir = join(tempDir, "oc4-no-agents");
-      mkdirSync(projectDir, { recursive: true });
-      const plugin = await createTestPlugin(projectDir);
-      await plugin["tool.execute.after"](
-        { tool: "Read", sessionID: "oc4-empty-sess", callID: "c1", args: { file_path: "/y.ts" } },
-        { title: "Read", output: "y", metadata: {} },
-      );
-
-      const { SessionDB } = await import("../src/session/db.js");
-      const { OpenCodeAdapter } = await import("../src/adapters/opencode/index.js");
-      const adapter = new OpenCodeAdapter("opencode");
-      const db = new SessionDB({ dbPath: adapter.getSessionDBPath(projectDir) });
-      const events = db.getEvents("oc4-empty-sess") as any[];
-      db.close();
-      expect(events.find((e: any) => e.type === "rule")).toBeUndefined();
     });
   });
 


### PR DESCRIPTION

## What / Why / How

- Remove redundant routing block injection when system prompt already contains context-mode instructions
- Remove AGENTS.md/CLAUDE.md rule capture functionality as it's handled by the host
- Add quorum-based routing detection to prevent duplicate instruction injection
- Update plugin documentation to reflect simplified hook behavior

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [x] OpenCode
- [x] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Two new tests added, two removed:

**Added** (in `tests/opencode-plugin.test.ts`):
- `"OC-1: skips routing block when system prompt already contains context-mode instructions"` — verifies the `systemHasRoutingInstructions` quorum guard (2+ markers → no injection)
- `"OC-1: injects routing block when only one marker present (below quorum)"` — verifies single marker is below threshold and routing block still injects

**Removed** (in `tests/opencode-plugin.test.ts`):
- `"OC-4: captures AGENTS.md as rule + rule_content events on first tool.execute.after"` — removed along with the `captureAgentsMd` function
- `"OC-4: skips capture when AGENTS.md missing"` — same removal

The entire `describe("AGENTS.md rule capture (OC-4)")` block was deleted. Net: -49 lines removed, +34 lines added in the test file.

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
