### PR TITLE
fix(install): ship .mcp.json + heal-create when missing (#609)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,16 +20,16 @@ AGENTS.md
 context-mode-guidance-*/
 .claude/worktrees/
 
-# .mcp.json is local-only — purpose splits between contributor dev
-# (relative paths work because cwd = repo root) and end-user marketplace
-# install (placeholder ${CLAUDE_PLUGIN_ROOT}/start.mjs is required).
-# These two forms have flip-flopped 3 times in history (#253 #531 etc),
-# causing every fresh install to silently break. End users get MCP via
-# .claude-plugin/plugin.json (always placeholder) and /ctx-upgrade's
-# cli.ts write (always placeholder). The .mcp.json at repo root only
-# helps contributors during local dev. Untracked → can't regress.
-# Copy .mcp.json.example to .mcp.json for local dev.
-.mcp.json
+# .mcp.json is now tracked + shipped (#609 — Claude Code's native plugin
+# auto-update doesn't include .mcp.json from the previous version, leaves it
+# stranded, and the cache scanner picks up the stale file → MODULE_NOT_FOUND).
+# Canonical placeholder form (${CLAUDE_PLUGIN_ROOT}/start.mjs) is committed
+# at repo root so npm pack includes it in every version's cache dir. Drift is
+# guarded by asymmetric-drift assert + a unit test asserting the exact shape.
+# Contributors running local dev may see Claude Code's "Missing environment
+# variable: CLAUDE_PLUGIN_ROOT" warning — harmless, can be silenced by setting
+# CLAUDE_PLUGIN_ROOT=$PWD in the dev shell. The contributor-relative shape
+# (./start.mjs) is no longer supported — use the placeholder form universally.
 .claude-worktrees/
 .vibetree/
 .cw/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context-mode": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/start.mjs"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     ".codex-plugin",
     ".openclaw-plugin",
     "openclaw.plugin.json",
+    ".mcp.json",
     "start.mjs",
     "scripts/postinstall.mjs",
     "scripts/heal-better-sqlite3.mjs",

--- a/scripts/heal-installed-plugins.mjs
+++ b/scripts/heal-installed-plugins.mjs
@@ -341,7 +341,28 @@ export function healMcpJsonArgs({ pluginRoot, pluginCacheRoot, pluginKey }) {
   // `.mcp.json` lives at pluginRoot/.mcp.json (flat), NOT under .claude-plugin/.
   const mcpJsonPath = resolve(pluginRoot, ".mcp.json");
   if (!existsSync(mcpJsonPath)) {
-    return { healed: [], skipped: "no-mcp-json" };
+    // #609: Claude Code's native plugin auto-update doesn't ship a fresh
+    // `.mcp.json` into the new version dir and leaves a stale one behind in
+    // the previous version dir. CC's cache scanner then picks the stale file
+    // and tries to boot from the deleted previous-version `start.mjs`. The
+    // primary fix is shipping `.mcp.json` via the npm tarball; this branch is
+    // the defensive heal for the `/ctx-upgrade` tmpdir path + any other
+    // pipeline that lands files without invoking the prepack.
+    const ourServerName = pluginKey.split("@")[0];
+    const canonical = {
+      mcpServers: {
+        [ourServerName]: {
+          command: "node",
+          args: [PLACEHOLDER_ARG],
+        },
+      },
+    };
+    try {
+      writeFileSync(mcpJsonPath, JSON.stringify(canonical, null, 2) + "\n", "utf-8");
+      return { healed: ["mcp-json-created"] };
+    } catch (err) {
+      return { healed: [], error: `create-failed: ${(err && err.message) || err}` };
+    }
   }
 
   let raw;

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -216,16 +216,39 @@ describe(".mcp.json — MCP server config", () => {
     expect(args[0]).toContain("start.mjs");
   });
 
-  it("package.json files[] MUST NOT ship .mcp.json (architectural lock — closes #531)", () => {
-    // PR #253 flip-flop: source .mcp.json kept switching between the
-    // placeholder form (correct for end-users via marketplace install) and
-    // the relative form (correct for contributors opening the repo as a
-    // regular project). Stop shipping it in the tarball so the two roles
-    // never collide again. End users get MCP via .claude-plugin/plugin.json
-    // and cli.ts upgrade()'s plugin-cache write — both placeholder.
+  it("package.json files[] MUST ship .mcp.json with the placeholder form (#609 reverses #531)", () => {
+    // History:
+    //   - PR #253: .mcp.json source flip-flopped between placeholder + relative
+    //     forms (contributor vs end-user). #531 fixed it by un-tracking + not
+    //     shipping .mcp.json — end-users were supposed to get MCP via
+    //     .claude-plugin/plugin.json.
+    //   - #609: Claude Code's native plugin auto-update doesn't include .mcp.json
+    //     in the new version dir, leaves stale .mcp.json in the previous version,
+    //     and CC's cache scanner picks the stale one → MODULE_NOT_FOUND on every
+    //     boot (start.mjs of the previous version is already deleted).
+    //   - The fix that breaks the deadlock is the simplest one: ship .mcp.json
+    //     (placeholder form) in every npm tarball → every cache version dir has
+    //     its own current .mcp.json → CC's scanner finds the current one.
+    //
+    // Contributor trade-off: local dev sees CC's "Missing environment variable:
+    // CLAUDE_PLUGIN_ROOT" warning. Harmless, silenceable via
+    // `export CLAUDE_PLUGIN_ROOT=$PWD`. Documented in .gitignore comment.
+    //
+    // The DRIFT GUARD lives in `scripts/assert-asymmetric-drift.mjs` + the
+    // sibling vitest at `tests/scripts/asymmetric-drift-assert.test.ts`. Both
+    // pin the args[0] string to "${CLAUDE_PLUGIN_ROOT}/start.mjs" verbatim
+    // across .mcp.json, .mcp.json.example, and .claude-plugin/plugin.json.
     const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8"));
     expect(pkg.files).toBeDefined();
-    expect(pkg.files).not.toContain(".mcp.json");
+    expect(pkg.files).toContain(".mcp.json");
+
+    // Content guard: file exists in repo + uses placeholder form (not relative).
+    const mcpJsonPath = resolve(ROOT, ".mcp.json");
+    expect(existsSync(mcpJsonPath)).toBe(true);
+    const mcpJson = JSON.parse(readFileSync(mcpJsonPath, "utf-8"));
+    expect(mcpJson.mcpServers?.["context-mode"]?.args?.[0]).toBe(
+      "${CLAUDE_PLUGIN_ROOT}/start.mjs",
+    );
   });
 });
 

--- a/tests/util/heal-installed-plugins.test.ts
+++ b/tests/util/heal-installed-plugins.test.ts
@@ -17,6 +17,7 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -830,17 +831,21 @@ describe("healMcpJsonArgs (Issue #531)", () => {
     });
   });
 
