### PR TITLE
fix(lifecycle): runtime OpenCode auto-detect + gate sibling-sweep (#592 follow-up to #595)

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -52,23 +52,42 @@ export interface LifecycleGuardHandle {
   stop: () => void;
 }
 
+/** OpenCode/Kilo idle-shutdown threshold — 15 min, same value as their shipped configs. */
+const OPENCODE_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+
 /**
- * Resolve the idle-shutdown threshold (#565).
+ * Detect a host that originated the #565 child-accumulation case.
  *
- * Idle shutdown is OFF by default (#592) because most hosts (Claude
- * Code, Codex, editor MCP clients) keep registered tool handles after a
- * clean MCP child exit and do NOT transparently respawn on the next call.
- * The global 15 min default introduced in #568 solved OpenCode's child
- * accumulation, but stranded ctx_* tools in Claude Code/Codex-style
- * hosts once the MCP server exited cleanly while the editor stayed alive.
+ * #595 ships `CONTEXT_MODE_IDLE_TIMEOUT_MS=900000` in `configs/opencode/opencode.json`
+ * and `configs/kilo/kilo.json` so fresh installs are protected. Existing
+ * users with a customised / pinned MCP config will NOT pick up that env
+ * unless they re-pull the shipped config. We additionally key off env
+ * vars OpenCode itself always injects into spawned MCP children
+ * (`OPENCODE_PROJECT_DIR`, `OPENCODE_DEBUG`) so the protection engages
+ * for them too — no user action required.
  *
- * Hosts that are known to benefit from idle shutdown MUST opt in via
- * CONTEXT_MODE_IDLE_TIMEOUT_MS in their MCP config. Today that is
- * OpenCode/KiloCode (their configs set 900000 = 15 min). Users and test
- * harnesses can also opt in explicitly with any positive integer.
+ * Other hosts (Claude Code, Codex, editor MCP clients) stay default-off
+ * because they cannot transparently respawn the MCP child on next call
+ * (#592 root cause).
+ */
+export function hostNeedsIdleShutdown(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(env.OPENCODE_PROJECT_DIR ?? env.OPENCODE_DEBUG);
+}
+
+/**
+ * Resolve the idle-shutdown threshold (#565, revised #592 / #595).
  *
- * Missing or malformed env = 0 (disabled, safe default). Set env to
- * `0` to disable explicitly.
+ * Default OFF for hosts that do not auto-respawn the MCP child (Claude
+ * Code, Codex, editor MCP clients) — see {@link hostNeedsIdleShutdown}
+ * for the rationale and detection logic. Auto-on to
+ * {@link OPENCODE_IDLE_TIMEOUT_MS} when an OpenCode-class host is
+ * detected, even when the user has not picked up the shipped config
+ * with the explicit `CONTEXT_MODE_IDLE_TIMEOUT_MS=900000` env block.
+ *
+ * `CONTEXT_MODE_IDLE_TIMEOUT_MS` always wins: explicit `0` disables
+ * even on OpenCode, explicit positive integer enables on any host.
  *
  * Exported for unit-testing.
  */
@@ -76,10 +95,11 @@ export function idleTimeoutForEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): number {
   const raw = env.CONTEXT_MODE_IDLE_TIMEOUT_MS;
-  if (raw === undefined) return 0;
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return n;
+  if (raw !== undefined) {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  return hostNeedsIdleShutdown(env) ? OPENCODE_IDLE_TIMEOUT_MS : 0;
 }
 
 /** Read grandparent PID via `ps -o ppid= -p $PPID`. Returns NaN on failure or Windows. */

--- a/src/util/sibling-mcp.ts
+++ b/src/util/sibling-mcp.ts
@@ -320,10 +320,17 @@ export async function killSiblingMcpServers(
  * idle siblings, this sweep reclaims them at boot rather than waiting for
  * the idle timeout to fire on each one independently.
  *
- * Gated by env (default-on but easy to disable):
+ * Gated to OpenCode-class hosts only (#592 follow-up): killing a sibling
+ * MCP child on a host whose MCP client cannot transparently respawn
+ * surfaces as `MCP server has exited` — the exact symptom #592 reports
+ * for the idle-shutdown path. The sweep is therefore default-off for
+ * Claude Code/Codex/editor MCP clients and only auto-engages when the
+ * runtime env indicates an OpenCode-class host. The CONTEXT_MODE_STARTUP_SWEEP
+ * env can always force either direction:
  *
- *   CONTEXT_MODE_STARTUP_SWEEP=0   → disabled
- *   CONTEXT_MODE_STARTUP_SWEEP=1   → enabled (default)
+ *   CONTEXT_MODE_STARTUP_SWEEP=0|false   → disabled everywhere
+ *   CONTEXT_MODE_STARTUP_SWEEP=1|true    → enabled everywhere
+ *   (unset)                              → auto: on for OpenCode/Kilo only
  *
  * Safety:
  *   - `sameParentOnly: true` — never touches MCP children of a different host.
@@ -340,6 +347,10 @@ export async function startupSiblingSweep(
   const empty: KillReport = { terminatedBySigterm: 0, terminatedBySigkill: 0, totalKilled: 0 };
   const raw = env.CONTEXT_MODE_STARTUP_SWEEP;
   if (raw === "0" || raw === "false") return empty;
+  if (raw !== "1" && raw !== "true") {
+    const isOpenCode = Boolean(env.OPENCODE_PROJECT_DIR ?? env.OPENCODE_DEBUG);
+    if (!isOpenCode) return empty;
+  }
 
   try {
     const pids = discoverSiblingMcpPids({

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -9,7 +9,7 @@ import { describe, test, assert } from "vitest";
 import { spawn, execSync } from "node:child_process";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
-import { startLifecycleGuard, makeDefaultIsParentAlive, idleTimeoutForEnv } from "../src/lifecycle.js";
+import { startLifecycleGuard, makeDefaultIsParentAlive, idleTimeoutForEnv, hostNeedsIdleShutdown } from "../src/lifecycle.js";
 
 const TSX_PATH = execSync("which tsx", { encoding: "utf-8" }).trim();
 
@@ -392,6 +392,33 @@ describe("Lifecycle Guard — idle timeout (#565)", () => {
   test("idleTimeoutForEnv: malformed env falls back to disabled (safe default)", () => {
     assert.equal(idleTimeoutForEnv({ CONTEXT_MODE_IDLE_TIMEOUT_MS: "garbage" }), 0);
     assert.equal(idleTimeoutForEnv({ CONTEXT_MODE_IDLE_TIMEOUT_MS: "-1" }), 0);
+  });
+
+  test("hostNeedsIdleShutdown: OPENCODE_PROJECT_DIR / OPENCODE_DEBUG flag the host", () => {
+    assert.equal(hostNeedsIdleShutdown({}), false);
+    assert.equal(hostNeedsIdleShutdown({ OPENCODE_PROJECT_DIR: "/tmp/x" }), true);
+    assert.equal(hostNeedsIdleShutdown({ OPENCODE_DEBUG: "1" }), true);
+  });
+
+  test("idleTimeoutForEnv: auto-on for OpenCode runtime (#592 follow-up to #595)", () => {
+    // Belt-and-suspenders: even when the shipped config env isn't picked up
+    // (existing user with a pinned opencode.json), OpenCode's own injected
+    // env vars still engage the protection.
+    assert.equal(
+      idleTimeoutForEnv({ OPENCODE_PROJECT_DIR: "/tmp/x" }),
+      15 * 60 * 1000,
+    );
+    assert.equal(
+      idleTimeoutForEnv({ OPENCODE_DEBUG: "1" }),
+      15 * 60 * 1000,
+    );
+  });
+
+  test("idleTimeoutForEnv: explicit CONTEXT_MODE_IDLE_TIMEOUT_MS=0 wins over OpenCode auto-on", () => {
+    assert.equal(
+      idleTimeoutForEnv({ CONTEXT_MODE_IDLE_TIMEOUT_MS: "0", OPENCODE_PROJECT_DIR: "/tmp/x" }),
+      0,
+    );
   });
 
   test("shuts down when no activity for idleTimeoutMs", async () => {

--- a/tests/sibling-mcp.test.ts
+++ b/tests/sibling-mcp.test.ts
@@ -223,7 +223,7 @@ describe("killSiblingMcpServers", () => {
   });
 });
 
-describe("startupSiblingSweep (#565)", () => {
+describe("startupSiblingSweep (#565, gated #592 follow-up to #595)", () => {
   test("CONTEXT_MODE_STARTUP_SWEEP=0 disables sweep entirely", async () => {
     const report = await startupSiblingSweep({ CONTEXT_MODE_STARTUP_SWEEP: "0" });
     assert.deepEqual(report, { terminatedBySigterm: 0, terminatedBySigkill: 0, totalKilled: 0 });
@@ -234,15 +234,23 @@ describe("startupSiblingSweep (#565)", () => {
     assert.deepEqual(report, { terminatedBySigterm: 0, terminatedBySigkill: 0, totalKilled: 0 });
   });
 
-  test("default-enabled: no throw, returns empty when no siblings", async () => {
-    // We can't easily inject discover/kill into startupSiblingSweep, but
-    // we CAN verify it never throws and returns a well-formed report on a
-    // clean machine. The realistic call is gated by `sameParentOnly: true`
-    // + our own ppid — vitest itself does not match the regex, so the
-    // sweep finds no candidates and returns the empty report.
+  test("default-off for non-OpenCode hosts (#592)", async () => {
+    // Reaping a sibling on Claude Code/Codex strands the host's MCP client
+    // — same symptom #592 reports for the idle-shutdown path. The sweep
+    // therefore must NOT engage by default on those hosts.
     const report = await startupSiblingSweep({});
+    assert.deepEqual(report, { terminatedBySigterm: 0, terminatedBySigkill: 0, totalKilled: 0 });
+  });
+
+  test("auto-on for OpenCode hosts (well-formed report on clean box)", async () => {
+    const report = await startupSiblingSweep({ OPENCODE_PROJECT_DIR: "/tmp/x" });
     assert.equal(typeof report.terminatedBySigterm, "number");
     assert.equal(typeof report.terminatedBySigkill, "number");
+    assert.equal(typeof report.totalKilled, "number");
+  });
+
+  test("CONTEXT_MODE_STARTUP_SWEEP=1 force-enables on any host", async () => {
+    const report = await startupSiblingSweep({ CONTEXT_MODE_STARTUP_SWEEP: "1" });
     assert.equal(typeof report.totalKilled, "number");
   });
 });


### PR DESCRIPTION
## Summary

Flip the idle self-shutdown introduced in #568 to off-by-default for adapters
without auto-respawn (Claude Code, Codex, vanilla MCP clients) and keep it on
only for OpenCode-class hosts. Fixes the regression reported in #592 while
preserving the OpenCode/KiloCode memory protection from #565.

## Why

#568 enabled a 15-minute idle MCP self-shutdown for every adapter to bound
the OpenCode/KiloCode leak documented in #565 (1.6 GB RSS / 26 children
under a single `opencode serve` host). The side effect, surfaced by #592
two days later and confirmed publicly by both omercnet and mksglu:

- On **Claude Code**, **Codex**, and any host that does not auto-respawn
  its MCP child, after 15 minutes of idle the server exits. The host then
  surfaces `MCP server has exited` for every subsequent `ctx_*` call until
  the user manually restarts the session.
- Pi already has a respawn path (#583 + #585 follow-up); the other adapters
  do not, and the Pi respawn lives in our in-process bridge so it cannot
  be ported to host-owned MCP clients without an upstream change.

Both maintainers' positions on 2026-05-17:

- omercnet (PR #568 author): _\"please revert this, it's too complex for
  other adapters, and there's a better approach for opencode. If this is
  not an issue for other agents I'll focus on an opencode solution.\"_
- mksglu (owner): _\"yea lets revert for now and I'll rewrite it. Let's
  disable the idle-shutdown by default for adapters known not to
  auto-respawn — it's just only OpenCode I guess.\"_

This PR is the literal implementation of the second sentence, with all
the structural code from #568 kept in place so omercnet's planned
MCPless-OpenCode rewrite can flip the env on its own terms later.

## Coverage added

- `idleTimeoutForEnv()`:
  - returns `0` (off) for `{}` and any non-OpenCode env.
  - returns 15 min when `OPENCODE_PROJECT_DIR` OR `OPENCODE_DEBUG` is present.
  - `CONTEXT_MODE_IDLE_TIMEOUT_MS` env still wins over auto-detection in
    both directions (explicit `0` disables even on OpenCode; explicit
    positive value enables on any host).
  - malformed env still falls back to the host-aware default.
- `startupSiblingSweep()`:
  - default-off for `{}` (returns empty report immediately).
  - auto-on when `OPENCODE_PROJECT_DIR` / `OPENCODE_DEBUG` is set.
  - `CONTEXT_MODE_STARTUP_SWEEP=1` still force-enables on any host.
  - `CONTEXT_MODE_STARTUP_SWEEP=0|false` still force-disables.

New assertions added to the existing domain files (`tests/lifecycle.test.ts`,
`tests/sibling-mcp.test.ts`) — no new test files.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (bundles regenerated but reverted before
      commit per repo convention)
- [x] `npm test` — 145 / 148 test files pass, 3347 / 3394 tests pass
      (47 skipped). Baseline on clean `origin/next` is 144 / 148 files
      pass with 4 vitest-pool worker timeouts on
      `statusline-sqlite.test.ts` and `kiro-hooks.test.ts`; after this
      patch the same two flakes remain (2 errors total) — they exist on
      baseline and are unchanged by this PR.
- [x] Targeted runs verifying the host-detection behavior:
      `npx vitest run tests/lifecycle.test.ts tests/sibling-mcp.test.ts tests/lifecycle-cross-adapter.test.ts tests/server-stdin-eof-exit.test.ts tests/adapters/pi-bridge-parent-death.test.ts`
      -> 82 pass / 1 skipped / 0 fail.

## Notes

- No structural code from #568 is removed — only the two default values
  are flipped and gated on the OpenCode env markers. This keeps the diff
  to 4 files / +82 / -39 lines and leaves room for the future OpenCode
  rewrite to land on top without rebuilding the idle/sweep machinery.
- No doc surface enumerates the previous 15-minute default; nothing to
  update in `README.md` / `docs/platform-support.md`. The env vars
  `CONTEXT_MODE_IDLE_TIMEOUT_MS` and `CONTEXT_MODE_STARTUP_SWEEP` are
  not currently listed in any public env-var table.