### PR TITLE
fix(routing): re-fire external-MCP nudge periodically, not once per session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,6 +1372,12 @@ Two runtime knobs control how MCP server processes self-manage. Defaults are saf
 
 Both vars are read fresh at MCP server start — no restart of the host CLI is required, just spawn a new MCP child (open a new session) for changes to take effect. Invalid values (non-numeric `CONTEXT_MODE_IDLE_TIMEOUT_MS`, unrecognized `CONTEXT_MODE_STARTUP_SWEEP`) fall back to defaults silently.
 
+### Routing-guidance environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY` | `10` | Cadence (in tool calls) at which the PreToolUse hook re-injects the "wrap large external-MCP payloads in `ctx_execute`" guidance. The original implementation ([#529](https://github.com/mksglu/context-mode/pull/529)) fired only once per session, which got lost after context compaction in MCP-heavy sessions (e.g. 50+ Jira/Slack/Notion calls — see [#567](https://github.com/mksglu/context-mode/issues/567) follow-up). The default re-fires every 10th matching call, keeping the guidance in the model's recent window. Range `[1, 100]`; invalid values fall back to `10`. Set to `1` for "every call" (most aggressive — adds ~250 tokens/call) or to a larger value for less frequent reminders. |
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and TDD guidelines.

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -17,7 +17,7 @@ import {
 } from "../routing-block.mjs";
 import { createToolNamer } from "./tool-naming.mjs";
 import { isMCPReady } from "./mcp-ready.mjs";
