### PR TITLE
fix(pi): move UPSTREAM-CREDITS.md out of skills/

### DIFF
--- a/UPSTREAM-CREDITS.md
+++ b/UPSTREAM-CREDITS.md
@@ -2,7 +2,7 @@
 
 context-mode vendors a small set of operating-discipline skills authored
 by Matt Pocock. They are referenced as the operational backbone of the
-[`context-mode-ops`](context-mode-ops/SKILL.md) skill (`/diagnose`, `/tdd`,
+[`context-mode-ops`](skills/context-mode-ops/SKILL.md) skill (`/diagnose`, `/tdd`,
 `/grill-me`, `/grill-with-docs`, `/improve-codebase-architecture`).
 
 ## Source
@@ -23,7 +23,7 @@ by Matt Pocock. They are referenced as the operational backbone of the
 
 ## Why vendor instead of just listing as docs?
 
-The owner operating directive at the top of `context-mode-ops/SKILL.md`
+The owner operating directive at the top of `skills/context-mode-ops/SKILL.md`
 treats these skills as **mandatory tools**, not advisory references. If a
 context-mode user invokes `/context-mode-ops` and the directive points to
 skills they have never installed, the discipline collapses. Vendoring

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -119,4 +119,4 @@ Required before declaring done:
 
 ---
 
-_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [skills/UPSTREAM-CREDITS.md](../UPSTREAM-CREDITS.md) for refresh instructions._
+_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [UPSTREAM-CREDITS.md](../../UPSTREAM-CREDITS.md) for refresh instructions._

--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -12,4 +12,4 @@ If a question can be answered by exploring the codebase, explore the codebase in
 
 ---
 
-_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [skills/UPSTREAM-CREDITS.md](../UPSTREAM-CREDITS.md) for refresh instructions._
+_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [UPSTREAM-CREDITS.md](../../UPSTREAM-CREDITS.md) for refresh instructions._

--- a/skills/grill-with-docs/SKILL.md
+++ b/skills/grill-with-docs/SKILL.md
@@ -90,4 +90,4 @@ If any of the three is missing, skip the ADR. Use the format in [ADR-FORMAT.md](
 
 ---
 
-_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [skills/UPSTREAM-CREDITS.md](../UPSTREAM-CREDITS.md) for refresh instructions._
+_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [UPSTREAM-CREDITS.md](../../UPSTREAM-CREDITS.md) for refresh instructions._

--- a/skills/improve-codebase-architecture/SKILL.md
+++ b/skills/improve-codebase-architecture/SKILL.md
@@ -73,4 +73,4 @@ Side effects happen inline as decisions crystallize:
 
 ---
 
-_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [skills/UPSTREAM-CREDITS.md](../UPSTREAM-CREDITS.md) for refresh instructions._
+_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [UPSTREAM-CREDITS.md](../../UPSTREAM-CREDITS.md) for refresh instructions._

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -111,4 +111,4 @@ After all tests pass, look for [refactor candidates](refactoring.md):
 
 ---
 
-_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [skills/UPSTREAM-CREDITS.md](../UPSTREAM-CREDITS.md) for refresh instructions._
+_Vendored from [mattpocock/skills](https://github.com/mattpocock/skills) @ `b843cb5` — MIT License. See [UPSTREAM-CREDITS.md](../../UPSTREAM-CREDITS.md) for refresh instructions._

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "134.9k+",
+  "message": "138.8k+",
   "color": "brightgreen",
-  "npm": "108.9k+",
+  "npm": "112.7k+",
   "marketplace": "26k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "144.7k+",
+  "message": "147k+",
   "color": "brightgreen",
-  "npm": "115.5k+",
+  "npm": "117.8k+",
   "marketplace": "29.2k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "127.7k+",
+  "message": "132.7k+",
   "color": "brightgreen",
-  "npm": "103.9k+",
+  "npm": "108.9k+",
   "marketplace": "23.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "138.8k+",
+  "message": "141.1k+",
   "color": "brightgreen",
   "npm": "112.7k+",
-  "marketplace": "26k+"
+  "marketplace": "28.3k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "147.5k+",
+  "message": "149.6k+",
   "color": "brightgreen",
-  "npm": "117.8k+",
+  "npm": "120k+",
   "marketplace": "29.6k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "132.7k+",
+  "message": "134.9k+",
   "color": "brightgreen",
   "npm": "108.9k+",
-  "marketplace": "23.7k+"
+  "marketplace": "26k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "141.1k+",
+  "message": "143.9k+",
   "color": "brightgreen",
-  "npm": "112.7k+",
+  "npm": "115.5k+",
   "marketplace": "28.3k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "143.9k+",
+  "message": "144.7k+",
   "color": "brightgreen",
   "npm": "115.5k+",
-  "marketplace": "28.3k+"
+  "marketplace": "29.2k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "125.4k+",
+  "message": "127.7k+",
   "color": "brightgreen",
   "npm": "103.9k+",
-  "marketplace": "21.4k+"
+  "marketplace": "23.7k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "147k+",
+  "message": "147.5k+",
   "color": "brightgreen",
   "npm": "117.8k+",
-  "marketplace": "29.2k+"
+  "marketplace": "29.6k+"
 }


### PR DESCRIPTION
Pi treats every markdown file under the packaged skills directory as a skill and requires frontmatter (e.g. description). UPSTREAM-CREDITS.md is documentation, not a skill, which triggered Pi startup conflicts.

Move the file to the repository root and update relative links from vendored SKILL.md footers and within the credits doc.