### PR TITLE
fix(pi): move behavioral_directive to end of system prompt

### DIFF
--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -484,6 +484,7 @@ export default function piExtension(pi: any): void {
         minPriority: 3,
         limit: 50,
       });
+      let behavioralDirective = "";
       if (activeEvents.length > 0) {
         const buildAuto = await getAutoInjection(pluginRoot);
         let memoryContext = "";
@@ -494,6 +495,14 @@ export default function piExtension(pi: any): void {
               data: String(e.data ?? ""),
             })),
           );
+          const bdMatch = memoryContext.match(/(<behavioral_directive>\n[^<]*\n<\/behavioral_directive>)/);
+          if (bdMatch) {
+            behavioralDirective = bdMatch[1];
+            memoryContext = memoryContext.replace(bdMatch[1], "");
+            if (memoryContext.match(/^<session_state[^>]*>\s*<\/session_state>\s*$/)) {
+              memoryContext = "";
+            }
+          }
         }
         // Fallback (or if helper produced empty output): inline 500-token cap.
         if (!memoryContext) {
@@ -517,6 +526,8 @@ export default function piExtension(pi: any): void {
         parts.push(resume.snapshot);
         db.markResumeConsumed(_sessionId);
       }
+
+      if (behavioralDirective) parts.push(behavioralDirective);
 
       // Return modified systemPrompt only if we added something beyond existing.
       const baseLen = existingPrompt ? 1 : 0;

--- a/stats.json
+++ b/stats.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "195.1k+",
+  "message": "195.2k+",
   "color": "brightgreen",
   "npm": "160.5k+",
   "marketplace": "34.6k+"


### PR DESCRIPTION
vLLM prefix caching invalidated by behavioral_directive in the middle of system prompt. Move it to the end so the stable prefix stays intact.

**Problem:** behavioral_directive injected into session_state changes the system prompt on every turn, invalidating vLLM prefix cache.

**Fix:** Extract behavioral_directive from memoryContext and append it at the end of the system prompt.

Ref: #598