-import { existsSync, mkdirSync, rmSync, rmdirSync, readdirSync, unlinkSync, openSync, closeSync, statSync, constants as fsConstants } from "node:fs";
+import { existsSync, mkdirSync, rmSync, rmdirSync, readdirSync, unlinkSync, openSync, closeSync, readFileSync, writeFileSync, statSync, constants as fsConstants } from "node:fs";
 
 /**
  * Guard for actions that redirect to MCP tools (#230).
@@ -48,6 +48,32 @@ import { resolve } from "node:path";
 // pass it to routePreToolUse so the marker directory stays consistent across
 // invocations of the same logical session.
 const _guidanceShown = new Set();
+
+// Periodic-guidance counters: how many times each (sessionId, type) pair has
+// fired the periodic branch. Keyed by `${sessionId-or-ppid}::${type}`.
+// File-backed for cross-process so hook invocations from the same logical
+// session keep the counter coherent.
+const _guidanceCounters = new Map();
+
+// External-MCP nudge cadence — fire every N matching tool calls.
+// Default 10: keeps the guidance fresh in long MCP-heavy sessions (e.g. a
+// Jira/Slack/Notion run with 50+ tool calls — see #567 follow-up) without
+// flooding context with repeat nudges. Bounds [1, 100]; invalid env values
+// fall back to default. period=1 means "fire every call" (opt-in only).
+const EXTERNAL_MCP_NUDGE_DEFAULT = 10;
+const EXTERNAL_MCP_NUDGE_MIN = 1;
+const EXTERNAL_MCP_NUDGE_MAX = 100;
+const EXTERNAL_MCP_NUDGE_ENV = "CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY";
+
+function getExternalMcpNudgeEvery() {
+  const raw = process.env[EXTERNAL_MCP_NUDGE_ENV];
+  if (raw == null || raw === "") return EXTERNAL_MCP_NUDGE_DEFAULT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < EXTERNAL_MCP_NUDGE_MIN || parsed > EXTERNAL_MCP_NUDGE_MAX) {
+    return EXTERNAL_MCP_NUDGE_DEFAULT;
+  }
+  return parsed;
+}
 
 function defaultGuidanceId() {
   return process.env.VITEST_WORKER_ID
@@ -86,6 +112,56 @@ function guidanceOnce(type, content, sessionId) {
 }
 
 /**
+ * Like guidanceOnce, but fires on a periodic cadence (calls 1, period+1,
+ * 2·period+1, …) rather than once per session.
+ *
+ * Motivation: external-MCP tool runs can span 50+ calls (e.g. a Jira/Slack
+ * search loop — see #567 follow-up). A single one-shot nudge gets lost
+ * after the model's context compaction kicks in, and subsequent large MCP
+ * payloads flood context unchecked. Re-firing the nudge every N calls
+ * keeps the guidance in the model's recent window without saturating it.
+ *
+ * Counter state is process-aware: in-memory Map for same-process callers,
+ * file-backed `<guidanceDir>/<type>.count` for cross-process hook
+ * invocations. On any IO/parse failure we fall back to firing — losing a
+ * counter is preferable to silently dropping the advisory.
+ */
+function guidancePeriodic(type, content, sessionId, period) {
+  const safePeriod = Math.max(1, period | 0);
+  const id = sessionId ? `s-${sessionId}` : defaultGuidanceId();
+  const key = `${id}::${type}`;
+
+  // Read counter from memory first; fall through to disk on miss.
+  let count = _guidanceCounters.get(key);
+  const dir = guidanceDirFor(sessionId);
+  const counterPath = resolve(dir, `${type}.count`);
+
+  if (count == null) {
+    try {
+      const parsed = Number.parseInt(readFileSync(counterPath, "utf8"), 10);
+      count = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+    } catch {
+      count = 0;
+    }
+  }
+
+  const next = count + 1;
+  _guidanceCounters.set(key, next);
+
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(counterPath, String(next), "utf8");
+  } catch {
+    // Best-effort: cross-process counter may drift on FS failure, but we
+    // still return a decision based on the in-memory tick.
+  }
+
+  // Fire on the 1st, (period+1)th, (2·period+1)th… call.
+  if ((next - 1) % safePeriod !== 0) return null;
+  return { action: "context", additionalContext: content };
+}
+
+/**
  * Robust recursive delete. On Windows, `fs.rmSync` on directories under a
  * tmpdir whose path contains non-ASCII characters (e.g. a Chinese / Japanese /
  * Korean username) silently no-ops without throwing — see #454. Fall back to a
@@ -105,6 +181,7 @@ function rmSyncRobust(dir) {
 
 export function resetGuidanceThrottle(sessionId) {
   _guidanceShown.clear();
+  _guidanceCounters.clear();
   // Clear ppid-based dir (legacy / fallback callers) and the sessionId dir if given
   rmSyncRobust(guidanceDirFor());
   if (sessionId) {
@@ -806,14 +883,20 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
     return null;
   }
 
-  // ─── External MCP tools: one-shot guidance about routing large payloads ─── (#529)
+  // ─── External MCP tools: periodic guidance about routing large payloads ─── (#529, #567 follow-up)
   // hooks/hooks.json registers a `mcp__(?!plugin_context-mode_)` matcher so this
   // branch fires for slack/telegram/gdrive/notion-style MCPs whose results would
   // otherwise spill into context. We don't deny or modify — the agent still needs
   // the tool's output; we just nudge it to pipe large results through ctx_execute.
+  //
+  // Cadence: every N calls (default 10, tunable via CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY).
+  // The original one-shot nudge (#529) was lost after context compaction in
+  // MCP-heavy sessions (e.g. 50+ Jira calls in #567 follow-up), letting later
+  // payloads flood context unchecked. Re-firing periodically keeps the guidance
+  // in the model's recent window without saturating it.
   if (isExternalMcpTool(toolName)) {
     const externalMcpGuidance = platform ? createExternalMcpGuidance(t) : EXTERNAL_MCP_GUIDANCE;
-    return guidanceOnce("external-mcp", externalMcpGuidance, sessionId);
+    return guidancePeriodic("external-mcp", externalMcpGuidance, sessionId, getExternalMcpNudgeEvery());
   }
 
   // Unknown tool — pass through

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -636,14 +636,68 @@ describe("routePreToolUse", () => {
       }
     });
 
-    it("respects the once-per-session guidance throttle", () => {
-      const first = routePreToolUse("mcp__slack__post_message", {});
-      expect(first).not.toBeNull();
-      expect(first!.action).toBe("context");
+    // #567 follow-up — the external-MCP nudge is intentionally periodic, not
+    // one-shot. A single nudge gets lost in MCP-heavy sessions (50+ Jira
+    // calls) once context compaction kicks in, so we re-fire every N calls to
+    // keep the guidance in the model's recent window.
+    it("re-fires guidance every N calls (default cadence = 10)", () => {
+      const calls = Array.from({ length: 22 }, (_, i) =>
+        routePreToolUse(`mcp__slack__tool_${i}`, {}),
+      );
 
-      // Second call in the same session — guidanceOnce should suppress it.
+      // Fires on the 1st, 11th, 21st calls — null in between.
+      const fired = calls.map((c) => c?.action === "context");
+      const expected = calls.map((_, i) => i % 10 === 0);
+      expect(fired).toEqual(expected);
+    });
+
+    it("honors CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY to tune cadence", () => {
+      const prev = process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY;
+      try {
+        process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY = "3";
+        const calls = Array.from({ length: 7 }, (_, i) =>
+          routePreToolUse(`mcp__notion__tool_${i}`, {}),
+        );
+        const fired = calls.map((c) => c?.action === "context");
+        // period=3 → fires on calls 1, 4, 7 (indices 0, 3, 6).
+        expect(fired).toEqual([true, false, false, true, false, false, true]);
+      } finally {
+        if (prev === undefined) delete process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY;
+        else process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY = prev;
+      }
+    });
+
+    it("falls back to default cadence on invalid env values", () => {
+      const prev = process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY;
+      try {
+        // Out-of-range, NaN, negative — all coerce to the default (10).
+        for (const v of ["0", "-1", "9999", "not-a-number", ""]) {
+          process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY = v;
+          resetGuidanceThrottle();
+          const first = routePreToolUse("mcp__slack__a", {});
+          const second = routePreToolUse("mcp__slack__b", {});
+          expect(first?.action, `value=${JSON.stringify(v)}`).toBe("context");
+          // With default=10, the 2nd call must NOT fire.
+          expect(second, `value=${JSON.stringify(v)}`).toBeNull();
+        }
+      } finally {
+        if (prev === undefined) delete process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY;
+        else process.env.CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY = prev;
+      }
+    });
+
+    it("resetGuidanceThrottle resets the periodic counter", () => {
+      // Burn one call to advance the counter.
+      const first = routePreToolUse("mcp__slack__post_message", {});
+      expect(first?.action).toBe("context");
       const second = routePreToolUse("mcp__slack__list_users", {});
       expect(second).toBeNull();
+
+      // Reset clears both the in-memory throttle and the periodic counter so
+      // the next call re-fires from tick 1 (e.g. start of a fresh session).
+      resetGuidanceThrottle();
+      const afterReset = routePreToolUse("mcp__slack__list_users", {});
+      expect(afterReset?.action).toBe("context");
     });
 
     it("does NOT match plain Bash/Read/etc as external MCP", () => {


### PR DESCRIPTION
## What

Replace the one-shot external-MCP PreToolUse nudge (#529) with a periodic one. The guidance — *"wrap large external-MCP payloads in `ctx_execute` / `ctx_fetch_and_index`"* — now re-fires every N matching tool calls (default 10, tunable via `CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY`).

## Why

Reported as a [follow-up on #567](https://github.com/mksglu/context-mode/issues/567#issuecomment-4460517077) by @Rajan-p-simform: with `context-mode` enabled but using the Jira MCP tool, token usage *did not decrease*. The user's [session_analysis.md](https://github.com/user-attachments/files/27804315/session_analysis.md) shows 55 Jira searches and input tokens growing 24K → 75K per turn — each full Jira response stayed in conversation history. Context compaction kicked in repeatedly just to keep the session alive.

Tracing the cause: `hooks/core/routing.mjs:816` registers the external-MCP nudge via `guidanceOnce("external-mcp", …)`. After the first matching MCP call in a session the nudge never re-fires. By call ~10–15 the original advisory has been compacted out of the model's recent window, and the agent stops piping Jira/Slack/Notion responses through `ctx_execute`. The remaining 40+ calls return full payloads straight into context.

The original `guidanceOnce` design works fine for Bash/Read/Grep — those guide *tool category* selection (one reminder is enough). External-MCP is different: each call brings new payload pressure, and the agent needs the reminder near the call site, not just at the start of the session.

## How

- New `guidancePeriodic(type, content, sessionId, period)` helper in `hooks/core/routing.mjs` — fires on the 1st, (period+1)th, (2·period+1)th… matching call. Counter is in-memory (same-process) + file-backed `<guidanceDir>/<type>.count` (cross-process), so hook invocations from the same logical session share state. On any IO/parse failure the helper falls back to firing — losing a counter is preferable to silently dropping the advisory.
- External-MCP branch now calls `guidancePeriodic("external-mcp", …, getExternalMcpNudgeEvery())`. Default cadence: every 10 calls. Env override: `CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY`, range `[1, 100]`, invalid values fall back to 10.
- `resetGuidanceThrottle` now clears the in-memory counter Map as well as the existing `_guidanceShown` Set + marker dirs.
- Bash/Read/Grep nudges keep their one-shot semantics — explicitly out of scope.
- README "Routing-guidance environment variables" table documents the new env var (doc-sync gate per `~/.claude/opensource-kb/mksglu-context-mode.md`).

## Coverage added

`tests/hooks/core-routing.test.ts`:
- The previous `respects the once-per-session guidance throttle` test was rewritten — it locked in exactly the behavior this PR changes.
- `re-fires guidance every N calls (default cadence = 10)` — drives 22 matching MCP calls, asserts guidance fires on indices 0, 10, 20 and nothing else.
- `honors CONTEXT_MODE_EXTERNAL_MCP_NUDGE_EVERY to tune cadence` — sets env to `3`, drives 7 calls, asserts fires on indices 0, 3, 6.
- `falls back to default cadence on invalid env values` — covers `"0"`, `"-1"`, `"9999"`, `"not-a-number"`, `""`.
- `resetGuidanceThrottle resets the periodic counter` — confirms a fresh session restarts from tick 1.

## Test plan

- [x] `npx vitest run tests/hooks/core-routing.test.ts` → **80 passed**
- [x] `npm run typecheck` → clean
- [x] `npm test` → **3342 passed / 47 skipped**. Two `[vitest-pool]: Timeout terminating forks worker` warnings on `kiro-hooks.test.ts` and `statusline-sqlite.test.ts` reproduce on plain `upstream/next` without this patch — pre-existing worker-teardown flakes, not caused by this change. All tests within those files pass.
- [x] `npm run build` → clean (no bundle diffs committed; per repo etiquette, `cli.bundle.mjs` / `server.bundle.mjs` rebuild in CI).

## Before / after (Jira-style session, default cadence)

| Tool call # | Before this PR | After this PR |
|---|---|---|
| 1 | guidance fires | guidance fires |
| 2–10 | silent | silent |
| 11 | silent | **guidance re-fires** |
| 12–20 | silent | silent |
| 21 | silent | **guidance re-fires** |
| 22–55 | silent | re-fires at 31, 41, 51 |

Net guidance cost over a 55-call session: ~6 firings × ~250 tokens ≈ 1.5K tokens — small compared to the 50K+ saved by the model actually piping large Jira responses through `ctx_execute` for the rest of the session.

## Out of scope (intentional)

- PostToolUse-side response interception (replacing large MCP responses with FTS5-stored summaries). That's a much bigger architectural change and would need maintainer alignment before any code lands.
- Per-MCP-server granularity (Jira/Slack/Notion currently share the same `external-mcp` marker). Easy to extend later if the cadence ever needs per-server tuning.

