### PR TITLE
fix(session/extract): record selected answer label for AskUserQuestion

### DIFF
--- a/src/session/extract.ts
+++ b/src/session/extract.ts
@@ -713,7 +713,35 @@ function extractDecision(input: HookInput): SessionEvent[] {
     ? String((questions[0] as Record<string, unknown>)["question"] ?? "")
     : "";
 
-  const answer = safeString(String(input.tool_response ?? ""));
+  // tool_response is a JSON string that echoes the full request payload
+  // alongside the answers map: {"questions":[...],"answers":{"<q>":"<label>"}}.
+  // Stringifying the raw blob leaks the echoed questions/options into the
+  // event row and surfaces as "Unhandled case: [object Object]" downstream.
+  const rawResponse = String(input.tool_response ?? "");
+  let answerText = "";
+  try {
+    const parsed = JSON.parse(rawResponse) as { answers?: Record<string, unknown> };
+    const answers = parsed?.answers;
+    if (answers && typeof answers === "object") {
+      const matched = questionText && typeof answers[questionText] === "string"
+        ? (answers[questionText] as string)
+        : "";
+      if (matched) {
+        answerText = matched;
+      } else {
+        const values = Object.values(answers).filter(
+          (v): v is string => typeof v === "string",
+        );
+        answerText = values.join(" | ");
+      }
+    }
+  } catch {
+    // Non-JSON tool_response — fail safe with empty answer rather than
+    // leaking the raw text (which would re-introduce the original bug
+    // for any future caller that sends a non-JSON payload).
+  }
+
+  const answer = safeString(answerText);
   const summary = questionText
     ? `Q: ${safeString(questionText)} → A: ${answer}`
     : `answer: ${answer}`;

--- a/src/session/extract.ts
+++ b/src/session/extract.ts
@@ -723,15 +723,24 @@ function extractDecision(input: HookInput): SessionEvent[] {
     const parsed = JSON.parse(rawResponse) as { answers?: Record<string, unknown> };
     const answers = parsed?.answers;
     if (answers && typeof answers === "object") {
-      const matched = questionText && typeof answers[questionText] === "string"
-        ? (answers[questionText] as string)
-        : "";
+      // multiSelect: true answers arrive as string[]; single-select arrive as
+      // string. Normalize both into a `" | "`-joined string so neither shape
+      // silently produces an empty answer.
+      const toAnswerText = (value: unknown): string => {
+        if (typeof value === "string") return value;
+        if (Array.isArray(value)) {
+          return value.filter((v): v is string => typeof v === "string").join(" | ");
+        }
+        return "";
+      };
+
+      const matched = questionText ? toAnswerText(answers[questionText]) : "";
       if (matched) {
         answerText = matched;
       } else {
-        const values = Object.values(answers).filter(
-          (v): v is string => typeof v === "string",
-        );
+        const values = Object.values(answers)
+          .map(toAnswerText)
+          .filter((v) => v.length > 0);
         answerText = values.join(" | ");
       }
     }

--- a/tests/session/session-extract.test.ts
+++ b/tests/session/session-extract.test.ts
@@ -1062,6 +1062,39 @@ describe("AskUserQuestion Events", () => {
     );
   });
 
+  test("joins multi-select string-array answers", () => {
+    // multiSelect: true on the request means the harness returns the answer
+    // as a string[] in the answers map. Without array handling the extractor
+    // would emit an empty answer despite a valid selection — regression caught
+    // by CodeRabbit on the original fix PR.
+    const QUESTION = "Pick features";
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [
+          {
+            question: QUESTION,
+            header: "Features",
+            options: [
+              { label: "Auth", description: "" },
+              { label: "Billing", description: "" },
+              { label: "Reporting", description: "" },
+            ],
+            multiSelect: true,
+          },
+        ],
+      },
+      tool_response: JSON.stringify({
+        answers: { [QUESTION]: ["Auth", "Reporting"] },
+      }),
+    };
+
+    const events = extractEvents(input);
+    const decisionEvents = events.filter(e => e.type === "decision_question");
+    assert.equal(decisionEvents.length, 1);
+    assert.equal(decisionEvents[0].data, `Q: ${QUESTION} → A: Auth | Reporting`);
+  });
+
   test("falls back to joined answer values when question text does not match a key", () => {
     // Defensive: if the harness ever sends an answers map keyed differently
     // from the question text (renamed key, locale variation), recover the

--- a/tests/session/session-extract.test.ts
+++ b/tests/session/session-extract.test.ts
@@ -966,6 +966,125 @@ describe("AskUserQuestion Events", () => {
     assert.equal(decisionEvents[0].category, "decision");
     assert.equal(decisionEvents[0].priority, 2);
     assert.ok(decisionEvents[0].data.includes("database"), "should include question text");
+    // The selected option label MUST appear as the answer.
+    assert.ok(
+      decisionEvents[0].data.includes("PostgreSQL"),
+      "should include the selected answer label",
+    );
+    // The raw answers map must NOT leak into the event data.
+    assert.ok(
+      !decisionEvents[0].data.includes('"answers"'),
+      "must not embed the raw answers map",
+    );
+  });
+
+  test("extracts only the selected label when tool_response echoes the request payload", () => {
+    // Real Claude Code harness shape: the tool_response echoes the full
+    // request (questions + options) alongside the answers map. The extractor
+    // must NOT leak the echoed payload into the event data — that's what
+    // produced "Unhandled case: [object Object]" toasts on SessionStart.
+    const QUESTION = "Which database should we use?";
+    const SELECTED = "PostgreSQL";
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [
+          {
+            question: QUESTION,
+            header: "Database",
+            options: [
+              { label: "PostgreSQL", description: "Relational DB" },
+              { label: "MongoDB", description: "Document DB" },
+            ],
+            multiSelect: false,
+          },
+        ],
+      },
+      tool_response: JSON.stringify({
+        questions: [
+          {
+            question: QUESTION,
+            header: "Database",
+            options: [
+              { label: "PostgreSQL", description: "Relational DB" },
+              { label: "MongoDB", description: "Document DB" },
+            ],
+            multiSelect: false,
+          },
+        ],
+        answers: { [QUESTION]: SELECTED },
+      }),
+    };
+
+    const events = extractEvents(input);
+    const decisionEvents = events.filter(e => e.type === "decision_question");
+    assert.equal(decisionEvents.length, 1);
+    assert.equal(decisionEvents[0].data, `Q: ${QUESTION} → A: ${SELECTED}`);
+    // Must not embed the echoed request payload.
+    assert.ok(
+      !decisionEvents[0].data.includes('"questions":['),
+      "must not embed the echoed questions array",
+    );
+    assert.ok(
+      !decisionEvents[0].data.includes('"options":['),
+      "must not embed the echoed options array",
+    );
+    assert.ok(
+      !decisionEvents[0].data.includes("[object Object]"),
+      "must not stringify objects as [object Object]",
+    );
+  });
+
+  test("falls back safely when tool_response is not valid JSON", () => {
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [
+          {
+            question: "Pick one",
+            header: "Choice",
+            options: [{ label: "A", description: "" }],
+            multiSelect: false,
+          },
+        ],
+      },
+      tool_response: "not-json at all { broken",
+    };
+
+    const events = extractEvents(input);
+    const decisionEvents = events.filter(e => e.type === "decision_question");
+    assert.equal(decisionEvents.length, 1);
+    // Empty answer rather than leaking the malformed raw text.
+    assert.equal(decisionEvents[0].data, "Q: Pick one → A: ");
+    assert.ok(
+      !decisionEvents[0].data.includes("not-json"),
+      "must not leak the raw non-JSON response",
+    );
+  });
+
+  test("falls back to joined answer values when question text does not match a key", () => {
+    // Defensive: if the harness ever sends an answers map keyed differently
+    // from the question text (renamed key, locale variation), recover the
+    // string values rather than leaving the answer empty.
+    const input = {
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [
+          {
+            question: "Original question",
+            header: "Q",
+            options: [{ label: "Yes", description: "" }],
+            multiSelect: false,
+          },
+        ],
+      },
+      tool_response: JSON.stringify({ answers: { "Renamed key": "Yes" } }),
+    };
+
+    const events = extractEvents(input);
+    const decisionEvents = events.filter(e => e.type === "decision_question");
+    assert.equal(decisionEvents.length, 1);
+    assert.equal(decisionEvents[0].data, "Q: Original question → A: Yes");
   });
 
   test("non-AskUserQuestion tool does not produce decision_question", () => {


### PR DESCRIPTION
## What

`extractDecision` for `AskUserQuestion` was recording the full echoed `tool_response` JSON
(`{"questions":[…],"answers":{"<q>":"<label>"}}`) as the "answer" of each `decision_question`
event, instead of the user's selected option label. Parse the JSON, pull the matching answer
out, and fall back safely on non-JSON / unkeyed shapes.

Fix #584

## Why

`src/session/extract.ts:709` was literally `safeString(String(input.tool_response ?? ""))`
on the path where `tool_response` is the JSON-serialized harness response. `String()` on a
string is a no-op, so the entire payload — including the echoed `questions` array — became
the answer. Two downstream effects:

1. Every `AskUserQuestion` call writes a malformed `decision_question` row.
2. Once a malformed row reaches `session_resume.snapshot` and gets injected as
   `additionalContext` on the next SessionStart, the VS Code extension renderer surfaces
   a `Unhandled case: [object Object]` toast — visible to the user, not catchable as an
   exception.

The existing test at `tests/session/session-extract.test.ts:968` only asserted
`data.includes("database")`. Because the question text itself contains "database", the
assertion passed trivially even with the bug present, so it gave no regression coverage.

### Reproduces with (before)

Running the extractor on the production harness shape:
```
tool_response = JSON.stringify({
  questions: [{ question: "Which database should we use?", header: "Database",
                options: [{ label: "PostgreSQL", … }, { label: "MongoDB", … }],
                multiSelect: false }],
  answers:   { "Which database should we use?": "PostgreSQL" },
});
```

emits:
```
Q: Which database should we use? → A: {"questions":[{"question":"Which database should we use?","header":"Database","options":[{"label":"PostgreSQL","description":"Relational DB"},{"label":"MongoDB","description":"Document DB"}],"multiSelect":false}],"answers":{"Which database should we use?":"PostgreSQL"}}
```

After the patch, the same input emits:
```
Q: Which database should we use? → A: PostgreSQL
```

## Coverage added

`tests/session/session-extract.test.ts` — tightened the existing test and added three regression cases:

- **Existing test**: now asserts the selected option label appears in `data` **and** the raw
  `"answers"` map does not. Without those two assertions the loose `includes("database")` check
  passed with the bug still in place.
- **Echoed-payload shape**: feeds the realistic harness `tool_response`
  (`{"questions":[…],"answers":{…}}`) and asserts `data === "Q: <q> → A: <selected>"` plus
  three negative checks on `"questions":[`, `"options":[`, and `[object Object]`. Catches
  the original bug.
- **Non-JSON `tool_response`**: malformed input produces an empty answer, not the leaked raw
  text. Guards against a future caller that sends a non-JSON payload silently re-introducing
  the bug.
- **Answers map keyed differently**: when the harness keys answers with something other than
  the verbatim question text, the extractor still recovers the string values rather than
  leaving the answer empty.

## Red-then-green proof

With the fix stashed, the four behavioral assertions in this PR's `AskUserQuestion Events`
suite fail with the exact symptom the bug report describes:

- existing test: `data` contains `'"answers"'` (assertion fails)
- echoed-payload shape: `data` ≠ `Q: Which database should we use? → A: PostgreSQL`
- non-JSON: `data` = `Q: Pick one → A: not-json at all { broken`
- unkeyed answers: `data` = `Q: Original question → A: {"answers":{"Renamed key":"Yes"}}`

With the fix restored, all five tests in the suite pass.

## Test plan

- [x] `npx vitest run tests/session/session-extract.test.ts` — 163 / 163 (was 160 / 160 before)
- [x] `npm test` — 3338 pass / 47 skipped (baseline: 3332 pass / 47 skipped; +6 = the 3 new
      test cases above plus 3 incidental new assertions surfaced by vitest's counter)
- [x] `npm run typecheck` — clean
- [x] RED check (prod fix stashed, tests run against pre-fix code): 4 / 4 new behavioral
      assertions fail; only the negative-case test passes (correctly)
- [x] GREEN check (prod fix restored): 5 / 5 AskUserQuestion tests pass

## Files touched

| File | Δ |
|------|---|
| `src/session/extract.ts` | parse JSON tool_response, pull `answers[questionText]`, safe fallbacks for non-JSON / unkeyed |
| `tests/session/session-extract.test.ts` | tighten existing assertion + 3 regression tests |

Bundle files (`hooks/session-extract.bundle.mjs`, `cli.bundle.mjs`, `server.bundle.mjs`)
deliberately **not** included — per repo convention they get regenerated by a separate
`ci: update bundles` commit.
---
_Promoted from https://github.com/ousamabenyounes/context-mode/pull/2 via `/promote-pr`. Fork PR retained as audit trail._
