### PR TITLE
feat(runtime): add C# support via dotnet-script

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -32,6 +32,7 @@ const SCRIPT_EXT: Record<Language, string> = {
   perl: "pl",
   r: "R",
   elixir: "exs",
+  csharp: "csx",
 };
 
 /** Pure helper — exported for unit testing. Returns "script" or "script.<ext>". */
@@ -297,7 +298,7 @@ export class PolyglotExecutor {
       // .exe paths now (#506), but if it falls back to the bare "bun" string
       // on Windows that resolution typically goes through a `bun.cmd` shim
       // (npm i -g bun) which CreateProcess can't execute without cmd.exe.
-      const needsShell = isWin && ["tsx", "ts-node", "elixir", "bun"].includes(cmd[0]);
+      const needsShell = isWin && ["tsx", "ts-node", "elixir", "bun", "dotnet-script"].includes(cmd[0]);
 
       // On Windows with Git Bash, pass the script as `bash -c "source /posix/path"`
       // rather than `bash /path/to/script.sh`. This avoids MSYS2 path mangling
@@ -492,6 +493,13 @@ export class PolyglotExecutor {
       "R_PROFILE",            // site-wide R profile
       "R_PROFILE_USER",       // user R profile
       "R_HOME",               // R installation override
+      // .NET / C# — runtime/startup hooks, additional deps
+      "DOTNET_STARTUP_HOOKS",       // injects managed assemblies on startup
+      "DOTNET_ADDITIONAL_DEPS",     // additional .deps.json injection
+      "DOTNET_SHARED_STORE",        // shared assembly probe path injection
+      "DOTNET_ROOT",                // arbitrary .NET runtime override
+      "DOTNET_ROOT(x86)",           // 32-bit override
+      "DOTNET_HOST_PATH",           // host binary substitution
       // Dynamic linker — shared library injection
       "LD_PRELOAD",           // loads .so before all others (Linux)
       "DYLD_INSERT_LIBRARIES", // macOS equivalent of LD_PRELOAD
@@ -598,6 +606,11 @@ export class PolyglotExecutor {
         return `FILE_CONTENT_PATH <- ${escaped}\nfile_path <- FILE_CONTENT_PATH\nFILE_CONTENT <- readLines(FILE_CONTENT_PATH, warn=FALSE, encoding="UTF-8")\nFILE_CONTENT <- paste(FILE_CONTENT, collapse="\\n")\n${code}`;
       case "elixir":
         return `file_content_path = ${escaped}\nfile_path = file_content_path\nfile_content = File.read!(file_content_path)\n${code}`;
+      case "csharp":
+        // .csx forbids `using` directives after any other top-level statement
+        // (CS1529). User code inside executeFile must use fully-qualified type
+        // names (e.g. `System.Text.Json.JsonDocument`) instead of `using`.
+        return `var FILE_CONTENT_PATH = ${escaped};\nvar file_path = FILE_CONTENT_PATH;\nvar FILE_CONTENT = System.IO.File.ReadAllText(FILE_CONTENT_PATH);\n${code}`;
     }
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -32,7 +32,8 @@ export type Language =
   | "php"
   | "perl"
   | "r"
-  | "elixir";
+  | "elixir"
+  | "csharp";
 
 export interface RuntimeInfo {
   command: string;
@@ -53,6 +54,7 @@ export interface RuntimeMap {
   perl: string | null;
   r: string | null;
   elixir: string | null;
+  csharp: string | null;
 }
 
 const isWindows = process.platform === "win32";
@@ -264,6 +266,7 @@ export function detectRuntimes(): RuntimeMap {
         ? "r"
         : null,
     elixir: commandExists("elixir") ? "elixir" : null,
+    csharp: commandExists("dotnet-script") ? "dotnet-script" : null,
   };
 }
 
@@ -326,6 +329,10 @@ export function getRuntimeSummary(runtimes: RuntimeMap): string {
     lines.push(
       `  Elixir:     ${runtimes.elixir} (${getVersion(runtimes.elixir)})`,
     );
+  if (runtimes.csharp)
+    lines.push(
+      `  C#:         ${runtimes.csharp} (${getVersion(runtimes.csharp)})`,
+    );
 
   if (!bunPreferred) {
     lines.push("");
@@ -348,6 +355,7 @@ export function getAvailableLanguages(runtimes: RuntimeMap): Language[] {
   if (runtimes.perl) langs.push("perl");
   if (runtimes.r) langs.push("r");
   if (runtimes.elixir) langs.push("elixir");
+  if (runtimes.csharp) langs.push("csharp");
   return langs;
 }
 
@@ -448,5 +456,13 @@ export function buildCommand(
         throw new Error( "Elixir not available. Install elixir.");
       }
       return ["elixir", filePath];
+
+    case "csharp":
+      if (!runtimes.csharp) {
+        throw new Error(
+          "C# not available. Install dotnet-script via `dotnet tool install -g dotnet-script`.",
+        );
+      }
+      return [runtimes.csharp, filePath];
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1063,12 +1063,13 @@ server.registerTool(
           "perl",
           "r",
           "elixir",
+          "csharp",
         ])
         .describe("Runtime language"),
       code: z
         .string()
         .describe(
-          "Source code to execute. Use console.log (JS/TS), print (Python/Ruby/Perl/R), echo (Shell), echo (PHP), fmt.Println (Go), or IO.puts (Elixir) to output a summary to context.",
+          "Source code to execute. Use console.log (JS/TS), print (Python/Ruby/Perl/R), echo (Shell), echo (PHP), fmt.Println (Go), IO.puts (Elixir), or Console.WriteLine (C#) to output a summary to context.",
         ),
       timeout: z
         .coerce.number()
@@ -1396,12 +1397,13 @@ server.registerTool(
           "perl",
           "r",
           "elixir",
+          "csharp",
         ])
         .describe("Runtime language"),
       code: z
         .string()
         .describe(
-          "Code to process FILE_CONTENT (file_content in Elixir). Print summary via console.log/print/echo/IO.puts.",
+          "Code to process FILE_CONTENT (file_content in Elixir). Print summary via console.log/print/echo/IO.puts/Console.WriteLine.",
         ),
       timeout: z
         .coerce.number()

--- a/tests/executor.test.ts
+++ b/tests/executor.test.ts
@@ -110,6 +110,7 @@ describe("Runtime Detection", () => {
       perl: null,
       r: null,
       elixir: null,
+      csharp: null,
     };
     assert.throws(
       () => buildCommand(noRuntimes, "typescript", "/tmp/t.ts"),
@@ -126,6 +127,10 @@ describe("Runtime Detection", () => {
     assert.throws(
       () => buildCommand(noRuntimes, "elixir", "/tmp/t.exs"),
       /Elixir not available/,
+    );
+    assert.throws(
+      () => buildCommand(noRuntimes, "csharp", "/tmp/t.csx"),
+      /C# not available/,
     );
   });
 
@@ -686,6 +691,40 @@ IO.puts(result)
   });
 });
 
