### PR TITLE
fix(skills): ship skills/.ignore so Pi loader skips non-skill markdown (#496)

### DIFF
--- a/skills/.ignore
+++ b/skills/.ignore
@@ -1,0 +1,7 @@
+# Files in this directory that are NOT skills.
+# Pi's skill loader (@mariozechner/pi-coding-agent) reads `.ignore`, `.gitignore`,
+# and `.fdignore` while scanning skill directories with includeRootFiles=true,
+# and skips matching entries. Keeping this list in-package guarantees Pi will not
+# attempt to parse non-skill markdown as a skill — even if a stale copy of the
+# file ever slips into a published tarball (see issue #496 / v1.0.120 regression).
+UPSTREAM-CREDITS.md


### PR DESCRIPTION
## What / Why / How

**What:** Adds `skills/.ignore` listing `UPSTREAM-CREDITS.md` so Pi's skill loader silently skips it during directory scan.

**Why:** Issue #496 was closed in v1.0.112 by PR #428, which moved `skills/UPSTREAM-CREDITS.md` → `docs/UPSTREAM-CREDITS.md`. However, the user [@binhex reports the warning is still present in **v1.0.120**](https://github.com/mksglu/context-mode/issues/496#issuecomment-4418988490):

> The issue is not fixed, still seeing it in v1.0.120:-
> ```
> [Skill conflicts]
>   /config/home/.nvm/versions/node/v24.15.0/lib/node_modules/context-mode/skills/UPSTREAM-CREDITS.md
>     description is required
> ```

Reproduced against the published npm registry tarball:

```bash
npm pack context-mode@1.0.120
tar tzf context-mode-1.0.120.tgz | grep UPSTREAM
# → package/skills/UPSTREAM-CREDITS.md
```

The file is **absent in git** at the v1.0.120 tag (`gh api repos/mksglu/context-mode/contents/skills/UPSTREAM-CREDITS.md?ref=v1.0.120` → 404) and on `main`/`next`. But the published tarball still contains it — classic dirty-working-directory publish regression.

I tried `.npmignore`-based exclusion first, but `package.json`'s `"files"` field [overrides `.npmignore`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files) when a listed directory (here, `"skills"`) contains the file. `.npmignore` cannot scrub it.

**How:** Pi's loader honors `[".gitignore", ".ignore", ".fdignore"]` — verified in `@mariozechner/pi-coding-agent` `dist/core/skills.js:13`:

```js
const IGNORE_FILE_NAMES = [".gitignore", ".ignore", ".fdignore"];
```

Shipping `skills/.ignore` in the package is the **idempotent, defense-in-depth fix**: it works regardless of whether the maintainer publishes from a dirty WD again, regardless of any future non-skill markdown landing in `skills/`, and regardless of which AI-CLI host loads the package.

This is the *exact* "Low-risk fix" the original issue author ([@davegomez](https://github.com/davegomez)) proposed in the issue body — the v1.0.112 fix took the alternative "move file out" path which has now demonstrably failed at the publish boundary.

## Affected platforms

- All hosts that consume the npm package and use a `skills/`-aware loader: Pi (`@mariozechner/pi-coding-agent`), and any other agent that walks the `skills/` directory.
- No runtime impact for Claude Code / Codex / Cursor — those address skills by subdirectory name and ignore non-skill files.

## Test plan

End-to-end repro using Pi's own `loadSkills` against `skills/` with a stale `UPSTREAM-CREDITS.md` planted at the root:

| Scenario | Diagnostics |
|---|---|
| Stale file, **no** `skills/.ignore` (pre-fix, reproduces issue) | `[{ type: "warning", message: "description is required", path: ".../skills/UPSTREAM-CREDITS.md" }]` ← matches the comment verbatim |
| Stale file, **with** `skills/.ignore` (this PR) | `[]` |

The 6 real skills (`context-mode`, `ctx-doctor`, `ctx-insight`, `ctx-purge`, `ctx-stats`, `ctx-upgrade`) continue to load correctly in both cases — the `.ignore` does not over-match.

`npm pack --dry-run` confirms `skills/.ignore` ships in the tarball (so it's effective for end users, not just local).

## Checklist

- [x] Tests added/updated (TDD: red → green) — end-to-end loader repro documented in commit body; no unit test file because Pi loader is an external runtime dependency.
- [x] `npm test` passes (no source changes)
- [x] `npm run typecheck` passes (no source changes)
- [x] Docs updated if needed (README, platform-support.md) — N/A, internal packaging fix
- [x] No Windows path regressions (forward slashes only) — single dotfile, no path code
- [x] Targets `next` branch

## Note on the dirty-publish root cause

The deeper root cause is that `v1.0.120` was published with `skills/UPSTREAM-CREDITS.md` still present in the working directory even though git had removed it. A follow-up could harden the release process (e.g. `git clean -fdx` step before `npm publish`, or a `prepublishOnly` guard that errors if `skills/UPSTREAM-CREDITS.md` exists on disk). I left that out of this PR to keep the diff to one file and one obvious change. Happy to add the guard in a follow-up if you want.

Refs #496