### PR TITLE
docs: update grep documentation and remove routing markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Otherwise: `ctx_batch_execute(commands, queries)` or `ctx_execute(language: "she
 ### Read (for analysis)
 Reading to **Edit** → Read correct. Reading to **analyze/explore/summarize** → `ctx_execute_file(path, language, code)`.
 
-### Grep (large results)
+### Grep — may flood context
 Use `ctx_execute(language: "shell", code: "grep ...")` in sandbox.
 
 ## Tool selection

--- a/configs/claude-code/CLAUDE.md
+++ b/configs/claude-code/CLAUDE.md
@@ -28,7 +28,7 @@ Otherwise: `ctx_batch_execute(commands, queries)` or `ctx_execute(language: "she
 ### Read (for analysis)
 Reading to **Edit** → Read correct. Reading to **analyze/explore/summarize** → `ctx_execute_file(path, language, code)`.
 
-### Grep (large results)
+### Grep — may flood context
 Use `ctx_execute(language: "shell", code: "grep ...")` in sandbox.
 
 ## Tool selection

--- a/configs/qwen-code/QWEN.md
+++ b/configs/qwen-code/QWEN.md
@@ -28,7 +28,7 @@ Otherwise: `mcp__context-mode__ctx_batch_execute(commands, queries)` or `mcp__co
 ### Read (for analysis)
 Reading to **Edit** → Read correct. Reading to **analyze/explore/summarize** → `mcp__context-mode__ctx_execute_file(path, language, code)`.
 
-### Grep (large results)
+### Grep — may flood context
 Use `mcp__context-mode__ctx_execute(language: "shell", code: "grep ...")` in sandbox.
 
 ## Tool selection

--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -460,8 +460,7 @@ async function createContextModePlugin(ctx: PluginContext) {
       if (Array.isArray(output?.system)) {
         if (!systemHasRoutingInstructions(output.system)) {
           try {
-            const marker = `<!-- context-mode v${VERSION}: routing block injected (sessionID=${sessionId.slice(0, 8)}) -->\n`;
-            output.system.splice(1, 0, marker + routingBlock);
+            output.system.splice(1, 0, routingBlock);
           } catch {
             // Never break the chat turn on routing-block injection failure.
           }
@@ -489,15 +488,6 @@ async function createContextModePlugin(ctx: PluginContext) {
         }
 
         if (Array.isArray(output?.system)) {
-          // Visible signal — without this, the injection is silent and users
-          // cannot tell the feature is active (Mickey: "I can't find use case
-          // for it"). The XML comment is harmless to the model and shows up in
-          // OPENCODE_DEBUG logs as proof the snapshot landed.
-          const eventCount = row.snapshot.match(/events="(\d+)"/)?.[1] ?? "?";
-          const marker =
-            `<!-- context-mode v${VERSION}: resumed prior session ${row.sessionId.slice(0, 8)} ` +
-            `(${eventCount} events, ${row.snapshot.length} chars) -->\n`;
-
           // Insert at index 1 (after the header) — NOT unshift.
           // OpenCode's llm.ts:117-128 saves `header = system[0]` BEFORE this
           // hook runs and then folds the rest into a 2-part structure
@@ -508,7 +498,7 @@ async function createContextModePlugin(ctx: PluginContext) {
           // provider prompt cache is invalidated on every resume injection.
           // Inserting at index 1 keeps the header invariant and lets the
           // snapshot ride along inside the cached body block.
-          output.system.splice(1, 0, marker + row.snapshot);
+          output.system.splice(1, 0, row.snapshot);
           // Mark consumed only AFTER successful splice so failed paths can retry
           if (process.env.OPENCODE_DEBUG) {
             await logger(output.system[1], { sessionId, source: "on resume" });

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -521,14 +521,11 @@ describe("ContextModePlugin", () => {
         { sessionID: "C", model: {} } as any,
         outC,
       );
-      expect(outC.system.length).toBe(3); // HEADER + routing + snapshot
+      expect(outC.system.length).toBe(3); // HEADER + routing
       expect(outC.system.some((s) => s.includes("session_resume"))).toBe(true);
     });
 
-    // v1.0.106 — visible signal so users can confirm the feature actually
-    // fired (without it Mickey reported "I can't find use case for it" —
-    // the inject was silent and invisible in OPENCODE_DEBUG logs).
-    it("emits a visible context-mode marker comment alongside the snapshot", async () => {
+    it("emits a snapshot", async () => {
       const projectDir = join(tempDir, "sysxform-marker");
       const plugin = await createTestPlugin(projectDir);
 
@@ -546,11 +543,10 @@ describe("ContextModePlugin", () => {
         { sessionID: "consumer", model: {} } as any,
         out,
       );
-      // v1.0.107 — out.system is [HEADER, routing-block, snapshot-with-marker]
+      // v1.0.107 — out.system is [HEADER, routing-block]
       expect(out.system.length).toBe(3);
       const snapshotEntry = out.system.find((s) => s.includes("session_resume"));
       expect(snapshotEntry).toBeDefined();
-      expect(snapshotEntry!).toMatch(/^<!-- context-mode v[\d.]+: resumed prior session [\w-]{1,8}/);
     });
   });
 


### PR DESCRIPTION

## What / Why / How

Update grep guidance across configuration files to warn about context flooding. Remove XML comment markers from OpenCode plugin routing logic to streamline system message injection.

## Affected platforms

<!-- Check all platforms affected by this change -->

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [x] Qwen Code
- [x] OpenCode
- [x] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Remove XML comment markers from snapshot assertions in OpenCode plugin test to streamline snapshot validation. Update test description to focus on snapshot emission rather than marker comments.

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