+describe.runIf(runtimes.csharp)("CSharp Execution", () => {
+  test("C#: hello world", async () => {
+    const r = await executor.execute({
+      language: "csharp",
+      code: 'Console.WriteLine("hello from csharp");',
+    });
+    assert.equal(r.exitCode, 0, r.stderr);
+    assert.ok(r.stdout.includes("hello from csharp"));
+  });
+
+  test("C#: LINQ over array", async () => {
+    const r = await executor.execute({
+      language: "csharp",
+      code: `
+using System.Linq;
+var nums = Enumerable.Range(1, 10);
+var evens = nums.Where(n => n % 2 == 0).ToArray();
+Console.WriteLine($"sum: {evens.Sum()}");
+      `,
+    });
+    assert.equal(r.exitCode, 0, r.stderr);
+    assert.ok(r.stdout.includes("sum: 30"));
+  });
+
+  test("C#: error returns non-zero exit", async () => {
+    const r = await executor.execute({
+      language: "csharp",
+      code: 'throw new System.Exception("intentional error");',
+    });
+    assert.notEqual(r.exitCode, 0);
+    assert.ok(r.stderr.length > 0 || r.stdout.includes("intentional error"));
+  });
+});
+
 describe("Error Handling", () => {
   test("JS: syntax error returns non-zero", async () => {
     const r = await executor.execute({
@@ -946,6 +985,21 @@ puts "Users: #{data['users'].length}"
       `,
     });
     assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.includes("Users: 3"));
+  });
+
+  test.runIf(runtimes.csharp)("execute_file: C# reads FILE_CONTENT", async () => {
+    const r = await executor.executeFile({
+      path: testFile,
+      language: "csharp",
+      code: `
+using (var doc = System.Text.Json.JsonDocument.Parse(FILE_CONTENT)) {
+  var users = doc.RootElement.GetProperty("users").GetArrayLength();
+  System.Console.WriteLine($"Users: {users}");
+}
+      `,
+    });
+    assert.equal(r.exitCode, 0, r.stderr);
     assert.ok(r.stdout.includes("Users: 3"));
   });
 
@@ -1689,6 +1743,7 @@ describe("Windows Shell Support", () => {
     assert.equal(buildScriptFilename("ruby", "win32"), "script.rb");
     assert.equal(buildScriptFilename("go", "win32"), "script.go");
     assert.equal(buildScriptFilename("rust", "win32"), "script.rs");
+    assert.equal(buildScriptFilename("csharp", "win32"), "script.csx");
   });
 
   test("buildScriptFilename: non-shell languages keep their extension on Unix", async () => {

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -55,6 +55,7 @@ describe("runtime version reporting", () => {
       perl: null,
       r: null,
       elixir: null,
+      csharp: null,
     };
 
     const summary = getRuntimeSummary(runtimes);
@@ -283,6 +284,7 @@ describe("runnableExists — Windows MS Store stub filter (#454)", () => {
         Rscript: "throw",
         r: "throw",
         elixir: "throw",
+        "dotnet-script": "throw",
       },
       versionExits: { python3: "ok" },
     });
@@ -325,6 +327,7 @@ describe("runnableExists — Windows MS Store stub filter (#454)", () => {
         Rscript: "throw",
         r: "throw",
         elixir: "throw",
+        "dotnet-script": "throw",
       },
       // Probes must NOT be reached because all hits are stubs and `where` short-circuits.
       versionExits: {},
@@ -366,6 +369,7 @@ describe("runnableExists — Windows MS Store stub filter (#454)", () => {
         Rscript: "throw",
         r: "throw",
         elixir: "throw",
+        "dotnet-script": "throw",
       },
       versionExits: { python3: { code: 9009 } },
     });
@@ -399,6 +403,7 @@ describe("runnableExists — Windows MS Store stub filter (#454)", () => {
         Rscript: "throw",
         r: "throw",
         elixir: "throw",
+        "dotnet-script": "throw",
       },
       versionExits: { py: "ok" },
     });
@@ -576,6 +581,7 @@ describe("buildCommand shell variants", () => {
       perl: null,
       r: null,
       elixir: null,
+      csharp: null,
     };
   }
 


### PR DESCRIPTION
## What / Why / How

  Adds C# as the 11th polyglot runtime in context-mode. `ctx_execute(language: "csharp")` and `ctx_execute_file(...,
  language: "csharp")` now run `.csx` scripts via `dotnet-script`. Mirrors how Ruby, Perl, and Elixir are already wired.

  **Why:** users on .NET-heavy stacks were forced to leave the sandbox to run any C# (`Bash` then context flood) or rewrite snippets in another language. Adding the runtime keeps think-in-code working for the same audience that already gets Ruby/Elixir support.

  **How:**

  - **`src/runtime.ts`**: extend `Language` union, `RuntimeMap`, `detectRuntimes`, `getRuntimeSummary`,
  `getAvailableLanguages`, and `buildCommand`. Detection is `commandExists("dotnet-script")`; the install hint surfaces in the buildCommand error: `dotnet tool install -g dotnet-script`.
  - **`src/executor.ts`**: `SCRIPT_EXT` maps `csharp` to `csx`; `dotnet-script` added to the Windows `needsShell` list (it's a `.cmd` shim under `%USERPROFILE%\.dotnet\tools`); six `DOTNET_*` env vars stripped from the sandboxed child env (`DOTNET_STARTUP_HOOKS`, `DOTNET_ADDITIONAL_DEPS`, `DOTNET_SHARED_STORE`, `DOTNET_ROOT`, `DOTNET_ROOT(x86)`, `DOTNET_HOST_PATH`, all known runtime-hijack or startup-hook injection vectors); `#wrapWithFileContent` emits `var FILE_CONTENT_PATH = ...;` with a code comment documenting the `.csx` CS1529 constraint (a `using` directive cannot follow any other top-level statement, so user code inside `executeFile` must use fully-qualified type names).
  - **`src/server.ts`**: add `"csharp"` to both MCP tool language enums (ctx_execute + ctx_execute_file) and mention
  `Console.WriteLine` in the output-summary descriptions. `langList` derives from `getAvailableLanguages`, so the runtime  list in the tool description updates automatically.

  ## Affected platforms

  - [x] All platforms

  Runtime additions flow through the shared MCP server, so every adapter that surfaces `ctx_execute` / `ctx_execute_file` picks up `csharp` automatically. No adapter-specific wiring was touched.

  ## Test plan

  Added to `tests/executor.test.ts`:

  - `buildCommand` throws-for-unavailable case asserting `/C# not available/` matches the runtime.ts error.
  - `buildScriptFilename("csharp", "win32") === "script.csx"`.
  - A `describe.runIf(runtimes.csharp)("CSharp Execution", ...)` block with three tests: hello-world via `Console.WriteLine`, LINQ over `Enumerable.Range`, and a `throw` returning a non-zero exit code.
  - A `test.runIf(runtimes.csharp)("execute_file: C# reads FILE_CONTENT")` that parses the shared `users.json` fixture via `System.Text.Json.JsonDocument` (fully-qualified per the CS1529 note).

  Added to `tests/runtime.test.ts`:

  - `csharp: null` added to every `RuntimeMap` literal (2 locations).
  - `"dotnet-script": "throw"` added to all 4 `whereResults` mocks so the existing detection-cascade tests stay tight.

  **Local results** (macOS 24.6, `dotnet-script` installed via `dotnet tool install -g dotnet-script`):

  Test Files  2 passed (2)
  Tests       135 passed | 14 skipped (149)

  Without `dotnet-script`, the `runIf`-gated tests skip and the suite still passes, matching how Ruby/Perl/Elixir behave on
  minimal CI images.

  **ctx_doctor before / after** (after symlinking the local clone over the cache per CONTRIBUTING.md):

  Before: [OK] Runtimes: 8/11 (73%) - javascript, shell, typescript, python, ruby, go, rust, perl
  After:  [OK] Runtimes: 9/12 (75%) - javascript, shell, typescript, python, ruby, go, rust, perl, csharp

  ## Checklist

  - [x] Tests added/updated (TDD: red, green)
  - [x] `npm test` passes (135/135 in touched files; pre-existing flake in `tests/hooks/*` from parallel HOME collisions on
  `next` is unrelated, same files pass when run in isolation)
  - [x] `npm run typecheck` passes
  - [ ] Docs updated if needed (README, platform-support.md).
   **Happy to add a C# row to any runtime table if you point me at it; didn't see one called out**
  - [x] No Windows path regressions (forward slashes only). No path code touched; `dotnet-script` Windows quirk handled via the existing `needsShell` array
  - [x] Targets `next` branch

  <details>
  <summary><strong>Cross-platform notes</strong></summary>

  - **Windows:** `dotnet-script` installs as `dotnet-script.cmd` under `%USERPROFILE%\.dotnet\tools`. Added to `needsShell` alongside `tsx` / `ts-node` / `elixir` / `bun` so `CreateProcess` resolves it through `cmd.exe` instead of ENOENT-ing on the `.cmd` shim.
  - **macOS / Linux:** no special handling. `dotnet-script` is a single binary on `PATH`.
  - **Env stripping:** the six `DOTNET_*` keys removed from child env are the documented startup-hook / runtime-substitution injection vectors. `DOTNET_CLI_TELEMETRY_OPTOUT` and similar benign settings are intentionally **not** stripped.

  </details>