### PR TITLE
fix(pi): move respawn guard to request() + single-flight + smoke pin (#583 follow-up)

### DIFF
--- a/scripts/tier2-smoke/run-pi-smoke.sh
+++ b/scripts/tier2-smoke/run-pi-smoke.sh
@@ -19,6 +19,14 @@ SMOKE_DIR="$REPO_ROOT/scripts/tier2-smoke"
 LOG_DIR="${RUNNER_TEMP:-/tmp}/tier2-smoke-pi"
 mkdir -p "$LOG_DIR"
 
+# Disable MCP idle self-shutdown for the smoke run (#583 follow-up).
+# v1.0.132+ idles the MCP child after CONTEXT_MODE_IDLE_TIMEOUT_MS of no
+# activity (default 15 min). The Pi adapter's bridge auto-respawns on the
+# next tool call — which would mask a real silent-death regression by
+# making it look like a normal idle exit. Pin to 0 here so any MCP exit
+# during the smoke is genuinely anomalous and shows up in the log.
+export CONTEXT_MODE_IDLE_TIMEOUT_MS=0
+
 PI_BIN="${PI_BIN:-$(command -v pi || true)}"
 PI_HEADLESS_FLAGS="${PI_HEADLESS_FLAGS:---headless}"
 FIXTURE="${FIXTURE:-$SMOKE_DIR/fixtures/search-corpus.txt}"

--- a/src/adapters/pi/mcp-bridge.ts
+++ b/src/adapters/pi/mcp-bridge.ts
@@ -147,6 +147,15 @@ export class MCPStdioClient {
   private initialized = false;
   private exited = false;
   /**
+   * In-flight respawn promise — set while {@link respawn} runs so
+   * concurrent callers awaiting `request()` after an idle exit observe
+   * the SAME respawn, not N parallel ones. Without this guard, two
+   * simultaneous `callTool` calls would each see `this.exited === true`,
+   * each fire their own `respawn()`, and the loser leaks an orphaned
+   * child process the GC cannot reach (no `.kill()` reference).
+   */
+  private respawnPromise: Promise<void> | null = null;
+  /**
    * Live env passed to the spawned child — exposed (read-only intent)
    * so tests can pin the fork-bomb-prevention env counter (#516)
    * without needing to attach a process-tree probe.
@@ -260,13 +269,34 @@ export class MCPStdioClient {
     }
   }
 
-  request<T = unknown>(
+  async request<T = unknown>(
     method: string,
     params: unknown,
     timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
   ): Promise<T> {
+    // Respawn-on-idle-exit (#583, #583-followup).
+    //
+    // Initial #583 fix patched callTool() only. The structural location is
+    // here: `request()` is the single chokepoint for `initialize`,
+    // `tools/list`, `tools/call`, and any future method. Patching at this
+    // layer means listTools / re-initialize paths after an idle exit also
+    // self-heal, not just the registered-tool happy path.
+    //
+    // Sequencing is critical: respawn() resets `exited`, `child`, and
+    // `buffer` BEFORE start() + initialize(). The initialize() call inside
+    // respawn() goes through this same request() — recursion is safe
+    // because by the time we re-enter, `exited` is false again. We use a
+    // single-flight `respawnPromise` so concurrent callers share the same
+    // respawn (orphan-child guard, see field comment).
+    if (this.exited) {
+      if (!this.respawnPromise) {
+        this.respawnPromise = this.respawn().finally(() => {
+          this.respawnPromise = null;
+        });
+      }
+      await this.respawnPromise;
+    }
     if (!this.child) throw new Error("MCP client not started");
-    if (this.exited) return Promise.reject(new Error("MCP server has exited"));
     const id = ++this.requestId;
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -315,19 +345,11 @@ export class MCPStdioClient {
   }
 
   async callTool(name: string, args: unknown): Promise<MCPCallResult> {
-    // Respawn-on-idle-exit (#583). The MCP server gained an idle
-    // self-shutdown in 1.0.132 (#565/#568, src/lifecycle.ts). When the
-    // Pi-spawned child exits cleanly after the idle window, Pi keeps the
-    // tool handles registered, but the bridge client is `exited=true`
-    // and every subsequent request would reject with
-    // "MCP server has exited" — leaving Pi's ctx_* tools permanently
-    // broken until the user restarts Pi.
-    //
-    // The structural fix is here, not in lifecycle.ts: the bridge owns
-    // the child lifecycle, so it transparently respawns + re-initialises
-    // the server on the next call. Restores parity with adapters whose
-    // host MCP client respawns on EOF (Claude Code, Codex, etc.).
-    if (this.exited) await this.respawn();
+    // Respawn-on-idle-exit is now handled centrally in `request()`
+    // (#583 follow-up). Originally patched here in #583 — moving it up
+    // one layer covers `listTools` / `initialize` paths too, with a
+    // single-flight guard against orphan child processes from
+    // concurrent callers.
     return this.request<MCPCallResult>(
       "tools/call",
       { name, arguments: args ?? {} },
@@ -340,12 +362,23 @@ export class MCPStdioClient {
    * Resets state so a fresh `start()` + `initialize()` cycle runs, then
    * the caller's pending request flows through the new child.
    *
-   * Internal — exposed only via the public `callTool()` happy path.
+   * Single-flight — concurrent callers share one in-flight respawn via
+   * {@link respawnPromise}. Internal — only entered via {@link request}.
+   *
+   * Sequencing pinned (do not reorder without updating the regression
+   * test in tests/adapters/pi-mcp-bridge.test.ts):
+   *   1. `this.child = null`     — drop stale handle
+   *   2. `this.buffer = ""`       — discard leftover bytes from old child
+   *   3. `this.exited = false`    — must precede `start()` + `initialize()`,
+   *                                 because `request("initialize", …)`
+   *                                 inside `initialize()` re-checks this
+   *                                 flag and would otherwise re-enter
+   *                                 respawn in an infinite loop
+   *   4. `this.initialized = false`
+   *   5. `this.start()`
+   *   6. `await this.initialize()` — flows through `request()` recursively
    */
   private async respawn(): Promise<void> {
-    // Drop the dead child handle and clear stream buffer so leftover
-    // bytes from the previous incarnation don't get parsed as JSON-RPC
-    // for the new one. Pending map is already cleared by onExit().
     this.child = null;
     this.buffer = "";
     this.exited = false;

--- a/tests/adapters/pi-mcp-bridge.test.ts
+++ b/tests/adapters/pi-mcp-bridge.test.ts
@@ -249,3 +249,239 @@ describe("MCPStdioClient — respawns after idle self-shutdown (#583)", () => {
     client.shutdown();
   }, 15_000);
 });
+
+// ── #583 follow-up: hardening on top of the original respawn-on-exit fix ──
+//
+// The original #583 patch put the respawn guard in `callTool()` only.
+// The follow-up moves it into `request()` (covering `tools/list` and
+// `initialize` paths after idle exit) AND adds a single-flight guard so
+// concurrent callers don't each spawn their own child and leak orphans.
+describe("MCPStdioClient — request() respawns for any method after idle exit (#583 follow-up)", () => {
+  it("listTools() after an idle exit triggers respawn (not just callTool)", async () => {
+    // Fake server: exits after the FIRST tools/list response. The bridge
+    // must respawn on the next listTools() invocation — proving the
+    // respawn guard fires for `tools/list`, not only `tools/call`.
+    const markerPath = join(scratch, "first-incarnation-marker-list");
+    const fakePath = join(scratch, "exit-after-list.mjs");
+    writeFileSync(
+      fakePath,
+      `
+      import { existsSync, writeFileSync } from "node:fs";
+      const MARKER = ${JSON.stringify(markerPath)};
+      const isFirst = !existsSync(MARKER);
+      let line = "";
+      let listCount = 0;
+      process.stdin.on("data", (chunk) => {
+        line += chunk.toString("utf-8");
+        let idx;
+        while ((idx = line.indexOf("\\n")) >= 0) {
+          const raw = line.slice(0, idx).trim();
+          line = line.slice(idx + 1);
+          if (!raw) continue;
+          let msg;
+          try { msg = JSON.parse(raw); } catch { continue; }
+          if (msg.method === "initialize") {
+            process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-06-18", capabilities: {} } }) + "\\n");
+          } else if (msg.method === "tools/list") {
+            listCount++;
+            process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "ping-pid-" + process.pid, description: "p", inputSchema: { type: "object" } }] } }) + "\\n");
+            if (isFirst && listCount === 1) {
+              writeFileSync(MARKER, "1");
+              setTimeout(() => process.exit(0), 10);
+            }
+          }
+        }
+      });
+      setInterval(() => {}, 60000);
+      `,
+      "utf-8",
+    );
+
+    const { MCPStdioClient } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const client = new MCPStdioClient(fakePath);
+    client.start();
+    await client.initialize();
+
+    // First listTools: original incarnation responds, then exits.
+    const tools1 = await client.listTools();
+    expect(tools1).toHaveLength(1);
+    const pid1 = tools1[0].name.replace(/^ping-pid-/, "");
+
+    // Wait for the child to actually exit.
+    await new Promise<void>((resolve) => {
+      const wait = () => {
+        if ((client as unknown as { exited: boolean }).exited) return resolve();
+        setTimeout(wait, 25);
+      };
+      wait();
+    });
+
+    // Second listTools: should respawn + re-init, NOT reject. Bug class:
+    // pre-fix, this would reject with "MCP server has exited" because the
+    // respawn guard lived in callTool only and tools/list went straight
+    // through request().
+    const tools2 = await client.listTools();
+    expect(tools2).toHaveLength(1);
+    const pid2 = tools2[0].name.replace(/^ping-pid-/, "");
+    expect(pid2).not.toBe(pid1);
+
+    client.shutdown();
+  }, 15_000);
+
+  it("concurrent callTool() invocations after exit share ONE respawn (no orphan children)", async () => {
+    // Failure mode without the single-flight guard: caller A and caller B
+    // both observe `this.exited === true`, both invoke respawn(), each
+    // spawns a child. The loser of the race overwrites `this.child` and
+    // its child becomes an orphan with no `.kill()` reference.
+    //
+    // The fake server marks every PID it spawns under a directory. After
+    // two concurrent calls, exactly ONE new PID should be observed.
+    const markerPath = join(scratch, "first-incarnation-marker-concurrent");
+    const pidsDir = join(scratch, "spawned-pids-concurrent");
+    const fakePath = join(scratch, "exit-after-call-concurrent.mjs");
+    writeFileSync(
+      fakePath,
+      `
+      import { existsSync, writeFileSync, mkdirSync } from "node:fs";
+      import { join as joinPath } from "node:path";
+      const MARKER = ${JSON.stringify(markerPath)};
+      const PIDS_DIR = ${JSON.stringify(pidsDir)};
+      mkdirSync(PIDS_DIR, { recursive: true });
+      // Record this process pid the moment we boot — covers both the
+      // first incarnation AND any respawned child.
+      writeFileSync(joinPath(PIDS_DIR, String(process.pid)), "1");
+      const isFirst = !existsSync(MARKER);
+      let line = "";
+      let callCount = 0;
+      process.stdin.on("data", (chunk) => {
+        line += chunk.toString("utf-8");
+        let idx;
+        while ((idx = line.indexOf("\\n")) >= 0) {
+          const raw = line.slice(0, idx).trim();
+          line = line.slice(idx + 1);
+          if (!raw) continue;
+          let msg;
+          try { msg = JSON.parse(raw); } catch { continue; }
+          if (msg.method === "initialize") {
+            process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-06-18", capabilities: {} } }) + "\\n");
+          } else if (msg.method === "tools/list") {
+            process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "ping", description: "p", inputSchema: { type: "object" } }] } }) + "\\n");
+          } else if (msg.method === "tools/call") {
+            callCount++;
+            process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { content: [{ type: "text", text: "pong-" + process.pid }] } }) + "\\n");
+            if (isFirst && callCount === 1) {
+              writeFileSync(MARKER, "1");
+              setTimeout(() => process.exit(0), 10);
+            }
+          }
+        }
+      });
+      setInterval(() => {}, 60000);
+      `,
+      "utf-8",
+    );
+
+    const { MCPStdioClient } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const client = new MCPStdioClient(fakePath);
+    client.start();
+    await client.initialize();
+
+    // First call: original incarnation responds and exits.
+    await client.callTool("ping", {});
+
+    // Wait for exit.
+    await new Promise<void>((resolve) => {
+      const wait = () => {
+        if ((client as unknown as { exited: boolean }).exited) return resolve();
+        setTimeout(wait, 25);
+      };
+      wait();
+    });
+
+    // Now fire TWO callTool invocations simultaneously — both see
+    // `this.exited === true`. Without single-flight, both would call
+    // respawn(), each spawning its own child. With single-flight, only
+    // one child should be spawned and both calls share it.
+    const [r1, r2] = await Promise.all([
+      client.callTool("ping", {}),
+      client.callTool("ping", {}),
+    ]);
+    const respPid1 = (r1.content?.[0]?.text ?? "").replace(/^pong-/, "");
+    const respPid2 = (r2.content?.[0]?.text ?? "").replace(/^pong-/, "");
+    // Both calls must resolve through the SAME respawned child.
+    expect(respPid1).toBe(respPid2);
+
+    // Filesystem evidence: exactly two pids ever marked (original +
+    // one respawn). If two respawns raced, we'd see 3 pid files.
+    const { readdirSync } = await import("node:fs");
+    const recordedPids = readdirSync(pidsDir);
+    expect(recordedPids).toHaveLength(2);
+
+    client.shutdown();
+  }, 20_000);
+
+  it("respawn() resets state in the documented order — `exited=false` BEFORE initialize()", async () => {
+    // Pin the sequencing contract called out in respawn()'s JSDoc.
+    // If a future refactor moves `this.exited = false` to AFTER
+    // `await this.initialize()`, the recursive request("initialize", ...)
+    // inside respawn would see `exited === true` and re-enter respawn
+    // forever (infinite loop, not just a stale reject).
+    //
+    // We exercise the path: state ALL clears before initialize fires.
+    const fakePath = join(scratch, "introspect-respawn.mjs");
+    writeFileSync(
+      fakePath,
+      `
+      let line = "";
+      process.stdin.on("data", (chunk) => {
+        line += chunk.toString("utf-8");
+        let idx;
+        while ((idx = line.indexOf("\\n")) >= 0) {
+          const raw = line.slice(0, idx).trim();
+          line = line.slice(idx + 1);
+          if (!raw) continue;
+          let msg;
+          try { msg = JSON.parse(raw); } catch { continue; }
+          if (msg.method === "initialize") {
+            process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { protocolVersion: "2025-06-18", capabilities: {} } }) + "\\n");
+          } else if (msg.method === "tools/call") {
+            process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: { content: [{ type: "text", text: "ok" }] } }) + "\\n");
+          }
+        }
+      });
+      setInterval(() => {}, 60000);
+      `,
+      "utf-8",
+    );
+
+    const { MCPStdioClient } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const client = new MCPStdioClient(fakePath);
+    client.start();
+    await client.initialize();
+
+    // Force the exited flag, then trigger a callTool — request() should
+    // run respawn, which must reset state before initialize() fires.
+    const internal = client as unknown as {
+      exited: boolean;
+      initialized: boolean;
+      child: unknown;
+    };
+
+    // Mark it as exited manually (simulating the post-onExit state
+    // without actually killing the child — keeps test deterministic).
+    internal.exited = true;
+
+    // callTool must succeed via the respawn path. If `exited` is not
+    // cleared before the recursive request("initialize", ...) call,
+    // this hangs forever and the test times out at the per-it limit.
+    const res = await client.callTool("ping", {});
+    expect((res.content?.[0]?.text ?? "")).toBe("ok");
+
+    // Post-call invariants — proves respawn finished cleanly.
+    expect(internal.exited).toBe(false);
+    expect(internal.initialized).toBe(true);
+    expect(internal.child).not.toBeNull();
+
+    client.shutdown();
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

Hardens the [#583](#583) respawn-on-idle-exit fix in `src/adapters/pi/mcp-bridge.ts`. After auditing the original commit (`9df6fa1`), three remaining gaps in the same code path:

1. **`tools/list` and `initialize` paths bypass the respawn guard.** The original fix only patched `callTool()`, but both `listTools()` and the recursive `initialize()` inside the respawn itself go straight through `request()`, which still rejects with `"MCP server has exited"`.

2. **Concurrent `callTool()` calls after idle exit spawn orphan children.** Two parallel calls both observe `this.exited === true`, both invoke `respawn()`, each spawns a child. The loser of the race overwrites `this.child` and its child becomes an orphan with no `.kill()` reference.

3. **`respawn()` state-reset ordering is undocumented.** The `this.exited = false` flag MUST be cleared before `await this.initialize()` (which calls `request("initialize", …)` recursively). If a refactor moves the reset to after, the recursive request sees `exited === true` and re-enters respawn forever — a silent hang, not just a stale reject.

## Changes

### `src/adapters/pi/mcp-bridge.ts`

- **Move the respawn-on-exited guard from `callTool()` into `request()`** — the single chokepoint for `initialize` / `tools/list` / `tools/call` / any future method. `callTool()` simplified to delegate.
- **Add `private respawnPromise: Promise<void> | null` for single-flight semantics.** Concurrent callers awaiting `request()` after idle exit observe the SAME respawn promise. Cleared in `.finally()` so the next exit can respawn again.
- **Document the `respawn()` state-reset ordering** in JSDoc with explicit pointer to the new regression test that pins it (steps 1–6 numbered).

### `scripts/tier2-smoke/run-pi-smoke.sh`

- Export `CONTEXT_MODE_IDLE_TIMEOUT_MS=0` at startup so the smoke harness doesn't mask a real silent-death regression behind the new auto-respawn path. Without this, the smoke's long idle gaps would trigger the respawn → look like normal idle exit → swallow the failure signal.

### `tests/adapters/pi-mcp-bridge.test.ts`

Three new regression tests under a new `describe` block `"#583 follow-up"`:

<details>
<summary><strong>Test 1 — listTools() after idle exit triggers respawn (not just callTool)</strong></summary>

Fake MCP server exits after the first `tools/list` response. The bridge must respawn on the next `listTools()` invocation. Pre-fix this would reject with `"MCP server has exited"` because the respawn guard lived only in `callTool()` and `listTools()` went straight through `request()`.

Asserts: a fresh child PID is observed on the second listTools, proving respawn fired through the non-callTool path.
</details>

<details>
<summary><strong>Test 2 — Concurrent callTool() invocations after exit share ONE respawn</strong></summary>

The orphan-child guard. Fake server records its pid to a marker directory on every boot. Two parallel `callTool()` calls fire from the exited state.

Pre-fix without single-flight: 3 pid files on disk (original + 2 racing respawns), divergent caller pids.
Post-fix with single-flight: exactly 2 pid files (original + one respawn), both callers' responses carry the same pid.
</details>

<details>
<summary><strong>Test 3 — respawn() resets state in the documented order</strong></summary>

Pins the sequencing contract. Manually flips `internal.exited = true` (post-onExit shape without an actual kill, for determinism), then `callTool()` must run respawn → initialize() through `request()` recursively. This only terminates if `exited` was cleared before the recursive call.

If the contract is ever broken by a refactor (moving the flag reset to after `initialize()`), this test times out at the per-it limit instead of silently rejecting — surfacing the regression class loudly.
</details>

## Verification

```
Targeted: tests/adapters/pi-mcp-bridge.test.ts → 9/9 pass
Full suite: 3331 pass, 48 skipped
```

The full suite has 3 pre-existing failures (`VSCODE_PID` inheritance, `IDEA_INITIAL_DIRECTORY`) — confirmed unchanged by stashing this PR's diff and running against clean `upstream/next` HEAD. Not introduced here.

## Risk

All four risks bounded and tested:

| Risk | Mitigation |
|---|---|
| Single-flight promise leak if respawn throws | `.finally(() => { this.respawnPromise = null; })` ensures slot clears on both success and failure paths |
| Recursive `request → initialize → request` infinite loop | Test 3 pins the `exited = false` ordering invariant |
| `tools/list` still rejects | Test 1 pins the listTools respawn path |
| Smoke masks idle-exit by auto-respawn | `CONTEXT_MODE_IDLE_TIMEOUT_MS=0` in `run-pi-smoke.sh` |

Other adapters audited — only `src/adapters/pi/mcp-bridge.ts` spawns and keeps a long-lived MCP child in our own code. All other adapters delegate child management to the host (Claude Code, Codex, OpenCode, etc.) which has its own EOF/respawn behaviour outside our control.

## Refs

#583 (original fix this hardens), #565, #568
