### PR TITLE
fix(session): extract user events from Chinese messages (#535)

### DIFF
--- a/src/session/extract.ts
+++ b/src/session/extract.ts
@@ -815,6 +815,11 @@ const DECISION_PATTERNS: RegExp[] = [
   /\b(no,?\s+(use|do|try|make))\b/i,
   // Turkish patterns
   /\b(hayır|hayir|evet|böyle|boyle|degil|değil|yerine|kullan)\b/i,
+  // Chinese patterns (zh-CN) — \b is Unicode-unaware in JS, so CJK alternates
+  // must live outside any \b…\b group; substring matching is sufficient here.
+  /不要|不用|别|不是|而不是|改用|改成|换成|换用|应该|不应该|宁可|宁愿|优先|选择/,
+  /(?:改|换|用)(?:用|成)?\s*\S+\s*(?:而不是|代替|取代|替代)/,
+  /(?:不,?\s*(?:用|做|试|搞|写))/,
 ];
 
 function extractUserDecision(message: string): SessionEvent[] {
@@ -839,6 +844,9 @@ const ROLE_PATTERNS: RegExp[] = [
   /\b(senior|staff|principal|lead)\s+(engineer|developer|architect)\b/i,
   // Turkish patterns
   /\b(gibi davran|rolünde|olarak çalış)\b/i,
+  // Chinese patterns (zh-CN)
+  /扮演|充当|你是(?:一(?:个|名|位))?|作为(?:一(?:个|名|位))?|当作|角色|身份/,
+  /(?:高级|资深|首席|主管|架构师)(?:工程师|开发(?:者|人员)?|架构师)?/,
 ];
 
 function extractRole(message: string): SessionEvent[] {
@@ -858,11 +866,13 @@ function extractRole(message: string): SessionEvent[] {
  * Session mode classification from user messages.
  */
 
+// Chinese alternates live outside \b…\b groups because JS \b is
+// Unicode-unaware; substring matching is what we want for CJK anyway.
 const INTENT_PATTERNS: Array<{ mode: string; pattern: RegExp }> = [
-  { mode: "investigate", pattern: /\b(why|how does|explain|understand|what is|analyze|debug|look into)\b/i },
-  { mode: "implement",   pattern: /\b(create|add|build|implement|write|make|develop|fix)\b/i },
-  { mode: "discuss",     pattern: /\b(think about|consider|should we|what if|pros and cons|opinion)\b/i },
-  { mode: "review",      pattern: /\b(review|check|audit|verify|test|validate)\b/i },
+  { mode: "investigate", pattern: /\b(why|how does|explain|understand|what is|analyze|debug|look into)\b|为什么|为何|怎么(?!样做|做)|如何|解释|说明|理解|分析|调查|排查|研究(?:一下)?|看看|了解|搞懂|弄清/i },
+  { mode: "implement",   pattern: /\b(create|add|build|implement|write|make|develop|fix)\b|创建|新建|添加|增加|加上|构建|搭建|实现|编写|写一个|做一个|开发|修复|修一下|修改|改一下|完成/i },
+  { mode: "discuss",     pattern: /\b(think about|consider|should we|what if|pros and cons|opinion)\b|讨论|商量|考虑|想想|想一下|是否|要不要|该不该|利弊|优缺点|看法|意见|如果.*?(?:呢|的话)/i },
+  { mode: "review",      pattern: /\b(review|check|audit|verify|test|validate)\b|审查|审核|审计|复查|复审|检查|检验|核查|核对|验证|测试|校验/i },
 ];
 
 function extractIntent(message: string): SessionEvent[] {
@@ -892,6 +902,9 @@ const BLOCKER_PATTERNS: RegExp[] = [
   // Turkish patterns
   /\bbekliyor\b/i,
   /\bbekliyorum\b/i,
+  // Chinese patterns (zh-CN)
+  /阻塞|卡住|卡在|被卡|被阻塞|无法(?:继续|进行|推进)|没法(?:继续|进行)|等待|等着|在等|要等|需要等|依赖于?|取决于/,
+  /(?:需要|得|要)\S{0,8}(?:先|之前|后)?\s*才能/,
 ];
 
 const BLOCKER_RESOLVED_PATTERNS: RegExp[] = [
@@ -900,6 +913,8 @@ const BLOCKER_RESOLVED_PATTERNS: RegExp[] = [
   /\bgot the\s+\S+/i,
   /\bis ready now\b/i,
   /\bcan proceed\b/i,
+  // Chinese patterns (zh-CN)
+  /(?:已经?)?(?:解决|搞定|处理好|修好|完成|好了|就绪|准备好)(?:了|啦)?|可以(?:继续|开始|推进|进行)|解除(?:了)?(?:阻塞|限制)?|不(?:再)?阻塞了?/,
 ];
 
 function extractBlocker(message: string): SessionEvent[] {

--- a/tests/session/session-extract.test.ts
+++ b/tests/session/session-extract.test.ts
@@ -566,6 +566,18 @@ describe("Decision Events", () => {
     assert.equal(decisionEvents.length, 1);
   });
 
+  test("extracts decision from Chinese corrections (#535)", () => {
+    const events = extractUserEvents("不要使用 fetch，改用 ctx_execute");
+    const decisionEvents = events.filter(e => e.type === "decision");
+    assert.equal(decisionEvents.length, 1);
+  });
+
+  test("extracts decision from Chinese 'never/always' directives (#535)", () => {
+    const events = extractUserEvents("别直接 push 到 main，宁可先开 PR");
+    const decisionEvents = events.filter(e => e.type === "decision");
+    assert.equal(decisionEvents.length, 1);
+  });
+
   test("does not extract decision from regular messages", () => {
     const events = extractUserEvents("Can you read the server.ts file?");
     const decisionEvents = events.filter(e => e.type === "decision");
@@ -587,6 +599,18 @@ describe("Role Events", () => {
 
   test("extracts role from 'you are' pattern", () => {
     const events = extractUserEvents("You are a principal architect. Review this design.");
+    const roleEvents = events.filter(e => e.type === "role");
+    assert.equal(roleEvents.length, 1);
+  });
+
+  test("extracts role from Chinese 'act as' pattern (#535)", () => {
+    const events = extractUserEvents("扮演一个高级工程师帮我 review 这份代码");
+    const roleEvents = events.filter(e => e.type === "role");
+    assert.equal(roleEvents.length, 1);
+  });
+
+  test("extracts role from Chinese '你是' pattern (#535)", () => {
+    const events = extractUserEvents("你是一个资深架构师，帮我看看设计");
     const roleEvents = events.filter(e => e.type === "role");
     assert.equal(roleEvents.length, 1);
   });
@@ -794,6 +818,34 @@ describe("Intent Events", () => {
 
   test("extracts discussion intent", () => {
     const events = extractUserEvents("Think about the pros and cons of this approach");
+    const intentEvents = events.filter(e => e.type === "intent");
+    assert.equal(intentEvents.length, 1);
+    assert.equal(intentEvents[0].data, "discuss");
+  });
+
+  test("extracts Chinese investigation intent (#535)", () => {
+    const events = extractUserEvents("为什么这个 hook 没有触发？分析一下原因");
+    const intentEvents = events.filter(e => e.type === "intent");
+    assert.equal(intentEvents.length, 1);
+    assert.equal(intentEvents[0].data, "investigate");
+  });
+
+  test("extracts Chinese implementation intent (#535)", () => {
+    const events = extractUserEvents("创建一个新的 PostToolUse hook");
+    const intentEvents = events.filter(e => e.type === "intent");
+    assert.equal(intentEvents.length, 1);
+    assert.equal(intentEvents[0].data, "implement");
+  });
+
+  test("extracts Chinese review intent (#535)", () => {
+    const events = extractUserEvents("审查一下这段代码的安全问题");
+    const intentEvents = events.filter(e => e.type === "intent");
+    assert.equal(intentEvents.length, 1);
+    assert.equal(intentEvents[0].data, "review");
+  });
+
+  test("extracts Chinese discussion intent (#535)", () => {
+    const events = extractUserEvents("讨论一下这个方案的利弊");
     const intentEvents = events.filter(e => e.type === "intent");
     assert.equal(intentEvents.length, 1);
     assert.equal(intentEvents[0].data, "discuss");
@@ -2540,6 +2592,18 @@ describe("Blocked-On Events", () => {
     assert.equal(blockerEvents.length, 1);
   });
 
+  test("extracts blocker from Chinese '等待' pattern (#535)", () => {
+    const events = extractUserEvents("等待 mert 的回复，目前阻塞中");
+    const blockerEvents = events.filter(e => e.type === "blocker");
+    assert.equal(blockerEvents.length, 1);
+  });
+
+  test("extracts blocker from Chinese '依赖' pattern (#535)", () => {
+    const events = extractUserEvents("这个任务依赖于 auth 服务上线");
+    const blockerEvents = events.filter(e => e.type === "blocker");
+    assert.equal(blockerEvents.length, 1);
+  });
+
   // Resolution tests
 
   test("extracts blocker_resolved from 'unblocked' pattern", () => {
@@ -2570,6 +2634,18 @@ describe("Blocked-On Events", () => {
 
   test("extracts blocker_resolved from 'can proceed' pattern", () => {
     const events = extractUserEvents("we can proceed with the deployment");
+    const resolvedEvents = events.filter(e => e.type === "blocker_resolved");
+    assert.equal(resolvedEvents.length, 1);
+  });
+
+  test("extracts blocker_resolved from Chinese '解决了' pattern (#535)", () => {
+    const events = extractUserEvents("已经解决了，可以继续");
+    const resolvedEvents = events.filter(e => e.type === "blocker_resolved");
+    assert.equal(resolvedEvents.length, 1);
+  });
+
+  test("extracts blocker_resolved from Chinese '搞定了' pattern (#535)", () => {
+    const events = extractUserEvents("搞定了，继续下一步");
     const resolvedEvents = events.filter(e => e.type === "blocker_resolved");
     assert.equal(resolvedEvents.length, 1);
   });


### PR DESCRIPTION
## Summary

Closes #535.

`extractUserEvents()` in `src/session/extract.ts` returned `[]` for non-English (e.g. Chinese) user messages because all five pattern arrays — `DECISION_PATTERNS`, `ROLE_PATTERNS`, `INTENT_PATTERNS`, `BLOCKER_PATTERNS`, `BLOCKER_RESOLVED_PATTERNS` — were English-only (one had a Turkish alternation).

After session compaction, the resulting `<session_resume>` XML had empty `<mode>` / `<decisions>` / `<blockers>` / `<roles>` sections for affected users — the model lost intent, prior decisions, and blocker awareness on resume.

## Reproduction (before this PR)

Running `extractUserEvents()` against representative Chinese prompts on `next` @ `b3ee72f`:

| Message | English equivalent | Before | Expected |
|---|---|---|---|
| `为什么这个 hook 没有触发？分析一下原因` | "why is this hook not firing?" | `[]` | `intent=investigate` |
| `创建一个新的测试文件` | "create a new test file" | `[]` | `intent=implement` |
| `不要使用 fetch，改用 ctx_execute` | "don't use fetch, use ctx_execute instead" | `[]` | `decision` |
| `你扮演一个高级工程师` | "act as a senior engineer" | `[]` | `role` |
| `等待 mert 的回复，目前阻塞中` | "blocked on mert reply" | `[]` | `blocker` |
| `审查这个 PR` | "review this PR" | `[]` | `intent=review` |
| `已经解决了，可以继续` | "unblocked, can proceed" | `[]` | `blocker_resolved` |

After this PR: all 7 produce the expected events.

## Approach

Implemented the issue reporter's proposal (a) — extend each pattern with Chinese alternations. Mirrors the shape of the existing Turkish patterns: pure functions, sync hot path, zero dependencies, zero latency. The LLM-fallback alternative (b) was deferred because it conflicts with `extract.ts`'s file-header invariant ("pure functions, zero side effects") and would block every UserPromptSubmit hook on a model call.

### Key technical note

JavaScript `\b` is **Unicode-unaware** — it only word-boundaries against `[A-Za-z0-9_]`. Naively appending `|创建|添加` inside the existing `\b(...)\b` group would never match, because `\b` treats every CJK codepoint as a non-word character. So CJK alternates are placed **outside** the `\b...\b` group and rely on plain substring matching, which is the right semantic for CJK anyway (no word separators).

```ts
// Before
{ mode: "implement", pattern: /\b(create|add|build|implement|write|make|develop|fix)\b/i }

// After
{ mode: "implement", pattern: /\b(create|add|build|implement|write|make|develop|fix)\b|创建|新建|添加|实现|编写|开发|修复|.../i }
//                            ^^^^^^^ \b group preserved for English ^^^^^ CJK alternates as substrings
```

## Coverage

Pattern extensions per extractor:

- **decision**: 不要 / 别 / 不是 / 而不是 / 改用 / 改成 / 应该 / 宁可 / 选择 / …
- **role**: 扮演 / 充当 / 你是 / 作为 / 角色 / 高级 / 资深 / 首席 / 架构师 / …
- **intent[investigate]**: 为什么 / 为何 / 如何 / 解释 / 分析 / 调查 / 排查 / 研究 / 了解 / …
- **intent[implement]**: 创建 / 新建 / 添加 / 构建 / 实现 / 编写 / 开发 / 修复 / 修改 / 完成 / …
- **intent[discuss]**: 讨论 / 考虑 / 想想 / 是否 / 要不要 / 利弊 / 优缺点 / 看法 / 意见 / …
- **intent[review]**: 审查 / 审核 / 审计 / 复查 / 检查 / 检验 / 核查 / 验证 / 校验 / …
- **blocker**: 阻塞 / 卡住 / 无法继续 / 等待 / 在等 / 依赖于 / 取决于 / …
- **blocker_resolved**: 已解决 / 搞定 / 处理好 / 修好 / 完成 / 就绪 / 可以继续 / 解除阻塞 / …

The existing resolution-takes-priority behavior naturally extends to Chinese: when both blocker and resolved terms appear, `blocker_resolved` wins (matches the English `unblocked, can proceed` flow).

## Tests

Added 12 new zh-CN fixtures across all 5 user-message extractors in `tests/session/session-extract.test.ts`:

- 2 decision (corrections + never/always)
- 2 role (扮演 + 你是)
- 4 intent (investigate / implement / discuss / review)
- 2 blocker (等待 + 依赖)
- 2 blocker_resolved (解决 + 搞定)

Results:

- `tests/session/session-extract.test.ts`: **180/180 pass** (was 168 before; +12 new)
- All `extractUserEvents` callers (`session-extract` + `plugins/openclaw` + `opencode-plugin` + `pi-extension`): **368/368 pass**
- No English regressions

## Notes for reviewers

- **Word-list authority**: treated as best-effort, parallel to the existing Turkish list. Future PRs can add ja/ko/es/de/… by appending alternates to the same regex tail.
- **Mixed-language messages** (`修复 the bug`, `analyze 一下 logs`): existing `INTENT_PATTERNS.find()` returns the first matching mode by array order — unchanged behavior, just now matches more inputs.
- **Maintenance footprint**: if any per-extractor word list grows past ~25 entries, a follow-up should extract them into `src/session/extract-patterns.i18n.ts` to keep `extract.ts` readable. Not needed at current size.
- **Affected platforms**: every UserPromptSubmit hook that calls `extractUserEvents` — Claude Code, Codex, Kiro, Gemini CLI, OpenClaw, OpenCode, Pi (7 platforms).
