### PR TITLE
fix(codex): doctor warns on duplicate context-mode hook entries (#603)

### DIFF
--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -502,7 +502,7 @@ export class CodexAdapter extends BaseAdapter implements HookAdapter {
     }
 
     const expected = this.generateHookConfig("");
-    return results.concat(Object.entries(expected).map(([hookName, entries]) => {
+    const hookChecks = Object.entries(expected).map(([hookName, entries]) => {
       const actualEntries = hookConfig.config.hooks?.[hookName];
       const expectedEntry = entries[0];
       const ok = Array.isArray(actualEntries)
@@ -511,7 +511,7 @@ export class CodexAdapter extends BaseAdapter implements HookAdapter {
 
       return {
         check: `${hookName} hook`,
-        status: ok ? "pass" : missingStatus,
+        status: (ok ? "pass" : missingStatus) as "pass" | "warn" | "fail",
         message: ok
           ? `${hookName} hook configured in ${this.getHooksPath()}`
           : hookName === "PreCompact"
@@ -519,7 +519,31 @@ export class CodexAdapter extends BaseAdapter implements HookAdapter {
             : `${hookName} hook missing or not pointing to context-mode`,
         fix: ok ? undefined : `Update ${this.getHooksPath()} to match configs/codex/hooks.json`,
       };
-    }));
+    });
+
+    // #603: surface duplicate context-mode entries per hook event. Codex fires
+    // every matching entry, so duplicates double the work, can saturate the
+    // MCP transport (`Transport closed`), and have been observed to inflate
+    // codex-tui.log into the multi-GB range. `context-mode upgrade` collapses
+    // them via `upsertManagedHookEntry`, so the fix is one command away.
+    const duplicateChecks: DiagnosticResult[] = [];
+    for (const hookName of Object.keys(expected)) {
+      const actualEntries = hookConfig.config.hooks?.[hookName];
+      if (!Array.isArray(actualEntries)) continue;
+      const managedCount = actualEntries.filter(
+        (entry) => this.isManagedContextModeEntry(hookName, entry as HookEntry),
+      ).length;
+      if (managedCount > 1) {
+        duplicateChecks.push({
+          check: `${hookName} duplicates`,
+          status: "warn",
+          message: `${managedCount} context-mode entries found for ${hookName} in ${this.getHooksPath()}; Codex will fire all of them`,
+          fix: "context-mode upgrade (collapses duplicate context-mode entries; preserves unrelated hooks)",
+        });
+      }
+    }
+
+    return results.concat(hookChecks, duplicateChecks);
   }
 
   checkPluginRegistration(): DiagnosticResult {

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -437,6 +437,100 @@ describe("CodexAdapter", () => {
       expect(readFileSync(`${hooksPath}.bak`, "utf-8")).toContain('"hooks"');
       expect(readFileSync(`${settingsPath}.bak`, "utf-8")).toContain("hooks = false");
     });
+
+    // ─────────────────────────────────────────────────────
+    // Duplicate dedup regression suite (#603)
+    //
+    // Reported by jowch + skbsasikumar-rgb: after a context-mode upgrade,
+    // ~/.codex/hooks.json carries TWO context-mode entries for the same
+    // hook event (e.g., a legacy `node /path/.../hooks/codex/pretooluse.mjs`
+    // alongside the new `context-mode hook codex pretooluse`). Codex then
+    // fires both, doubling work and historically saturating the MCP
+    // transport / inflating codex-tui.log. `configureAllHooks` must collapse
+    // these to exactly one canonical entry per event.
+    // ─────────────────────────────────────────────────────
+
+    it("dedups twin canonical context-mode entries to a single entry (#603)", () => {
+      writeFileSync(hooksPath, JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: "old-matcher-A", hooks: [{ type: "command", command: "context-mode hook codex pretooluse" }] },
+            { matcher: "old-matcher-B", hooks: [{ type: "command", command: "context-mode hook codex pretooluse" }] },
+          ],
+          SessionStart: [
+            { hooks: [{ type: "command", command: "context-mode hook codex sessionstart" }] },
+            { hooks: [{ type: "command", command: "context-mode hook codex sessionstart" }] },
+          ],
+        },
+      }, null, 2));
+
+      const changes = adapter.configureAllHooks("/ignored/plugin/root");
+
+      const written = JSON.parse(readFileSync(hooksPath, "utf-8")) as {
+        hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      };
+
+      expect(written.hooks.PreToolUse).toHaveLength(1);
+      expect(written.hooks.PreToolUse[0]?.hooks[0]?.command).toBe("context-mode hook codex pretooluse");
+      expect(written.hooks.SessionStart).toHaveLength(1);
+      expect(written.hooks.SessionStart[0]?.hooks[0]?.command).toBe("context-mode hook codex sessionstart");
+      expect(changes.some((c) => c.includes("Removed duplicate"))).toBe(true);
+    });
+
+    it("dedups legacy-direct-node entry coexisting with canonical entry (#603)", () => {
+      // Mirrors the exact user-reported pattern: old direct-node hook left
+      // behind by an earlier installer + new canonical entry from a later
+      // upgrade run.
+      writeFileSync(hooksPath, JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: "", hooks: [{ type: "command", command: "node /Users/foo/.nvm/versions/node/v20/lib/node_modules/context-mode/hooks/codex/pretooluse.mjs" }] },
+            { matcher: "", hooks: [{ type: "command", command: "context-mode hook codex pretooluse" }] },
+          ],
+          PostToolUse: [
+            { hooks: [{ type: "command", command: "/opt/homebrew/bin/node /opt/homebrew/lib/node_modules/context-mode/hooks/posttooluse.mjs" }] },
+            { hooks: [{ type: "command", command: "context-mode hook codex posttooluse" }] },
+          ],
+        },
+      }, null, 2));
+
+      adapter.configureAllHooks("/ignored/plugin/root");
+
+      const written = JSON.parse(readFileSync(hooksPath, "utf-8")) as {
+        hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      };
+
+      expect(written.hooks.PreToolUse).toHaveLength(1);
+      expect(written.hooks.PreToolUse[0]?.hooks[0]?.command).toBe("context-mode hook codex pretooluse");
+      expect(written.hooks.PostToolUse).toHaveLength(1);
+      expect(written.hooks.PostToolUse[0]?.hooks[0]?.command).toBe("context-mode hook codex posttooluse");
+    });
+
+    it("dedups plugin-cache legacy entry left by /ctx-upgrade with canonical entry (#603)", () => {
+      // Plugin-cache install layout: ~/.claude/plugins/cache/context-mode/<v>/hooks/codex/<event>.mjs
+      writeFileSync(hooksPath, JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: "command", command: "node /Users/foo/.claude/plugins/cache/context-mode/context-mode/1.0.124/hooks/codex/userpromptsubmit.mjs" }] },
+            { hooks: [{ type: "command", command: "context-mode hook codex userpromptsubmit" }] },
+          ],
+          Stop: [
+            { hooks: [{ type: "command", command: "/usr/bin/node /Users/foo/.claude/plugins/marketplaces/context-mode/hooks/codex/stop.mjs" }] },
+          ],
+        },
+      }, null, 2));
+
+      adapter.configureAllHooks("/ignored/plugin/root");
+
+      const written = JSON.parse(readFileSync(hooksPath, "utf-8")) as {
+        hooks: Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+      };
+
+      expect(written.hooks.UserPromptSubmit).toHaveLength(1);
+      expect(written.hooks.UserPromptSubmit[0]?.hooks[0]?.command).toBe("context-mode hook codex userpromptsubmit");
+      expect(written.hooks.Stop).toHaveLength(1);
+      expect(written.hooks.Stop[0]?.hooks[0]?.command).toBe("context-mode hook codex stop");
+    });
   });
 
   describe("validateHooks", () => {
@@ -481,6 +575,53 @@ describe("CodexAdapter", () => {
       const results = adapter.validateHooks("/ignored/plugin/root");
 
       expect(results.some((result) => result.status === "fail" && result.message.includes("not valid JSON"))).toBe(true);
+    });
+
+    it("warns when duplicate context-mode entries exist for the same hook event (#603)", () => {
+      // Mirrors the user-reported scenario: hooks.json carries two
+      // context-mode entries for the same event after a partial upgrade.
+      // Doctor should surface this so the user knows to run upgrade.
+      writeFileSync(hooksPath, JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: "", hooks: [{ type: "command", command: "context-mode hook codex pretooluse" }] },
+            { matcher: "", hooks: [{ type: "command", command: "node /Users/foo/.nvm/versions/node/v20/lib/node_modules/context-mode/hooks/codex/pretooluse.mjs" }] },
+          ],
+          PostToolUse: [
+            { hooks: [{ type: "command", command: "context-mode hook codex posttooluse" }] },
+            { hooks: [{ type: "command", command: "context-mode hook codex posttooluse" }] },
+          ],
+          SessionStart: [
+            { hooks: [{ type: "command", command: "context-mode hook codex sessionstart" }] },
+          ],
+          PreCompact: [
+            { hooks: [{ type: "command", command: "context-mode hook codex precompact" }] },
+          ],
+          UserPromptSubmit: [
+            { hooks: [{ type: "command", command: "context-mode hook codex userpromptsubmit" }] },
+          ],
+          Stop: [
+            { hooks: [{ type: "command", command: "context-mode hook codex stop" }] },
+          ],
+        },
+      }, null, 2), "utf-8");
+      writeFileSync(join(codexDir, "config.toml"), "[features]\nhooks = true\n", "utf-8");
+
+      const results = adapter.validateHooks("/ignored/plugin/root");
+
+      const preToolDup = results.find((r) => r.check === "PreToolUse duplicates");
+      expect(preToolDup?.status).toBe("warn");
+      expect(preToolDup?.message).toMatch(/2 context-mode entries/);
+      expect(preToolDup?.fix).toMatch(/context-mode upgrade/);
+
+      const postToolDup = results.find((r) => r.check === "PostToolUse duplicates");
+      expect(postToolDup?.status).toBe("warn");
+      expect(postToolDup?.message).toMatch(/2 context-mode entries/);
+
+      // Events with only one context-mode entry must NOT trigger the duplicate warning.
+      expect(results.some((r) => r.check === "SessionStart duplicates")).toBe(false);
+      expect(results.some((r) => r.check === "PreCompact duplicates")).toBe(false);
+      expect(results.some((r) => r.check === "Stop duplicates")).toBe(false);
     });
 
     it("fails with a read error message when hooks.json cannot be read", () => {


### PR DESCRIPTION
## Summary

Closes #603 (duplicate Codex hook entries causing `Transport closed` + runaway log). Adds a per-event `<HookName> duplicates` warning in `validateHooks` so the doctor surfaces the state that #603 describes, and pins the existing dedup behavior with 3 regression tests covering the upgrade path.

## Why

Reported by jowch in #603, confirmed by skbsasikumar-rgb in [a follow-up comment](https://github.com/mksglu/context-mode/issues/603#issuecomment-4477401377):

> ~/.codex/hooks.json had duplicate context-mode hook entries for the same Codex events.
> ~/.codex/log/codex-tui.log had grown to about 63.5 GB.
> After truncating the log, deduping the hooks, upgrading context-mode, and restarting/resuming Codex, context-mode worked again.

Codex fires every matching entry, so duplicates double the work per tool call, can saturate the MCP transport (`Transport closed`), and have been observed inflating `codex-tui.log` into the multi-GB range.

The repair side already works: `upsertManagedHookEntry` (the upgrade path) collapses duplicates via `isManagedContextModeEntry` which recognises both the canonical `context-mode hook codex <event>` shape AND legacy direct-node command paths ending in `hooks/<event>.mjs` or `hooks/codex/<event>.mjs`. What was missing was the user-facing signal — `validateHooks` checked that each event had at least one context-mode entry but never surfaced duplicates.

## Changes

### `src/adapters/codex/index.ts` — `validateHooks` enhancement

Adds a `duplicateChecks` pass after the per-hook configuration check:

```ts
const duplicateChecks: DiagnosticResult[] = [];
for (const hookName of Object.keys(expected)) {
  const actualEntries = hookConfig.config.hooks?.[hookName];
  if (!Array.isArray(actualEntries)) continue;
  const managedCount = actualEntries.filter(
    (entry) => this.isManagedContextModeEntry(hookName, entry as HookEntry),
  ).length;
  if (managedCount > 1) {
    duplicateChecks.push({
      check: `${hookName} duplicates`,
      status: "warn",
      message: `${managedCount} context-mode entries found for ${hookName} in ${this.getHooksPath()}; Codex will fire all of them`,
      fix: "context-mode upgrade (collapses duplicate context-mode entries; preserves unrelated hooks)",
    });
  }
}
```

Reuses the existing `isManagedContextModeEntry` predicate so the doctor side matches the repair side perfectly — anything `upsertManagedHookEntry` would dedup is what the doctor flags.

### `tests/adapters/codex.test.ts` — 4 new tests under existing `configureAllHooks` / `validateHooks` blocks

1. **Dedup twin canonical entries** — two `context-mode hook codex pretooluse` rows collapse to one.
2. **Dedup legacy-direct-node + canonical** — `node /Users/foo/.nvm/.../hooks/codex/pretooluse.mjs` + canonical → one canonical.
3. **Dedup plugin-cache legacy entry** — `~/.claude/plugins/cache/...` and `~/.claude/plugins/marketplaces/...` paths recognized.
4. **Doctor warns on duplicates** — `validateHooks` emits a `warn` status with message and `fix: context-mode upgrade` only for events with > 1 managed entry. Events with one or zero entries emit no duplicate warning.

No new test file — added to the existing `tests/adapters/codex.test.ts` per the contributing rules.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 145/145 test files pass, 3306/3349 tests pass (43 skipped, 0 fail). Same baseline as `origin/next` — no regression introduced.
- [x] Targeted: `npx vitest run tests/adapters/codex.test.ts -t '#603'` → 4/4 pass.

## Compatibility / scope

- Pure additive change to `validateHooks` (no behavior change for users who already have one entry per event).
- Doctor warning has clear actionable fix (`context-mode upgrade`).
- No new env vars, no new CLI commands, no doc surface changes.
- Hook fixing path (`configureAllHooks`) untouched — the existing dedup is already correct, this PR locks it in with tests and surfaces the upstream state in the doctor.

Refs: #603.