### PR TITLE
chore: remove bundle files from git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ packages/*/dist/
 .DS_Store
 /tmp/
 *.db
-server.bundle.mjs
-cli.bundle.mjs
 package-lock.json
 hooks/session-extract.bundle.mjs
 hooks/session-snapshot.bundle.mjs


### PR DESCRIPTION

## What / Why / How

Deleted cli.bundle.mjs and server.bundle.mjs from the repository. These appear to be compiled bundle files that are not needed in the source control.

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
