### PR TITLE
test(statusline): align with v1.0.118 byte format + add kb() regression suite

### DIFF
--- a/tests/adapters/omp-statusline-integration.test.ts
+++ b/tests/adapters/omp-statusline-integration.test.ts
@@ -11,6 +11,16 @@ import "../setup-home";
  * a realistic session lifecycle, then spawn bin/statusline.mjs against
  * the DB the plugin actually wrote to and assert the v1.0.118 contract
  * holds end-to-end (no '$', kb()-formatted numbers, expected copy).
+ *
+ * Slices:
+ *   1. ACTIVE render — basic session_start + tool_results → statusline shows
+ *      "{kb} this chat · {kb} lifetime · % kept out"
+ *   2. Routing — tool_call(curl) is blocked AND statusline still renders the
+ *      v1.0.118 format afterward (block side effects don't poison the DB)
+ *   3. Compaction — session_before_compact persists a resume snapshot AND
+ *      statusline continues to render the v1.0.118 format
+ *   4. Tolerance — malformed events don't take statusline down and the
+ *      output stays free of '$'
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
@@ -24,6 +34,11 @@ import { fakeHome } from "../setup-home";
 const STATUSLINE = resolve(process.cwd(), "bin", "statusline.mjs");
 
 type HandlerFn = (...args: unknown[]) => unknown | Promise<unknown>;
+
+interface BlockResult {
+  block?: boolean;
+  reason?: string;
+}
 
 function createMockOmpApi() {
   const handlers: Record<string, HandlerFn[]> = {};
@@ -51,42 +66,47 @@ function runStatusline(env: Record<string, string>): string {
   return (result.stdout ?? "").trim();
 }
 
+/**
+ * Boot a fresh OMP plugin against the mock API and drive `session_start`
+ * so subsequent tool_result events have a session_id to attach to.
+ * Returns the path the plugin's SessionDB lives at and the session_id
+ * it picked, so tests can wire statusline to the right slot.
+ */
+async function bootPlugin(api: ReturnType<typeof createMockOmpApi>) {
+  const { OMPAdapter } = await import("../../src/adapters/omp/index.js");
+  const ompSessionDir = new OMPAdapter().getSessionDir();
+
+  const plugin = await import("../../src/adapters/omp/plugin.js");
+  plugin._resetOmpPluginStateForTests();
+  plugin.default(
+    api as unknown as Parameters<typeof plugin.default>[0],
+  );
+
+  await api._trigger("session_start", { type: "session_start" }, {});
+  const sessionId = plugin._getOmpPluginSessionIdForTests();
+
+  return { ompSessionDir, sessionId };
+}
+
+async function emitReadResult(
+  api: ReturnType<typeof createMockOmpApi>,
+  filePath: string,
+  textBytes: number,
+) {
+  await api._trigger("tool_result", {
+    toolName: "read",
+    input: { file_path: filePath },
+    content: [{ type: "text", text: "x".repeat(textBytes) }],
+  });
+}
+
 describe("OMP plugin → statusline integration (v1.0.118)", () => {
   let tempDir: string;
   let api: ReturnType<typeof createMockOmpApi>;
-  let ompSessionDir: string;
-  let pluginSessionId: string;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), "omp-statusline-int-"));
     api = createMockOmpApi();
-
-    // Discover where the OMP adapter will write — same homedir-rooted path
-    // setup-home's vi.mock on node:os redirects to fakeHome.
-    const { OMPAdapter } = await import("../../src/adapters/omp/index.js");
-    ompSessionDir = new OMPAdapter().getSessionDir();
-
-    // Fresh plugin singletons per test so _sessionId is rebound.
-    const plugin = await import("../../src/adapters/omp/plugin.js");
-    plugin._resetOmpPluginStateForTests();
-    plugin.default(
-      api as unknown as Parameters<typeof plugin.default>[0],
-    );
-
-    // Drive a session: start → a few tool_results carrying real text bytes.
-    await api._trigger("session_start", { type: "session_start" }, {});
-    pluginSessionId = plugin._getOmpPluginSessionIdForTests();
-
-    // Three Read tool_results with sizable text content. extractEvents
-    // converts the response text into a session_event whose bytes_avoided
-    // is the text length — that's what statusline aggregates.
-    for (let i = 0; i < 3; i++) {
-      await api._trigger("tool_result", {
-        toolName: "read",
-        input: { file_path: `/tmp/file-${i}.ts` },
-        content: [{ type: "text", text: "x".repeat(8 * 1024) }],
-      });
-    }
   });
 
   afterEach(() => {
@@ -97,56 +117,214 @@ describe("OMP plugin → statusline integration (v1.0.118)", () => {
     }
   });
 
-  it("writes the session DB to the OMP-rooted path", () => {
-    expect(existsSync(join(ompSessionDir, "context-mode.db"))).toBe(true);
+  // ═══════════════════════════════════════════════════════════
+  // Slice 1: ACTIVE render — plugin + statusline share the DB
+  // ═══════════════════════════════════════════════════════════
+
+  describe("Slice 1: ACTIVE render", () => {
+    it("writes the SessionDB at OMPAdapter.getSessionDir()", async () => {
+      const { ompSessionDir } = await bootPlugin(api);
+      await emitReadResult(api, "/tmp/a.ts", 8 * 1024);
+      expect(existsSync(join(ompSessionDir, "context-mode.db"))).toBe(true);
+    });
+
+    it("statusline renders the ACTIVE block in v1.0.118 byte format", async () => {
+      const { ompSessionDir, sessionId } = await bootPlugin(api);
+      for (let i = 0; i < 3; i++) {
+        await emitReadResult(api, `/tmp/file-${i}.ts`, 8 * 1024);
+      }
+      const out = runStatusline({
+        HOME: fakeHome,
+        CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+        CLAUDE_SESSION_ID: sessionId,
+      });
+      expect(out).toMatch(/context-mode/);
+      // kb() can emit B / KB / MB / GB depending on magnitude — the contract
+      // we pin is the phrase shape, not the magnitude.
+      expect(out).toMatch(/\b\d+(\.\d+)?\s*(B|KB|MB|GB)\s+this chat\b/);
+      expect(out).toMatch(/\b\d+(\.\d+)?\s*(B|KB|MB|GB)\s+lifetime\b/);
+      expect(out).toMatch(/\b\d+%\s+kept out\b/);
+      expect(out).not.toMatch(/\$/);
+      expect(out).not.toMatch(/saved this session/);
+      expect(out).not.toMatch(/efficient/);
+    });
+
+    it("rendered bytes go up monotonically with more events", async () => {
+      const { ompSessionDir, sessionId } = await bootPlugin(api);
+
+      await emitReadResult(api, "/tmp/one.ts", 8 * 1024);
+      const after1 = parseRenderedThisChatBytes(
+        runStatusline({
+          HOME: fakeHome,
+          CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+          CLAUDE_SESSION_ID: sessionId,
+        }),
+      );
+      expect(after1).toBeGreaterThan(0);
+
+      for (let i = 0; i < 5; i++) {
+        await emitReadResult(api, `/tmp/extra-${i}.ts`, 16 * 1024);
+      }
+      const after6 = parseRenderedThisChatBytes(
+        runStatusline({
+          HOME: fakeHome,
+          CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+          CLAUDE_SESSION_ID: sessionId,
+        }),
+      );
+      expect(after6).toBeGreaterThanOrEqual(after1);
+    });
+
+    it("non-matching CLAUDE_SESSION_ID falls back to FRESH state", async () => {
+      const { ompSessionDir } = await bootPlugin(api);
+      await emitReadResult(api, "/tmp/x.ts", 8 * 1024);
+
+      const out = runStatusline({
+        HOME: fakeHome,
+        CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+        CLAUDE_SESSION_ID: "pid-this-id-was-never-seen-by-the-plugin",
+      });
+      expect(out).toMatch(/context-mode/);
+      expect(out).toMatch(/kept out\b/);
+      expect(out).toMatch(/preserved across compact/);
+      expect(out).not.toMatch(/\bthis chat\b/);
+      expect(out).not.toMatch(/\$/);
+    });
   });
 
-  it("statusline renders the ACTIVE block in v1.0.118 byte format", () => {
-    const out = runStatusline({
-      HOME: fakeHome,
-      CONTEXT_MODE_SESSION_DIR: ompSessionDir,
-      CLAUDE_SESSION_ID: pluginSessionId,
+  // ═══════════════════════════════════════════════════════════
+  // Slice 2: Routing block flows back to OMP runtime
+  // ═══════════════════════════════════════════════════════════
+
+  describe("Slice 2: tool_call routing", () => {
+    it("returns a block decision for bash curl", async () => {
+      await bootPlugin(api);
+      const result = (await api._trigger("tool_call", {
+        toolName: "bash",
+        input: { command: "curl https://example.com" },
+      })) as BlockResult | undefined;
+
+      expect(result?.block).toBe(true);
+      expect(result?.reason).toMatch(/context-mode/);
     });
-    expect(out).toMatch(/context-mode/);
-    // kb() emits B / KB / MB / GB depending on magnitude. The plugin only
-    // records bytes_avoided when extractEvents promotes a tool_result to
-    // an event, so this small test ends up in the B range. The contract
-    // we pin is unit-agnostic.
-    expect(out).toMatch(/\b\d+(\.\d+)?\s*(B|KB|MB|GB)\s+this chat\b/);
-    expect(out).toMatch(/kept out\b/);
-    expect(out).not.toMatch(/\$/);
-    expect(out).not.toMatch(/saved this session/);
+
+    it("blocked tool_call does NOT poison the SessionDB used by statusline", async () => {
+      const { ompSessionDir, sessionId } = await bootPlugin(api);
+
+      // Capture one legit event so the session has known bytes.
+      await emitReadResult(api, "/tmp/before.ts", 8 * 1024);
+      const baselineBytes = parseRenderedThisChatBytes(
+        runStatusline({
+          HOME: fakeHome,
+          CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+          CLAUDE_SESSION_ID: sessionId,
+        }),
+      );
+
+      // Now attempt a blocked curl. The plugin should return {block:true}
+      // and the bash result should never reach tool_result, so statusline
+      // bytes should stay the same.
+      await api._trigger("tool_call", {
+        toolName: "bash",
+        input: { command: "curl https://api.example.com/big" },
+      });
+
+      const afterBlockBytes = parseRenderedThisChatBytes(
+        runStatusline({
+          HOME: fakeHome,
+          CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+          CLAUDE_SESSION_ID: sessionId,
+        }),
+      );
+      expect(afterBlockBytes).toBe(baselineBytes);
+    });
+
+    it("non-bash tool_call returns undefined (no block, no DB write)", async () => {
+      await bootPlugin(api);
+      const result = await api._trigger("tool_call", {
+        toolName: "read",
+        input: { file_path: "/tmp/whatever" },
+      });
+      expect(result).toBeUndefined();
+    });
   });
 
-  it("statusline reflects positive bytes captured by the OMP plugin", () => {
-    // We assert "this chat" surfaces a positive byte count rather than
-    // pinning a specific magnitude — extractEvents stores a normalized
-    // data payload, not the raw tool_result text, so the value drifts
-    // with extractor heuristics. The thing we care about: statusline
-    // and the plugin share a SessionDB and the kb() unit chain works
-    // end-to-end.
-    const out = runStatusline({
-      HOME: fakeHome,
-      CONTEXT_MODE_SESSION_DIR: ompSessionDir,
-      CLAUDE_SESSION_ID: pluginSessionId,
+  // ═══════════════════════════════════════════════════════════
+  // Slice 3: session_before_compact + statusline
+  // ═══════════════════════════════════════════════════════════
+
+  describe("Slice 3: compaction lifecycle", () => {
+    it("session_before_compact persists a resume snapshot", async () => {
+      const { ompSessionDir, sessionId } = await bootPlugin(api);
+      await emitReadResult(api, "/tmp/big.ts", 32 * 1024);
+
+      await api._trigger("session_before_compact", { type: "session_before_compact" }, {});
+
+      const { SessionDB } = await import("../../src/session/db.js");
+      const db = new SessionDB({ dbPath: join(ompSessionDir, "context-mode.db") });
+      const resume = db.getResume(sessionId);
+      expect(resume).not.toBeNull();
+      expect(resume?.snapshot.length).toBeGreaterThan(0);
+
+      const stats = db.getSessionStats(sessionId);
+      expect(stats?.compact_count).toBe(1);
     });
-    const match = out.match(/(\d+(?:\.\d+)?)\s*(B|KB|MB|GB)\s+this chat/);
-    expect(match).not.toBeNull();
-    if (!match) return;
-    const [, valueStr] = match;
-    expect(parseFloat(valueStr)).toBeGreaterThan(0);
+
+    it("statusline keeps rendering v1.0.118 format after compaction", async () => {
+      const { ompSessionDir, sessionId } = await bootPlugin(api);
+      await emitReadResult(api, "/tmp/c1.ts", 16 * 1024);
+      await api._trigger("session_before_compact", { type: "session_before_compact" }, {});
+      await emitReadResult(api, "/tmp/c2.ts", 16 * 1024);
+
+      const out = runStatusline({
+        HOME: fakeHome,
+        CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+        CLAUDE_SESSION_ID: sessionId,
+      });
+      expect(out).toMatch(/context-mode/);
+      expect(out).toMatch(/\b\d+(\.\d+)?\s*(B|KB|MB|GB)\s+this chat\b/);
+      expect(out).not.toMatch(/\$/);
+    });
   });
 
-  it("a session_id the plugin did not touch falls back to FRESH state", () => {
-    const out = runStatusline({
-      HOME: fakeHome,
-      CONTEXT_MODE_SESSION_DIR: ompSessionDir,
-      CLAUDE_SESSION_ID: "pid-this-id-was-never-seen-by-the-plugin",
+  // ═══════════════════════════════════════════════════════════
+  // Slice 4: tolerance — malformed events don't take the line down
+  // ═══════════════════════════════════════════════════════════
+
+  describe("Slice 4: malformed-event tolerance", () => {
+    it("malformed tool_result is swallowed; statusline still renders", async () => {
+      const { ompSessionDir, sessionId } = await bootPlugin(api);
+      // No toolName, no content — extractEvents must skip without throwing.
+      await expect(
+        api._trigger("tool_result", { input: {} }),
+      ).resolves.toBeUndefined();
+      // And a follow-up legit event still flows.
+      await emitReadResult(api, "/tmp/legit.ts", 8 * 1024);
+
+      const out = runStatusline({
+        HOME: fakeHome,
+        CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+        CLAUDE_SESSION_ID: sessionId,
+      });
+      expect(out).toMatch(/context-mode/);
+      expect(out).toMatch(/\b\d+(\.\d+)?\s*(B|KB|MB|GB)\s+this chat\b/);
+      expect(out).not.toMatch(/\$/);
     });
-    expect(out).toMatch(/context-mode/);
-    expect(out).toMatch(/kept out\b/);
-    expect(out).toMatch(/preserved across compact/);
-    expect(out).not.toMatch(/\bthis chat\b/);
-    expect(out).not.toMatch(/\$/);
   });
 });
+
+// ── helpers ──────────────────────────────────────────────────
+
+/** Extract the byte count from the "X this chat" segment, in bytes. */
+function parseRenderedThisChatBytes(out: string): number {
+  const match = out.match(/(\d+(?:\.\d+)?)\s*(B|KB|MB|GB)\s+this chat/);
+  if (!match) return 0;
+  const [, valueStr, unit] = match;
+  const value = parseFloat(valueStr);
+  switch (unit) {
+    case "GB": return value * 1024 ** 3;
+    case "MB": return value * 1024 ** 2;
+    case "KB": return value * 1024;
+    default:   return value;
+  }
+}

--- a/tests/adapters/omp-statusline-integration.test.ts
+++ b/tests/adapters/omp-statusline-integration.test.ts
@@ -1,0 +1,152 @@
+import "../setup-home";
+/**
+ * End-to-end integration: OMP plugin → SessionDB → statusline (v1.0.118).
+ *
+ * The unit tests in tests/adapters/omp-plugin.test.ts verify the plugin's
+ * hook behavior in isolation (events landing in SessionDB, snapshot
+ * captured before compact). The statusline tests in tests/statusline*.ts
+ * seed SessionDB directly and pin the v1.0.118 byte-format render.
+ *
+ * This file wires the two halves together: drive the OMP plugin through
+ * a realistic session lifecycle, then spawn bin/statusline.mjs against
+ * the DB the plugin actually wrote to and assert the v1.0.118 contract
+ * holds end-to-end (no '$', kb()-formatted numbers, expected copy).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+import { fakeHome } from "../setup-home";
+
+const STATUSLINE = resolve(process.cwd(), "bin", "statusline.mjs");
+
+type HandlerFn = (...args: unknown[]) => unknown | Promise<unknown>;
+
+function createMockOmpApi() {
+  const handlers: Record<string, HandlerFn[]> = {};
+  return {
+    on: (event: string, handler: HandlerFn) => {
+      (handlers[event] ??= []).push(handler);
+    },
+    _trigger: async (event: string, ...args: unknown[]) => {
+      for (const h of handlers[event] ?? []) {
+        const result = await h(...args);
+        if (result) return result;
+      }
+      return undefined;
+    },
+    _handlers: handlers,
+  };
+}
+
+function runStatusline(env: Record<string, string>): string {
+  const result = spawnSync("node", [STATUSLINE], {
+    input: "{}",
+    env: { ...process.env, NO_COLOR: "1", ...env },
+    encoding: "utf-8",
+  });
+  return (result.stdout ?? "").trim();
+}
+
+describe("OMP plugin → statusline integration (v1.0.118)", () => {
+  let tempDir: string;
+  let api: ReturnType<typeof createMockOmpApi>;
+  let ompSessionDir: string;
+  let pluginSessionId: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "omp-statusline-int-"));
+    api = createMockOmpApi();
+
+    // Discover where the OMP adapter will write — same homedir-rooted path
+    // setup-home's vi.mock on node:os redirects to fakeHome.
+    const { OMPAdapter } = await import("../../src/adapters/omp/index.js");
+    ompSessionDir = new OMPAdapter().getSessionDir();
+
+    // Fresh plugin singletons per test so _sessionId is rebound.
+    const plugin = await import("../../src/adapters/omp/plugin.js");
+    plugin._resetOmpPluginStateForTests();
+    plugin.default(
+      api as unknown as Parameters<typeof plugin.default>[0],
+    );
+
+    // Drive a session: start → a few tool_results carrying real text bytes.
+    await api._trigger("session_start", { type: "session_start" }, {});
+    pluginSessionId = plugin._getOmpPluginSessionIdForTests();
+
+    // Three Read tool_results with sizable text content. extractEvents
+    // converts the response text into a session_event whose bytes_avoided
+    // is the text length — that's what statusline aggregates.
+    for (let i = 0; i < 3; i++) {
+      await api._trigger("tool_result", {
+        toolName: "read",
+        input: { file_path: `/tmp/file-${i}.ts` },
+        content: [{ type: "text", text: "x".repeat(8 * 1024) }],
+      });
+    }
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  it("writes the session DB to the OMP-rooted path", () => {
+    expect(existsSync(join(ompSessionDir, "context-mode.db"))).toBe(true);
+  });
+
+  it("statusline renders the ACTIVE block in v1.0.118 byte format", () => {
+    const out = runStatusline({
+      HOME: fakeHome,
+      CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+      CLAUDE_SESSION_ID: pluginSessionId,
+    });
+    expect(out).toMatch(/context-mode/);
+    // kb() emits B / KB / MB / GB depending on magnitude. The plugin only
+    // records bytes_avoided when extractEvents promotes a tool_result to
+    // an event, so this small test ends up in the B range. The contract
+    // we pin is unit-agnostic.
+    expect(out).toMatch(/\b\d+(\.\d+)?\s*(B|KB|MB|GB)\s+this chat\b/);
+    expect(out).toMatch(/kept out\b/);
+    expect(out).not.toMatch(/\$/);
+    expect(out).not.toMatch(/saved this session/);
+  });
+
+  it("statusline reflects positive bytes captured by the OMP plugin", () => {
+    // We assert "this chat" surfaces a positive byte count rather than
+    // pinning a specific magnitude — extractEvents stores a normalized
+    // data payload, not the raw tool_result text, so the value drifts
+    // with extractor heuristics. The thing we care about: statusline
+    // and the plugin share a SessionDB and the kb() unit chain works
+    // end-to-end.
+    const out = runStatusline({
+      HOME: fakeHome,
+      CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+      CLAUDE_SESSION_ID: pluginSessionId,
+    });
+    const match = out.match(/(\d+(?:\.\d+)?)\s*(B|KB|MB|GB)\s+this chat/);
+    expect(match).not.toBeNull();
+    if (!match) return;
+    const [, valueStr] = match;
+    expect(parseFloat(valueStr)).toBeGreaterThan(0);
+  });
+
+  it("a session_id the plugin did not touch falls back to FRESH state", () => {
+    const out = runStatusline({
+      HOME: fakeHome,
+      CONTEXT_MODE_SESSION_DIR: ompSessionDir,
+      CLAUDE_SESSION_ID: "pid-this-id-was-never-seen-by-the-plugin",
+    });
+    expect(out).toMatch(/context-mode/);
+    expect(out).toMatch(/kept out\b/);
+    expect(out).toMatch(/preserved across compact/);
+    expect(out).not.toMatch(/\bthis chat\b/);
+    expect(out).not.toMatch(/\$/);
+  });
+});

--- a/tests/kb-formatter.test.ts
+++ b/tests/kb-formatter.test.ts
@@ -230,4 +230,44 @@ describe("statusline unit contract (v1.0.118)", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // BRAND_NEW state: both lifetime and session are zero — statusline shows
+  // the marketing headline (no kb() output at all). Pins that the "saves
+  // ~98%" tagline survives the v1.0.118 refactor and the byte-format
+  // surfaces don't intrude here.
+  test("BRAND_NEW state output shows the marketing headline only", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctx-kb-fmt-brand-"));
+    try {
+      // dir has no .db; HOME points to dir so multi-adapter scan finds nothing.
+      const out = runStatusline({
+        HOME: dir,
+        CONTEXT_MODE_SESSION_DIR: dir,
+        CLAUDE_SESSION_ID: "pid-anything",
+      });
+      assert.match(out, /context-mode/);
+      assert.match(out, /saves ~98% of context window/, "BRAND_NEW headline");
+      assert.doesNotMatch(out, /\$/, "no dollar math in any path");
+      assert.doesNotMatch(out, /\bthis chat\b/, "no ACTIVE block");
+      assert.doesNotMatch(out, /\bkept out\b/, "no FRESH/ACTIVE 'kept out' label");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // ACTIVE percent label boundary — v1.0.118 swapped "efficient" for "kept out"
+  // on the percent block. Pin that the new copy renders and the old one doesn't.
+  test("ACTIVE percent block uses 'kept out', never 'efficient'", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctx-kb-fmt-pct-"));
+    try {
+      seedDb({ dir, sessionId: "pid-pct", bytesAvoided: 1_048_576 });
+      const out = runStatusline({
+        CONTEXT_MODE_SESSION_DIR: dir,
+        CLAUDE_SESSION_ID: "pid-pct",
+      });
+      assert.match(out, /\b\d+%\s+kept out\b/, "percent block carries 'kept out' label");
+      assert.doesNotMatch(out, /efficient/, "old 'efficient' label retired");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/kb-formatter.test.ts
+++ b/tests/kb-formatter.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression tests for the v1.0.118 byte-formatter unification.
+ *
+ * v1.0.118 dropped the dual-currency display (statusline rendered "$X
+ * saved" while ctx_stats showed bytes) and routed both surfaces through
+ * a single exported `kb()` formatter in src/session/analytics.ts. These
+ * tests pin the contract so a future change cannot reintroduce a $ in
+ * the statusline or let the two surfaces drift apart again.
+ *
+ * Slices:
+ *   1. kb() boundary values (0, sub-KB, KB, MB, GB)
+ *   2. kb() is exported from analytics (so statusline can import it)
+ *   3. Statusline output never contains "$"
+ *   4. Statusline ACTIVE format uses "this chat" / "lifetime" / "kept out"
+ *   5. Statusline FRESH (lifetime-only) format uses "kept out" / "KB/day"
+ */
+
+import { describe, test, expect } from "vitest";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import Database from "better-sqlite3";
+
+import { kb } from "../src/session/analytics.js";
+
+const STATUSLINE = resolve(process.cwd(), "bin", "statusline.mjs");
+
+function runStatusline(env: Record<string, string>): string {
+  const result = spawnSync("node", [STATUSLINE], {
+    input: "{}",
+    env: { ...process.env, NO_COLOR: "1", ...env },
+    encoding: "utf-8",
+  });
+  return result.stdout.trim();
+}
+
+function seedDb(opts: {
+  dir: string;
+  sessionId: string;
+  bytesAvoided: number;
+  worktreeHash?: string;
+}): void {
+  const hash = opts.worktreeHash ?? "f".repeat(16);
+  const dbPath = join(opts.dir, `${hash}.db`);
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      type TEXT NOT NULL,
+      category TEXT NOT NULL,
+      priority INTEGER NOT NULL DEFAULT 2,
+      data TEXT NOT NULL,
+      project_dir TEXT NOT NULL DEFAULT '',
+      attribution_source TEXT NOT NULL DEFAULT 'unknown',
+      attribution_confidence REAL NOT NULL DEFAULT 0,
+      bytes_avoided INTEGER NOT NULL DEFAULT 0,
+      bytes_returned INTEGER NOT NULL DEFAULT 0,
+      source_hook TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      data_hash TEXT NOT NULL DEFAULT ''
+    );
+    CREATE TABLE IF NOT EXISTS session_meta (
+      session_id TEXT PRIMARY KEY,
+      project_dir TEXT NOT NULL,
+      started_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_event_at TEXT,
+      event_count INTEGER NOT NULL DEFAULT 0,
+      compact_count INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE IF NOT EXISTS session_resume (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL UNIQUE,
+      snapshot TEXT NOT NULL,
+      event_count INTEGER NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      consumed INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  db.prepare(
+    `INSERT INTO session_events (session_id, type, category, data, bytes_avoided, source_hook)
+     VALUES (?, 'tool_use', 'tool', ?, ?, '')`,
+  ).run(opts.sessionId, "x".repeat(64), opts.bytesAvoided);
+  db.prepare(
+    `INSERT OR IGNORE INTO session_meta (session_id, project_dir) VALUES (?, '/tmp/test')`,
+  ).run(opts.sessionId);
+  db.close();
+}
+
+// ── Slice 1: kb() boundaries ──────────────────────────────────────
+
+describe("kb() formatter", () => {
+  test("returns 0 B for non-positive or non-finite values", () => {
+    expect(kb(0)).toBe("0 B");
+    expect(kb(-1)).toBe("0 B");
+    expect(kb(NaN)).toBe("0 B");
+    expect(kb(Infinity)).toBe("0 B");
+  });
+
+  test("returns rounded bytes below 1 KB", () => {
+    expect(kb(1)).toBe("1 B");
+    expect(kb(512)).toBe("512 B");
+    expect(kb(1023)).toBe("1023 B");
+  });
+
+  test("returns KB with one decimal below 100 KB", () => {
+    expect(kb(1024)).toBe("1.0 KB");
+    expect(kb(1536)).toBe("1.5 KB");
+    expect(kb(99 * 1024)).toBe("99.0 KB");
+  });
+
+  test("drops the decimal in KB at and above 100 KB", () => {
+    expect(kb(100 * 1024)).toBe("100 KB");
+    expect(kb(512 * 1024)).toBe("512 KB");
+  });
+
+  test("returns MB with one decimal below 100 MB", () => {
+    expect(kb(1024 * 1024)).toBe("1.0 MB");
+    expect(kb(Math.round(1.5 * 1024 * 1024))).toBe("1.5 MB");
+  });
+
+  test("drops the decimal in MB at and above 100 MB", () => {
+    expect(kb(100 * 1024 * 1024)).toBe("100 MB");
+    expect(kb(356 * 1024 * 1024)).toBe("356 MB");
+  });
+
+  test("returns GB with two decimals below 100 GB", () => {
+    const oneGb = 1024 * 1024 * 1024;
+    expect(kb(oneGb)).toBe("1.00 GB");
+    expect(kb(2.55 * oneGb)).toBe("2.55 GB");
+  });
+
+  test("drops to one decimal in GB at and above 100 GB", () => {
+    const oneGb = 1024 * 1024 * 1024;
+    expect(kb(100 * oneGb)).toBe("100.0 GB");
+    expect(kb(216.6 * oneGb)).toBe("216.6 GB");
+  });
+});
+
+// ── Slice 2: kb is the shared export the statusline imports ───────
+
+describe("kb() shared export contract", () => {
+  test("kb is exported as a function from analytics", async () => {
+    const mod = await import("../src/session/analytics.js");
+    expect(typeof mod.kb).toBe("function");
+  });
+
+  test("statusline.mjs imports kb from analytics", async () => {
+    const { readFileSync } = await import("node:fs");
+    const src = readFileSync(STATUSLINE, "utf-8");
+    // Whitespace-tolerant: kb may sit between siblings inside a destructure.
+    assert.match(src, /\bkb\b\s*[,}]/);
+  });
+});
+
+// ── Slice 3: statusline output never contains "$" ─────────────────
+
+describe("statusline unit contract (v1.0.118)", () => {
+  test("ACTIVE state output contains no '$' character", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctx-kb-fmt-active-"));
+    try {
+      seedDb({ dir, sessionId: "pid-kb-test", bytesAvoided: 1_048_576 });
+      const out = runStatusline({
+        CONTEXT_MODE_SESSION_DIR: dir,
+        CLAUDE_SESSION_ID: "pid-kb-test",
+      });
+      assert.match(out, /context-mode/);
+      assert.doesNotMatch(out, /\$/, "v1.0.118 dropped dollar math from statusline");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ACTIVE state output uses 'this chat' and 'kept out' phrases", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctx-kb-fmt-words-"));
+    try {
+      seedDb({ dir, sessionId: "pid-words", bytesAvoided: 1_048_576 });
+      const out = runStatusline({
+        CONTEXT_MODE_SESSION_DIR: dir,
+        CLAUDE_SESSION_ID: "pid-words",
+      });
+      assert.match(out, /this chat/, "active block uses 'this chat'");
+      assert.match(out, /kept out/, "percentage label is 'kept out'");
+      assert.doesNotMatch(out, /saved this session/, "old phrase must not return");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("ACTIVE state surfaces session bytes through kb() (KB/MB/GB)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctx-kb-fmt-units-"));
+    try {
+      // 1 MB bytes-avoided → statusline must render "1.0 MB this chat".
+      seedDb({ dir, sessionId: "pid-mb", bytesAvoided: 1_048_576 });
+      const out = runStatusline({
+        CONTEXT_MODE_SESSION_DIR: dir,
+        CLAUDE_SESSION_ID: "pid-mb",
+      });
+      assert.match(out, /\b\d+(\.\d+)?\s*(KB|MB|GB)\s+this chat\b/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // FRESH state: lifetime > 0 but the current session has no events. Statusline
+  // falls into the "lead with lifetime" branch and renders the lifetime kb()
+  // total + the "preserved across compact" tagline. We seed under a session_id
+  // the resolver can't match so conversation bytes stay at zero while lifetime
+  // totals are nonzero. The optional "/day" metric only appears when the
+  // analytics layer can compute lifetime age — covered separately in
+  // stats-output-format tests.
+  test("FRESH state output uses kept out + lifetime kb() and contains no '$'", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctx-kb-fmt-fresh-"));
+    try {
+      seedDb({ dir, sessionId: "pid-other", bytesAvoided: 2_097_152 });
+      const out = runStatusline({
+        HOME: dir,
+        CONTEXT_MODE_SESSION_DIR: dir,
+        CLAUDE_SESSION_ID: "pid-mismatch",
+      });
+      assert.match(out, /context-mode/);
+      assert.match(out, /\bkept out\b/, "FRESH state surfaces 'kept out' label");
+      assert.match(out, /\b\d+(\.\d+)?\s*(KB|MB|GB)\b/, "lifetime rendered via kb()");
+      assert.match(out, /preserved across compact/, "FRESH tagline visible");
+      assert.doesNotMatch(out, /\$/, "v1.0.118 dropped dollar math everywhere");
+      assert.doesNotMatch(out, /\bthis chat\b/, "no ACTIVE 'this chat' block in FRESH");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/statusline-sqlite.test.ts
+++ b/tests/statusline-sqlite.test.ts
@@ -155,15 +155,17 @@ describe("statusline.mjs — SessionDB-backed reads", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  // SLICE 1: lifetime $ comes from SessionDB, not from sidecar JSON.
+  // SLICE 1: lifetime bytes come from SessionDB, not from sidecar JSON.
   // Seed a SessionDB with substantial event data → statusline must render
-  // a lifetime $ derived from those bytes (NOT $0.00, NOT a stale sidecar).
+  // a kb()-formatted byte total derived from those bytes (NOT 0, NOT a
+  // stale sidecar). v1.0.118 dropped dollar math; this slice now asserts
+  // on the unified byte formatter.
   // 60s timeout: Windows fork+exec + 1000-row SQLite seed + statusline subprocess
   // (which walks git worktrees + reads SessionDB analytics) regularly takes >30s
   // on the windows-latest runner. Mac/Linux finish in <2s.
-  test("renders lifetime $ from SessionDB session_events bytes", { timeout: 60_000 }, () => {
-    // 1000 events × ~256 bytes data = ~256KB → ~64K tokens → ~$0.96
-    // Use bytes_avoided so it counts as keptOut savings.
+  test("renders lifetime bytes from SessionDB session_events", { timeout: 60_000 }, () => {
+    // 1000 events × 1 KB avoided = ~1 MB lifetime → rendered as "1.0 MB"
+    // by kb(). Use bytes_avoided so it counts as keptOut savings.
     const events = Array.from({ length: 1000 }, () => ({
       bytesAvoided: 1024, // 1KB avoided per event
       data: "x".repeat(64),
@@ -176,20 +178,24 @@ describe("statusline.mjs — SessionDB-backed reads", () => {
     });
 
     assert.match(stdout, /context-mode/, "brand visible");
-    // 1MB avoided ÷ 4 bytes/token = 256K tokens × $15/1M = $3.84 (and bytes_returned=0)
-    // Substantively positive lifetime $ — proves SessionDB is the source.
+    // Substantively positive lifetime number in kb() units (KB/MB/GB) —
+    // proves SessionDB is the source.
     assert.match(
       stdout,
-      /\$([1-9]\d*|0\.\d*[1-9])/,
-      "non-zero $ derived from SessionDB rows",
+      /\b\d+(\.\d+)?\s*(KB|MB|GB)\b/,
+      "kb()-formatted bytes derived from SessionDB rows",
     );
+    assert.doesNotMatch(stdout, /\$/, "v1.0.118 dropped dollar math from statusline");
     assert.doesNotMatch(stdout, /NaN/);
   });
 
   // SLICE 1 cont: no SessionDB → headline fallback (substantiated, no $).
+  // HOME is overridden to dir so getMultiAdapterLifetimeStats finds nothing
+  // and the brand-new path is reached deterministically across machines.
   test("empty sessionsDir falls back to substantiated headline", () => {
     // dir exists but has no .db files
     const { stdout } = runStatusline({
+      HOME: dir,
       CONTEXT_MODE_SESSION_DIR: dir,
       CLAUDE_SESSION_ID: "any-session-id",
     });

--- a/tests/statusline-sqlite.test.ts
+++ b/tests/statusline-sqlite.test.ts
@@ -310,6 +310,10 @@ describe("statusline.mjs — multi-adapter aggregation", () => {
       /across\s+\d+\s+tools?/i,
       "shows multi-adapter aggregate when 2+ real adapters",
     );
+    // v1.0.118 dropped the multi-USD figure that used to ride alongside
+    // "across N tools" — guard that it stays dropped under the
+    // multi-adapter render path too.
+    assert.doesNotMatch(stdout, /\$/, "v1.0.118 dropped dollar math from statusline");
   });
 
   // Slice 2 cont: with only ONE real adapter, do NOT show "across N tools".

--- a/tests/statusline.test.ts
+++ b/tests/statusline.test.ts
@@ -141,8 +141,11 @@ describe("statusline.mjs — render fallbacks", () => {
 
   // BRAND-NEW state: no SessionDB. Falls back to substantiated README
   // headline ("~98% of context window") — no fabricated $/dev/month copy.
+  // HOME is overridden to dir so getMultiAdapterLifetimeStats finds nothing
+  // and the brand-new path is reached deterministically across machines.
   test("brand-new state: no SessionDB shows substantiated headline", () => {
     const out = runStatusline({
+      HOME: dir,
       CONTEXT_MODE_SESSION_DIR: dir,
       CLAUDE_SESSION_ID: "pid-doesnotexist",
     });
@@ -155,6 +158,7 @@ describe("statusline.mjs — render fallbacks", () => {
   test("empty sessions dir shows substantiated headline", () => {
     // dir is freshly mkdtemp'd — empty, no .db files.
     const out = runStatusline({
+      HOME: dir,
       CONTEXT_MODE_SESSION_DIR: dir,
       CLAUDE_SESSION_ID: "pid-empty",
     });
@@ -169,6 +173,7 @@ describe("statusline.mjs — render fallbacks", () => {
   test("corrupt .db file degrades to headline", () => {
     writeFileSync(join(dir, "deadbeefdeadbeef.db"), "not a sqlite file");
     const out = runStatusline({
+      HOME: dir,
       CONTEXT_MODE_SESSION_DIR: dir,
       CLAUDE_SESSION_ID: "pid-bad",
     });
@@ -247,15 +252,17 @@ esac
       CLAUDE_SESSION_ID: "",
     });
 
-    // The session $ block surfaces only when conversation matches the
-    // resolved session_id. "saved this session" proves the walk landed
-    // on pid-90001 and getRealBytesStats found those events.
+    // The session block surfaces only when conversation matches the
+    // resolved session_id. "this chat" proves the walk landed on
+    // pid-90001 and getRealBytesStats found those events. v1.0.118
+    // replaced the $-based "saved this session" phrase with byte-based
+    // "this chat" — pin the new contract.
     assert.match(
       out,
-      /\$[0-9]/,
+      /this chat/,
       "resolver landed on pid-90001 → SessionDB had matching events",
     );
-    assert.match(out, /saved this session/);
+    assert.doesNotMatch(out, /\$/, "v1.0.118 dropped dollar math from statusline");
   });
 
   // linux: walk via /proc/<pid>/status. CTX_TEST_PROC_DIR points at a
@@ -286,8 +293,8 @@ esac
       CLAUDE_SESSION_ID: "",
     });
 
-    assert.match(out, /\$[0-9]/, "resolver landed on pid-70001 via /proc walk");
-    assert.match(out, /saved this session/);
+    assert.match(out, /this chat/, "resolver landed on pid-70001 via /proc walk");
+    assert.doesNotMatch(out, /\$/, "v1.0.118 dropped dollar math from statusline");
   });
 
   // win32: degraded fallback to process.ppid + one-shot stderr warning so
@@ -303,7 +310,8 @@ esac
       CLAUDE_SESSION_ID: "",
     });
 
-    assert.match(stdout, /\$[0-9]/, "fell back to ppid-based session_id");
+    assert.match(stdout, /this chat/, "fell back to ppid-based session_id");
+    assert.doesNotMatch(stdout, /\$/, "v1.0.118 dropped dollar math from statusline");
     assert.match(
       stderr,
       /Windows process-tree walk unsupported/i,
@@ -333,7 +341,7 @@ describe("statusline.mjs — CONTEXT_MODE_SESSION_DIR override", () => {
       CLAUDE_SESSION_ID: "any-id",
     });
     assert.match(out, /context-mode/);
-    assert.match(out, /\$[0-9]/, "render reflects override-dir SessionDB");
-    assert.match(out, /saved this session/);
+    assert.match(out, /this chat/, "render reflects override-dir SessionDB");
+    assert.doesNotMatch(out, /\$/, "v1.0.118 dropped dollar math from statusline");
   });
 });


### PR DESCRIPTION
## Context

`efbd294` ("fix(statusline): drop $ math, mirror ctx_stats byte metrics") landed in v1.0.118 and rewrote `bin/statusline.mjs` around the new exported `kb()` formatter. The test assertions weren't updated alongside it — running `vitest` against the v1.0.118 tag on a clean checkout currently fails 9 statusline tests for the same root cause (still matching on `$[0-9]` and `saved this session`).

This PR catches the tests up and pins the new contract so the dual-currency drift can't reappear silently.

## What changed

**`tests/statusline.test.ts`** — 4 resolver/override blocks and 3 fallback paths now assert on the v1.0.118 copy (`this chat`, `lifetime`, `kept out`, `preserved across compact, restart & upgrade`). Fallback tests also scope `HOME` to the temp dir so `getMultiAdapterLifetimeStats()` can't pull lifetime data from the developer's real home and skip the brand-new headline branch.

**`tests/statusline-sqlite.test.ts`** — the lifetime-$ assertion swapped for a `\b\d+(\.\d+)?\s*(KB|MB|GB)\b` regex; the empty-dir fallback gets the same `HOME` scoping fix.

**`tests/kb-formatter.test.ts`** (new) — regression suite around the unified formatter:
- `kb()` boundary cases across B / KB / MB / GB, including the 100-unit decimal switch in each scale
- `kb` is exported from analytics and `bin/statusline.mjs` imports it
- statusline output never contains `$` in ACTIVE or FRESH state
- ACTIVE renders `{kb} this chat` and ends in `kept out`
- FRESH renders `{kb} kept out · preserved across compact` and omits the ACTIVE `this chat` block

## Test plan

- [x] `npx vitest run tests/kb-formatter.test.ts tests/statusline.test.ts tests/statusline-sqlite.test.ts tests/adapters/omp.test.ts tests/adapters/omp-plugin.test.ts` → 64/64
- [x] `npx vitest run` (full suite) → 2843 passed, 20 skipped. Two `tests/session/continuity.test.ts` cases were flaky under full-suite parallelism but pass cleanly when the file is run in isolation; they're unrelated to this PR.
- [x] Live `node bin/statusline.mjs <<< '{}'` against a populated home produces `1016 KB kept out · 29.9 KB/day · preserved across compact, restart & upgrade` — no `$`.

## Notes for the reviewer

- The `HOME=temp_dir` scoping in the fallback tests is purely a test-isolation fix — it doesn't claim production behavior should change. If you'd rather see `getMultiAdapterLifetimeStats()` take an explicit `home` arg from statusline.mjs (so the test seam matches the production seam), happy to follow up.
- I considered an end-to-end "statusline and `ctx_stats` produce the same kb-formatted byte total for the same DB" parity test, but it's hard to do cleanly without an in-process MCP runtime. Left it out for now; the `kb` import-source check in `kb-formatter.test.ts` is the lightweight stand-in.
- Verified against `omp v14.9.3` with context-mode linked via `omp plugin link` — statusline renders the new format end-to-end.