### PR TITLE
fix(pi): move behavioral_directive to end of system prompt

### DIFF
--- a/stats.json
+++ b/stats.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "195.1k+",
+  "message": "195.2k+",
   "color": "brightgreen",
   "npm": "160.5k+",
   "marketplace": "34.6k+"


### PR DESCRIPTION
vLLM prefix caching invalidated by behavioral_directive in the middle of system prompt. Move it to the end so the stable prefix stays intact.

**Problem:** behavioral_directive injected into session_state changes the system prompt on every turn, invalidating vLLM prefix cache.

**Fix:** Extract behavioral_directive from memoryContext and append it at the end of the system prompt.

Ref: #598