### PR TITLE
feat(codex): expose plugin to Codex CLI marketplace

### DIFF
--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "name": "context-mode",
+  "owner": {
+    "name": "Mert Koseoğlu",
+    "email": "code.bm.ksglu@gmail.com"
+  },
+  "metadata": {
+    "description": "OpenAI Codex CLI plugins by Mert Koseoğlu",
+    "version": "1.0.118"
+  },
+  "plugins": [
+    {
+      "name": "context-mode",
+      "source": "./",
+      "description": "Codex CLI MCP plugin that saves 98% of your context window. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and intent-driven search.",
+      "version": "1.0.118",
+      "author": {
+        "name": "Mert Koseoğlu"
+      },
+      "category": "development",
+      "keywords": [
+        "mcp",
+        "context-window",
+        "sandbox",
+        "code-execution",
+        "fts5",
+        "bm25",
+        "playwright",
+        "context7"
+      ]
+    }
+  ]
+}

--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcp_servers": {
+    "context-mode": {
+      "command": "node",
+      "args": ["./start.mjs"]
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "context-mode",
+  "version": "1.0.118",
+  "description": "MCP server that saves 98% of your context window with session continuity. Sandboxed code execution in 11 languages, FTS5 knowledge base with BM25 ranking, and automatic state restore across compactions.",
+  "author": {
+    "name": "Mert Koseoğlu",
+    "url": "https://github.com/mksglu"
+  },
+  "homepage": "https://github.com/mksglu/context-mode#readme",
+  "repository": "https://github.com/mksglu/context-mode",
+  "license": "Elastic-2.0",
+  "keywords": [
+    "mcp",
+    "context-window",
+    "sandbox",
+    "code-execution",
+    "fts5",
+    "bm25",
+    "playwright",
+    "context7"
+  ],
+  "mcpServers": "./.codex-plugin/mcp.json",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "context-mode",
+    "shortDescription": "98% context window savings via FTS5 + sandboxed execution",
+    "developerName": "Mert Koseoğlu",
+    "category": "Productivity"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.codex-plugin/` (mirroring `.claude-plugin/`) so Codex CLI users can install context-mode via the native marketplace command — no manual edits to `~/.codex/config.toml` or `~/.codex/hooks.json` needed.

## Why

PR #492 added Codex runtime support (hooks, adapter, paths). However, Codex CLI's native `plugin marketplace add` command requires a `.codex-plugin/plugin.json` + `.codex-plugin/marketplace.json` at the repo root (analogous to Claude Code's `.claude-plugin/`). Without these files, Codex users have to:

1. `npm install -g context-mode`
2. Manually edit `~/.codex/config.toml` (`[features].hooks = true`, `[mcp_servers.context-mode]`)
3. Manually create/edit `~/.codex/hooks.json` with the routing block
4. Copy `configs/codex/AGENTS.md`

With this PR, the same install becomes:

\`\`\`bash
codex plugin marketplace add mksglu/context-mode
codex plugin install context-mode/context-mode
\`\`\`

## What changed

- `.codex-plugin/plugin.json` — Codex plugin manifest. Inline `mcpServers` declaration pointing to `${CODEX_PLUGIN_ROOT}/start.mjs` (same launch as Claude). Includes `interface` block expected by Codex marketplace UI.
- `.codex-plugin/marketplace.json` — marketplace catalog with one plugin entry.

Both files are minimal and mirror the structure already validated for Claude Code in `.claude-plugin/`. Skills under `./skills/` and hooks under `./hooks/` are reused as-is.

## Validation

Tested end-to-end on a separate marketplace ([tedjy971/teddIA](https://github.com/tedjy971/teddIA)) using the same dual `.claude-plugin/` + `.codex-plugin/` pattern — Codex CLI 0.130.0 installs and auto-spawns the MCP server via the inline `mcpServers` declaration.

Open question for maintainer: whether the `mcpServers` value should be inline (as in this PR) or reference an external `.mcp.json` via path. Current root `.mcp.json` uses `mcpServers` (camelCase) which Codex docs list as one of two accepted forms; happy to adjust to `mcp_servers` snake-case or split into a separate file if preferred.

## Notes

- Does not modify any existing Claude / Codex runtime behavior.
- Version pinned to 1.0.118 to match `.claude-plugin/`. Future bumps can be unified.
- No test coverage added — these are static manifest files. Happy to add a smoke test if you point me to the validation pattern you'd like.