### PR TITLE
docs: update context-mode routing rules and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,59 @@
-# context-mode
+# context-mode — MANDATORY routing rules
 
-Raw tool output floods context window. Use context-mode MCP tools to keep raw data in sandbox.
+context-mode MCP tools available. Rules protect context window from flooding. One unrouted command dumps 56 KB into context.
 
 ## Think in Code — MANDATORY
 
 Analyze/count/filter/compare/search/parse/transform data: **write code** via `ctx_execute(language, code)`, `console.log()` only the answer. Do NOT read raw data into context. PROGRAM the analysis, not COMPUTE it. Pure JavaScript — Node.js built-ins only (`fs`, `path`, `child_process`). `try/catch`, handle `null`/`undefined`. One script replaces ten tool calls.
 
-## Tool Selection
+## BLOCKED — do NOT attempt
 
-1. **GATHER**: `ctx_batch_execute(commands, queries)` — runs all commands, auto-indexes, searches. ONE call replaces many steps.
-2. **FOLLOW-UP**: `ctx_search(queries: ["q1", "q2", ...])` — all follow-up questions, ONE call.
+### curl / wget — BLOCKED
+Intercepted and replaced with error. Do NOT retry.
+Use: `ctx_fetch_and_index(url, source)` or `ctx_execute(language: "javascript", code: "const r = await fetch(...)")`
+
+### Inline HTTP — BLOCKED
+`fetch('http`, `requests.get(`, `requests.post(`, `http.get(`, `http.request(` — intercepted. Do NOT retry.
+Use: `ctx_execute(language, code)` — only stdout enters context
+
+### WebFetch — BLOCKED
+Use: `ctx_fetch_and_index(url, source)` then `ctx_search(queries)`
+
+## REDIRECTED — use sandbox
+
+### Bash (>20 lines output)
+Bash ONLY for: `git`, `mkdir`, `rm`, `mv`, `cd`, `ls`, `npm install`, `pip install`.
+Otherwise: `ctx_batch_execute(commands, queries)` or `ctx_execute(language: "shell", code: "...")`
+
+### Read (for analysis)
+Reading to **Edit** → Read correct. Reading to **analyze/explore/summarize** → `ctx_execute_file(path, language, code)`.
+
+### Grep (large results)
+Use `ctx_execute(language: "shell", code: "grep ...")` in sandbox.
+
+## Tool selection
+
+0. **MEMORY**: `ctx_search(sort: "timeline")` — after resume, check prior context before asking user.
+1. **GATHER**: `ctx_batch_execute(commands, queries)` — runs all commands, auto-indexes, returns search. ONE call replaces 30+. Each command: `{label: "header", command: "..."}`.
+2. **FOLLOW-UP**: `ctx_search(queries: ["q1", "q2", ...])` — all questions as array, ONE call (default relevance mode).
 3. **PROCESSING**: `ctx_execute(language, code)` | `ctx_execute_file(path, language, code)` — sandbox, only stdout enters context.
-4. **WEB**: `ctx_fetch_and_index(url)` then `ctx_search(queries)` — never dump raw HTML.
+4. **WEB**: `ctx_fetch_and_index(url, source)` then `ctx_search(queries)` — raw HTML never enters context.
+5. **INDEX**: `ctx_index(content, source)` — store in FTS5 for later search.
 
-## Rules
+## Parallel I/O batches
 
-- DO NOT use Bash for >20 lines output — use `ctx_execute` or `ctx_batch_execute`.
-- DO NOT use Read for analysis — use `ctx_execute_file`. Read IS correct for Edit.
-- DO NOT use WebFetch — use `ctx_fetch_and_index`.
-- DO NOT use curl/wget in Bash — use `ctx_execute` or `ctx_fetch_and_index`.
-- Bash ONLY for git, mkdir, rm, mv, navigation, short commands.
+For multi-URL fetches or multi-API calls, **always** include `concurrency: N` (1-8):
+
+- `ctx_batch_execute(commands: [3+ network commands], concurrency: 5)` — gh, curl, dig, docker inspect, multi-region cloud queries
+- `ctx_fetch_and_index(requests: [{url, source}, ...], concurrency: 5)` — multi-URL batch fetch
+
+**Use concurrency 4-8** for I/O-bound work (network calls, API queries). **Keep concurrency 1** for CPU-bound (npm test, build, lint) or commands sharing state (ports, lock files, same-repo writes).
+
+GitHub API rate-limit: cap at 4 for `gh` calls.
+
+## Subagent routing
+
+Routing block auto-injected into subagent prompts. Bash-type subagents upgraded to general-purpose. No manual instruction needed.
 
 ## Output
 
@@ -27,3 +61,34 @@ Terse like caveman. Technical substance exact. Only fluff die.
 Drop: articles, filler (just/really/basically), pleasantries, hedging. Fragments OK. Short synonyms. Code unchanged.
 Pattern: [thing] [action] [reason]. [next step]. Auto-expand for: security warnings, irreversible actions, user confusion.
 Write artifacts to FILES — never inline. Return: file path + 1-line description.
+Descriptive source labels for `ctx_search(source: "label")`.
+
+## Session Continuity
+
+Skills, roles, and decisions persist for the entire session. Do not abandon them as the conversation grows.
+
+## Memory
+
+Session history is persistent and searchable. On resume, search BEFORE asking the user:
+
+| Need | Command |
+|------|---------|
+| What were we working on? | `ctx_search(queries: ["summary"], source: "compaction", sort: "timeline")` |
+| What was the first request? | `ctx_search(queries: ["prompt"], source: "user-prompt", sort: "timeline")` |
+| What did we decide? | `ctx_search(queries: ["decision"], source: "decision", sort: "timeline")` |
+| What NOT to repeat? | `ctx_search(queries: ["rejected"], source: "rejected-approach")` |
+| What constraints exist? | `ctx_search(queries: ["constraint"], source: "constraint")` |
+
+DO NOT ask "what were we working on?" — SEARCH FIRST.
+If search returns 0 results, proceed as a fresh session.
+
+## ctx commands
+
+| Command | Action |
+|---------|--------|
+| `ctx stats` | Call `ctx_stats` MCP tool, display full output verbatim |
+| `ctx doctor` | Call `ctx_doctor` MCP tool, run returned shell command, display as checklist |
+| `ctx upgrade` | Call `ctx_upgrade` MCP tool, run returned shell command, display as checklist |
+| `ctx purge` | Call `ctx_purge` MCP tool with confirm: true. Warns before wiping knowledge base. |
+
+After /clear or /compact: knowledge base and session stats preserved. Use `ctx purge` to start fresh.


### PR DESCRIPTION

## What / Why / How

Clarify mandatory routing rules for context-mode MCP tools, including blocked operations, redirected tools, and parallel I/O batch guidance. Add concurrency recommendations and GitHub API rate-limiting guidance.

## Affected platforms

<!-- Check all platforms affected by this change -->

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
