### PR TITLE
fix(pi): parse session age timestamps as UTC

### DIFF
--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -151,6 +151,22 @@ function deriveSessionId(ctx: Record<string, unknown>): string {
   return `pi-${Date.now()}`;
 }
 
+/**
+ * Parse SessionDB timestamps as UTC. SQLite datetime('now') returns
+ * "YYYY-MM-DD HH:MM:SS" in UTC without a timezone suffix; JavaScript parses
+ * that shape as local time, which skews ages by the local UTC offset.
+ */
+function parseSessionTimestampMs(value: string): number {
+  const trimmed = value.trim();
+  const sqliteUtc = trimmed.match(
+    /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(\.\d+)?$/,
+  );
+  const normalized = sqliteUtc
+    ? `${sqliteUtc[1]}T${sqliteUtc[2]}${sqliteUtc[3] ?? ""}Z`
+    : trimmed;
+  return Date.parse(normalized);
+}
+
 /** Build stats text for the /ctx-stats command. */
 function buildStatsText(db: SessionDB, sessionId: string): string {
   try {
@@ -179,9 +195,11 @@ function buildStatsText(db: SessionDB, sessionId: string): string {
 
     // Session age
     if (stats?.started_at) {
-      const startedMs = new Date(stats.started_at).getTime();
-      const ageMinutes = Math.round((Date.now() - startedMs) / 60_000);
-      lines.push(`- Session age: ${ageMinutes}m`);
+      const startedMs = parseSessionTimestampMs(stats.started_at);
+      if (Number.isFinite(startedMs)) {
+        const ageMinutes = Math.round((Date.now() - startedMs) / 60_000);
+        lines.push(`- Session age: ${ageMinutes}m`);
+      }
     }
 
     return lines.join("\n");

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -21,6 +21,7 @@ import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { SessionDB } from "../src/session/db.js";
 
 // ── Mock Pi API ──────────────────────────────────────────────
 
@@ -533,6 +534,63 @@ describe("Pi Extension", () => {
       // Should not throw even with no events
       const result = await cmd!.handler!({});
       expect(result).toBeDefined();
+    });
+
+    it("/ctx-stats treats SQLite started_at as UTC", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-05-09T12:30:00Z"));
+
+      const originalTZ = process.env.TZ;
+      process.env.TZ = "America/Los_Angeles";
+
+      const sessionFile = join(tempDir, "stats-utc-session.jsonl");
+      const sessionId = createHash("sha256")
+        .update(sessionFile)
+        .digest("hex")
+        .slice(0, 16);
+
+      try {
+        await registerPiExtension(api);
+        await api._trigger(
+          "session_start",
+          { type: "session_start", reason: "startup" },
+          { sessionManager: { getSessionFile: () => sessionFile } },
+        );
+
+        const dbPath = join(
+          process.env.HOME!,
+          ".pi",
+          "context-mode",
+          "sessions",
+          "context-mode.db",
+        );
+        const db = new SessionDB({ dbPath });
+        try {
+          // SQLite datetime('now') stores UTC as "YYYY-MM-DD HH:MM:SS".
+          // If parsed as local time in America/Los_Angeles, this would be
+          // 2026-05-09T19:00:00Z and the age would not be 30 minutes.
+          db.db
+            .prepare(
+              "UPDATE session_meta SET started_at = ? WHERE session_id = ?",
+            )
+            .run("2026-05-09 12:00:00", sessionId);
+        } finally {
+          db.close();
+        }
+
+        const result = await api._getCommand("ctx-stats")!.handler!({});
+
+        expect((result as { text: string }).text).toContain(
+          "- Session age: 30m",
+        );
+      } finally {
+        if (originalTZ === undefined) {
+          delete process.env.TZ;
+        } else {
+          process.env.TZ = originalTZ;
+        }
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix Pi `/ctx-stats` session age calculation for SQLite UTC timestamps.
- Parse `session_meta.started_at` values from SQLite `datetime('now')` as UTC instead of local time.
- Add a Pi regression test that sets a non-UTC timezone and verifies `Session age` stays correct.

## Problem

`SessionDB` stores `session_meta.started_at` using SQLite `datetime('now')`, which is UTC text like `YYYY-MM-DD HH:MM:SS` without a timezone suffix. The Pi stats command previously used `new Date(stats.started_at)`, which JavaScript interprets as local time. In UTC+8, a fresh session could show roughly `480m` of age.

## Test evidence

RED first:

```text
npx vitest run tests/pi-extension.test.ts -t "SQLite started_at"
# failed: expected "- Session age: 30m", received "- Session age: -390m"
```

GREEN / validation:

```text
npx vitest run tests/pi-extension.test.ts -t "SQLite started_at"
# 1 passed

npx vitest run tests/pi-extension.test.ts
# 46 passed

npm run typecheck
# passed

npm test
# 75 passed, 2451 passed, 26 skipped
```

## Notes

During the first full-suite run, `tests/executor.test.ts > Shell: awk processing` failed because this local Fedora WSL image did not have `awk` installed (`exitCode 127`). After installing `gawk`, the full suite passed.
