### PR TITLE
fix(server): suppress startup banner when running as child process

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -3708,13 +3708,15 @@ async function main() {
   // statusline staleness threshold is 30min (cliff is 30 missed ticks away).
   setInterval(() => persistStats(), 60_000).unref();
 
-  console.error(`Context Mode MCP server v${VERSION} running on stdio`);
-  console.error(`Detected runtimes:\n${getRuntimeSummary(runtimes)}`);
-  if (!hasBunRuntime()) {
-    console.error(
-      "\nPerformance tip: Install Bun for 3-5x faster JS/TS execution",
-    );
-    console.error("  curl -fsSL https://bun.sh/install | bash");
+  if (process.stdin.isTTY) {
+    console.error(`Context Mode MCP server v${VERSION} running on stdio`);
+    console.error(`Detected runtimes:\n${getRuntimeSummary(runtimes)}`);
+    if (!hasBunRuntime()) {
+      console.error(
+        "\nPerformance tip: Install Bun for 3-5x faster JS/TS execution",
+      );
+      console.error("  curl -fsSL https://bun.sh/install | bash");
+    }
   }
 }
 

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -4413,3 +4413,28 @@ describe("analytics homedir() import is alive (#43c63cb regression guard)", () =
     expect(dirs.every((d) => d.sessionsDir.startsWith(home))).toBe(true);
   });
 });
+
+// ─────────────────────────────────────────────────────────
+// Startup banner suppression in stdio transport mode.
+// When the server runs as a child process (stdin is not a TTY), the banner
+// must not appear on stderr — Pi and other hosts render stderr in their UI.
+// ─────────────────────────────────────────────────────────
+describe("startup banner suppressed in stdio transport mode", () => {
+  test("no banner on stderr when stdin is not a TTY (child process)", async () => {
+    const bundlePath = resolve(__dirname, "../../server.bundle.mjs");
+    if (!existsSync(bundlePath)) return;
+
+    const stderr = await new Promise<string>((res) => {
+      const proc = spawn(process.execPath, [bundlePath], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, CONTEXT_MODE_SUPPRESS_SECURITY_WARNING: "1" },
+      });
+      let data = "";
+      proc.stderr.on("data", (chunk: Buffer) => { data += chunk.toString(); });
+      setTimeout(() => { proc.kill(); res(data); }, 300);
+    });
+
+    expect(stderr).not.toContain("Context Mode MCP server");
+    expect(stderr).not.toContain("Detected runtimes:");
+  });
+});


### PR DESCRIPTION
## Summary

- When the MCP server runs as a child process (stdio transport), `process.stdin.isTTY` is `false`
- Guard the startup `console.error` banner calls with `if (process.stdin.isTTY)` so they only fire on direct human invocation
- Fixes the `[mcp-bridge]` banner noise appearing in Pi's chat window on every session start

## Root cause

`src/server.ts` wrote the startup banner unconditionally to stderr. The Pi mcp-bridge forwards all child stderr to its UI, so the banner appeared in the chat window on every launch.

## Test plan

- [x] `npm test` — new integration test in `tests/core/server.test.ts` spawns the server bundle with piped stdin and asserts no banner on stderr
- [x] `npm run typecheck` — clean
- [x] Live Pi session — banner absent from chat window on startup