-  // Defensive — missing file returns silent skip
-  it("returns skipped:'no-mcp-json' when .mcp.json is missing", () => {
-    const cacheRoot = makeTmp("ctx-issue531-cache-");
+  // #609: missing-file branch now CREATES the canonical .mcp.json instead of
+  // skipping. Defensive layer 2 — primary fix is shipping .mcp.json via the
+  // npm tarball (#609 reverses #531's untrack). This branch covers
+  // `/ctx-upgrade` tmpdir + any pipeline that lands files without prepack.
+  it("creates canonical .mcp.json when missing (#609)", () => {
+    const cacheRoot = makeTmp("ctx-issue609-cache-");
     const pluginRoot = resolve(
       cacheRoot,
       "context-mode",
       "context-mode",
-      "1.0.121",
+      "1.0.137",
     );
     mkdirSync(pluginRoot, { recursive: true });
-    // No .mcp.json file written.
+    const mcpJsonPath = resolve(pluginRoot, ".mcp.json");
+    // No .mcp.json file written — the auto-update / cp -r path scenario.
 
     const result = healMcpJsonArgs({
       pluginRoot,
@@ -848,8 +853,13 @@ describe("healMcpJsonArgs (Issue #531)", () => {
       pluginKey: "context-mode@context-mode",
     });
 
-    expect(result.healed).toEqual([]);
-    expect(result.skipped).toBe("no-mcp-json");
+    expect(result.healed).toContain("mcp-json-created");
+    expect(existsSync(mcpJsonPath)).toBe(true);
+    const written = JSON.parse(readFileSync(mcpJsonPath, "utf-8"));
+    expect(written.mcpServers["context-mode"].args).toEqual([
+      "${CLAUDE_PLUGIN_ROOT}/start.mjs",
+    ]);
+    expect(written.mcpServers["context-mode"].command).toBe("node");
   });
 });
 

--- a/tests/util/postinstall-heal.test.ts
+++ b/tests/util/postinstall-heal.test.ts
@@ -106,6 +106,20 @@ function buildFakeHome(opts: {
     resolve(cacheDir, ".claude-plugin", "plugin.json"),
     JSON.stringify({ name: "context-mode", version: opts.cacheVersion }, null, 2),
   );
+  // #609: post-fix, every real install dir has .mcp.json shipped from the
+  // tarball. Seed it here so healMcpJsonArgs's missing-file branch doesn't
+  // trigger and emit an extra stderr line in tests that count heal output.
+  writeFileSync(
+    resolve(cacheDir, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        "context-mode": {
+          command: "node",
+          args: ["${CLAUDE_PLUGIN_ROOT}/start.mjs"],
+        },
+      },
+    }, null, 2) + "\n",
+  );
   const registry: Record<string, unknown> = {
     version: 2,
     plugins: {


### PR DESCRIPTION
## Summary

Closes #609. Claude Code's native plugin auto-update doesn't ship `.mcp.json` into the new version directory and leaves a stale one behind in the previous version. CC's cache scanner picks the stale file, tries to launch the deleted previous-version `start.mjs` → `MODULE_NOT_FOUND` on every MCP boot, `/plugin` returns no content, every hook fails.

The fix that breaks the deadlock: ship `.mcp.json` (placeholder form) in every npm tarball so every cache version dir holds its own current copy. Plus a defensive heal that creates `.mcp.json` when missing (covers `/ctx-upgrade` tmpdir + pipelines that don't run prepack).

## Resolving #609

Claude Code's plugin scanner reads `.mcp.json` from the cache version dir when present, and only falls back to `.claude-plugin/plugin.json` when it isn't. Since `.mcp.json` isn't currently shipped in the npm tarball, fresh version dirs hold none — but legacy install chains can leave a stale one in the previous version dir from before #531 landed. The scanner picks the stale file, expands `${CLAUDE_PLUGIN_ROOT}` to the previous version's path, and tries to spawn its `start.mjs` — which the auto-update already removed.

Shipping `.mcp.json` (placeholder form) inside the tarball guarantees the scanner always finds the current version's file in the current version's dir. The `${CLAUDE_PLUGIN_ROOT}/start.mjs` form makes the path correct regardless of which version dir CC picks it from.

Contributor note: local dev (cloning the repo and running Claude Code against it) may surface CC's `Missing environment variable: CLAUDE_PLUGIN_ROOT` warning when `CLAUDE_PLUGIN_ROOT` isn't set. The warning is harmless and can be silenced via `export CLAUDE_PLUGIN_ROOT=$PWD` in the dev shell. The relative-path form (`./start.mjs`) is no longer supported in the shipped file — the placeholder is universal across contributor and end-user contexts. Documented in the `.gitignore` comment.

## Changes

- **`.gitignore`** — remove `.mcp.json` exclusion. Replace the comment with a `#609 — shipped placeholder form is universal` block.
- **`.mcp.json`** (new, committed) — placeholder form matching `.mcp.json.example` verbatim.
- **`package.json`** — add `.mcp.json` to `files` array so it ships in npm tarball.
- **`scripts/heal-installed-plugins.mjs`** — `healMcpJsonArgs` now creates a canonical `.mcp.json` when missing instead of skipping with `no-mcp-json`. Defensive layer for paths that don't run prepack.
- **`tests/core/cli.test.ts`** — assertion now requires `.mcp.json` to be in `files[]` and to use the placeholder form. Content shape pinned (drift guard).
- **`tests/util/heal-installed-plugins.test.ts`** — `healMcpJsonArgs` create-when-missing assertion replaces the previous skip assertion.
- **`tests/util/postinstall-heal.test.ts`** — `buildFakeHome` seeds `.mcp.json` so the heal-create branch is a no-op for tests that count stderr heal output.

The asymmetric-drift assert (`scripts/assert-asymmetric-drift.mjs` + its vitest sibling) already covered `.mcp.json` content when present — that drift guard is now unconditional since `.mcp.json` always exists in repo.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — assert-asymmetric-drift passes (`.mcp.json`, `.mcp.json.example`, `.claude-plugin/plugin.json` all pin args[0] to `${CLAUDE_PLUGIN_ROOT}/start.mjs`)
- [x] `npm test` — 145/145 test files pass, 3317/3360 tests pass (43 skipped, 0 fail). Same baseline as `origin/next` — no regression introduced.
- [x] `npm pack --dry-run` — `.mcp.json (129B)` included in tarball.

## Risk / compatibility

- Existing v1.0.137 users will still see #609 once when they upgrade to v1.0.138 (the v1.0.137 → v1.0.138 transition still goes through CC's auto-update which won't include `.mcp.json` from the v1.0.137 tarball). The next transition (v1.0.138 → v1.0.139+) will be clean because v1.0.138 ships `.mcp.json` → CC's auto-update preserves it.
- Defensive heal-create covers users who run `/ctx-upgrade` or `npm install -g context-mode` — both run paths that invoke `healMcpJsonArgs` via postinstall.
- No new env var, no schema migration, no CLI command change.

Refs: #609, #531, #411, #523, #253.