### PR TITLE
fix(install): sweep stale .mcp.json post auto-update (closes #609)

### DIFF
--- a/scripts/heal-installed-plugins.mjs
+++ b/scripts/heal-installed-plugins.mjs
@@ -17,7 +17,7 @@
  * @see https://github.com/anthropics/claude-code/issues/46915
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { resolve, sep } from "node:path";
 
 /**
@@ -393,6 +393,90 @@ export function healMcpJsonArgs({ pluginRoot, pluginCacheRoot, pluginKey }) {
   }
 
   return { healed };
+}
+
+// ── Layer 8 (Issue #609) — Sweep stale `.mcp.json` from prev-version cache dirs ──
+//
+// After Claude Code's native plugin manager auto-updates `<X.Y.Z>` → `<X.Y.Z+1>`,
+// the previous version's `.mcp.json` (written by an earlier `/ctx-upgrade` run)
+// stays behind. CC scans the cache tree, finds the stale `.mcp.json` at
+// `<…>/context-mode/context-mode/<old-version>/.mcp.json`, sets
+// `CLAUDE_PLUGIN_ROOT=<old-version>`, then tries `node <old-version>/start.mjs`
+// → MODULE_NOT_FOUND because the auto-update cleaned start.mjs out of the
+// previous version dir but missed the sibling `.mcp.json`.
+//
+// CC plugin manager reads `.claude-plugin/plugin.json` mcpServers natively
+// (see PR #523's healPluginJsonMcpServers — pointless if CC didn't honor it).
+// `.mcp.json` in cache dirs is redundant legacy from #411 era. Sweeping it
+// makes #609 structurally impossible.
+//
+// Single source of truth shared by:
+//   - `start.mjs` HEAL (every MCP boot)
+//   - `scripts/postinstall.mjs` (every `npm install -g context-mode`)
+// ─────────────────────────────────────────────────────────────────────────
+
+const VERSION_DIR_RE = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+
+/** Extract X.Y.Z version from a context-mode cache pluginRoot. Returns null
+ * for npm-global / dev-checkout layouts — caller skips sweep in those cases. */
+function extractCacheVersion(pluginRoot) {
+  if (!pluginRoot) return null;
+  const fwd = String(pluginRoot).replace(/\\/g, "/");
+  const m = /context-mode\/context-mode\/([0-9]+\.[0-9]+\.[0-9]+)(?:\/|$)/.exec(fwd);
+  return m ? m[1] : null;
+}
+
+/**
+ * Delete `.mcp.json` from every sibling version dir under
+ * `<pluginCacheRoot>/context-mode/context-mode/<X.Y.Z>/` whose version
+ * does NOT match the current `pluginRoot`. Best-effort: per-file errors
+ * never abort the loop.
+ *
+ * @param {{
+ *   pluginRoot: string,
+ *   pluginCacheRoot: string,
+ * }} opts
+ * @returns {HealResult & { swept?: string[] }}
+ */
+export function sweepStaleMcpJson({ pluginRoot, pluginCacheRoot }) {
+  if (!pluginRoot || !pluginCacheRoot) {
+    return { healed: [], skipped: "missing-args" };
+  }
+
+  const currentVersion = extractCacheVersion(pluginRoot);
+  if (!currentVersion) {
+    return { healed: [], skipped: "not-cache-layout" };
+  }
+
+  // Path-traversal guard: pluginRoot must live inside pluginCacheRoot.
+  const resolvedRoot = resolve(pluginRoot);
+  const cacheRootWithSep = resolve(pluginCacheRoot) + sep;
+  if (!resolvedRoot.startsWith(cacheRootWithSep)) {
+    return { healed: [], skipped: "outside-cache-root" };
+  }
+
+  const parent = resolve(pluginCacheRoot, "context-mode", "context-mode");
+  if (!existsSync(parent)) {
+    return { healed: [], skipped: "no-parent" };
+  }
+
+  let entries;
+  try { entries = readdirSync(parent); }
+  catch (err) { return { healed: [], error: `readdir-failed: ${(err && err.message) || err}` }; }
+
+  const swept = [];
+  for (const entry of entries) {
+    if (entry === currentVersion) continue;
+    if (!VERSION_DIR_RE.test(entry)) continue;
+    const stale = resolve(parent, entry, ".mcp.json");
+    if (!existsSync(stale)) continue;
+    try {
+      unlinkSync(stale);
+      swept.push(`${entry}/.mcp.json`);
+    } catch { /* per-file best effort */ }
+  }
+
+  return { healed: swept, swept };
 }
 
 /**

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -14,7 +14,7 @@ import { dirname, resolve, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { healBetterSqlite3Binding } from "./heal-better-sqlite3.mjs";
-import { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, healMcpJsonArgs } from "./heal-installed-plugins.mjs";
+import { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, healMcpJsonArgs, sweepStaleMcpJson } from "./heal-installed-plugins.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(__dirname, "..");
@@ -197,10 +197,20 @@ if (isGlobalInstall()) {
               healedAny = true;
             }
           } catch { /* per-entry best effort */ }
+          // Issue #609 — Layer 8 sweep: delete stale `.mcp.json` from any
+          // prev-version cache dir so CC stops booting the plugin with
+          // CLAUDE_PLUGIN_ROOT pointing at a cleaned previous version.
+          // Idempotent — first installPath does the work, later iterations no-op.
+          try {
+            const r = sweepStaleMcpJson({ pluginRoot: installPath, pluginCacheRoot: cacheRoot });
+            if (r && Array.isArray(r.swept) && r.swept.length > 0) {
+              healedAny = true;
+            }
+          } catch { /* per-entry best effort */ }
         }
       }
       if (healedAny) {
-        process.stderr.write("context-mode: healed mcpServers args (Issues #523 + #531)\n");
+        process.stderr.write("context-mode: healed mcpServers args (Issues #523 + #531 + #609)\n");
       }
     }
   } catch { /* never block install */ }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,7 @@ import { discoverSiblingMcpPids, killSiblingMcpServers } from "./util/sibling-mc
 // v1.0.119 — Issue #523 Layer 5 heal: post-bump assertion on .claude-plugin/plugin.json
 // mcpServers args. Single source of truth shared with start.mjs HEAL block + postinstall.
 // @ts-expect-error — JS module, no TS declarations
-import { healPluginJsonMcpServers, healMcpJsonArgs } from "../scripts/heal-installed-plugins.mjs";
+import { healPluginJsonMcpServers, healMcpJsonArgs, sweepStaleMcpJson } from "../scripts/heal-installed-plugins.mjs";
 // @ts-expect-error — JS module, no TS declarations
 import { detectWindowsVsYear } from "../scripts/heal-better-sqlite3.mjs";
 // Private 16-LOC copy of browserOpenArgv. Canonical version lives in src/server.ts;
@@ -945,23 +945,13 @@ async function upgrade(opts?: { platform?: string }) {
         } catch { /* some files may not exist in source */ }
       }
 
-      // Write .mcp.json with CLAUDE_PLUGIN_ROOT placeholder (fixes #411).
-      // Absolute paths bake-in the current pluginRoot dir, which sessionstart.mjs
-      // (#181) deletes after upgrade — breaking MCP server resolution. The literal
-      // ${CLAUDE_PLUGIN_ROOT} placeholder is resolved by Claude at load-time and
-      // stays valid across version cleanups. Matches .claude-plugin/plugin.json.
-      const mcpConfig = {
-        mcpServers: {
-          "context-mode": {
-            command: "node",
-            args: ["${CLAUDE_PLUGIN_ROOT}/start.mjs"],
-          },
-        },
-      };
-      writeFileSync(
-        resolve(pluginRoot, ".mcp.json"),
-        JSON.stringify(mcpConfig, null, 2) + "\n",
-      );
+      // Issue #609: stopped writing .mcp.json into plugin cache dirs. CC plugin
+      // manager reads .claude-plugin/plugin.json mcpServers natively (proven by
+      // PR #523's plugin.json heal — pointless if CC ignored that file). A
+      // per-version .mcp.json is redundant legacy from #411 era and the
+      // previous-version copy is exactly what CC discovers stale post auto-
+      // update → MODULE_NOT_FOUND. Layer 8 sweep cleans existing prev-version
+      // .mcp.json instead — see Layer 8 block below the drift assertion.
 
       // Normalize hooks.json + plugin.json against the REAL pluginRoot now that
       // files have been copied. Two reasons:
@@ -1090,6 +1080,20 @@ async function upgrade(opts?: { platform?: string }) {
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
         throw new Error(`.mcp.json drift check failed: ${message}`);
+      }
+
+      // Issue #609 — Layer 8 sweep: delete stale .mcp.json from any prev-version
+      // cache dir under <pluginCacheRoot>/context-mode/context-mode/<X.Y.Z>/.
+      // Eliminates the discovery-confusion that causes CC to launch from a
+      // cleaned previous-version dir post auto-update.
+      try {
+        const pluginCacheRoot = resolve(resolveClaudeConfigDir(), "plugins", "cache");
+        const result = sweepStaleMcpJson({ pluginRoot, pluginCacheRoot });
+        if (result.swept && result.swept.length > 0) {
+          p.log.info(color.dim(`  swept stale .mcp.json: ${result.swept.join(", ")}`));
+        }
+      } catch {
+        /* best effort — never block upgrade */
       }
 
       // v1.0.X — Layer 7 heal: update user-level ~/.claude.json MCP server

--- a/start.mjs
+++ b/start.mjs
@@ -174,7 +174,7 @@ if (cacheMatch) {
 // truth) so users who fix themselves via `npm install -g context-mode`
 // follow the exact same code path. Best-effort, never blocks MCP boot.
 try {
-  const { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, healMcpJsonArgs } =
+  const { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, healMcpJsonArgs, sweepStaleMcpJson } =
     await import("./scripts/heal-installed-plugins.mjs");
   const pluginKey = "context-mode@context-mode";
   const claudeConfigDir = resolveClaudeConfigDir();
@@ -219,6 +219,15 @@ try {
               pluginRoot: installPath,
               pluginCacheRoot,
               pluginKey,
+            });
+          } catch { /* best effort — per-entry */ }
+          // Issue #609 — Layer 8 sweep: delete `.mcp.json` from any
+          // prev-version cache dir so CC never boots from a cleaned
+          // previous-version path. Idempotent across entries.
+          try {
+            sweepStaleMcpJson({
+              pluginRoot: installPath,
+              pluginCacheRoot,
             });
           } catch { /* best effort — per-entry */ }
         }

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -142,41 +142,41 @@ describe("cli.bundle.mjs — marketplace install support", () => {
 // ── .mcp.json — MCP server config ────────────────────────────────────
 
 describe(".mcp.json — MCP server config", () => {
-  it("upgrade writes cached .mcp.json with CLAUDE_PLUGIN_ROOT placeholder (#411)", () => {
+  it("upgrade does NOT write .mcp.json into plugin cache dir (#609)", () => {
+    // Issue #609: CC plugin manager reads .claude-plugin/plugin.json mcpServers
+    // natively (proven by healPluginJsonMcpServers — #523). Per-version .mcp.json
+    // in cache dirs was a #411-era legacy that became the root cause of #609:
+    // CC discovers the stale previous-version .mcp.json post auto-update, sets
+    // CLAUDE_PLUGIN_ROOT to that cleaned dir, fails MODULE_NOT_FOUND.
     const src = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
     const upgradeStart = src.indexOf("async function upgrade");
     const upgradeSrc = src.slice(upgradeStart);
-    // items array must NOT include .mcp.json (it's written dynamically)
+    // items array must NOT include .mcp.json (never shipped in tarball).
     const itemsMatch = upgradeSrc.match(/const items\s*=\s*\[([\s\S]*?)\];/);
     expect(itemsMatch).not.toBeNull();
     expect(itemsMatch![1]).not.toContain(".mcp.json");
-    // Must write .mcp.json dynamically with placeholder, not absolute path.
-    // Absolute paths break when sessionstart.mjs (#181) deletes old version dirs.
-    expect(upgradeSrc).toContain('resolve(pluginRoot, ".mcp.json")');
-    expect(upgradeSrc).not.toContain('resolve(pluginRoot, "start.mjs")');
-    expect(upgradeSrc).toContain("${CLAUDE_PLUGIN_ROOT}/start.mjs");
+    // Architectural lock: upgrade() MUST NOT call writeFileSync on .mcp.json.
+    expect(upgradeSrc).not.toMatch(/writeFileSync\s*\(\s*[\s\S]{0,80}\.mcp\.json/);
   });
 
-  it("upgrade .mcp.json placeholder is resilient to version cleanup (#411)", () => {
-    // Simulate two upgrade runs into different pluginRoot dirs and assert both
-    // produce identical placeholder-based args (no absolute paths to old dirs).
+  it("upgrade invokes sweepStaleMcpJson to clean prev-version cache dirs (#609)", () => {
+    // Layer 8 sweep — single source of truth shared with start.mjs HEAL
+    // and scripts/postinstall.mjs. cli.ts upgrade() MUST invoke the sweep
+    // after the existing heal/assertion chain so /ctx-upgrade also self-heals.
     const src = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
+    expect(src).toMatch(
+      /import\s*\{[^}]*sweepStaleMcpJson[^}]*\}\s*from\s+["']\.\.\/scripts\/heal-installed-plugins\.mjs["']/,
+    );
     const upgradeStart = src.indexOf("async function upgrade");
     const upgradeSrc = src.slice(upgradeStart);
-    // Extract the literal mcpConfig args entry — must be a string literal
-    // with ${CLAUDE_PLUGIN_ROOT}, not a runtime resolve(pluginRoot, ...) call.
-    const argsMatch = upgradeSrc.match(/args:\s*\[([^\]]+)\]/);
-    expect(argsMatch).not.toBeNull();
-    const argsContent = argsMatch![1];
-    // Must NOT depend on pluginRoot at write-time
-    expect(argsContent).not.toContain("pluginRoot");
-    expect(argsContent).not.toContain("resolve(");
-    // Must contain the literal placeholder
-    expect(argsContent).toContain("${CLAUDE_PLUGIN_ROOT}/start.mjs");
-    // Two simulated runs would produce identical JSON regardless of pluginRoot
-    // because the args value is a static string literal.
-    const literalCount = (upgradeSrc.match(/\$\{CLAUDE_PLUGIN_ROOT\}\/start\.mjs/g) || []).length;
-    expect(literalCount).toBeGreaterThanOrEqual(1);
+    expect(upgradeSrc).toContain("sweepStaleMcpJson({");
+    // Sweep must run AFTER the .mcp.json drift-check block — same ordering
+    // contract as the plugin.json / .mcp.json heals. Match the literal call
+    // shape so leading comment mentions don't satisfy the assertion.
+    const driftIdx = upgradeSrc.indexOf(".mcp.json drift check failed");
+    const sweepIdx = upgradeSrc.indexOf("sweepStaleMcpJson({");
+    expect(driftIdx).toBeGreaterThan(-1);
+    expect(sweepIdx).toBeGreaterThan(driftIdx);
   });
 
   it("plugin manifest keeps ${CLAUDE_PLUGIN_ROOT} for marketplace compatibility", () => {

--- a/tests/scripts/asymmetric-drift-assert.test.ts
+++ b/tests/scripts/asymmetric-drift-assert.test.ts
@@ -231,6 +231,7 @@ describe("Issue #531 — asymmetric-drift invariant", () => {
           "export function healSettingsEnabledPlugins() { return { healed: [] }; }",
           "export function healPluginJsonMcpServers() { return { healed: [] }; }",
           "export function healMcpJsonArgs() { return { healed: [] }; }",
+          "export function sweepStaleMcpJson() { return { healed: [] }; }",
           "",
         ].join("\n"),
       );


### PR DESCRIPTION
## Summary

Closes #609. CC native auto-update leaves stale `.mcp.json` in the previous version cache dir; CC discovers it, sets `CLAUDE_PLUGIN_ROOT` to the now-cleaned old version, fires `MODULE_NOT_FOUND` on every hook. This PR removes the root cause (the cache-dir `.mcp.json` write) and sweeps existing stale copies on every boot / install / `/ctx-upgrade`.

## Root Cause

After CC plugin manager auto-updates `<X.Y.Z>` → `<X.Y.Z+1>`:

| Path | `.mcp.json` | `start.mjs` |
|------|------------|------------|
| `cache/.../X.Y.Z/` | ✓ present (legacy write) | ✗ cleaned |
| `cache/.../X.Y.Z+1/` | ✗ never written by tarball | ✓ present |

CC scans the cache tree, finds `X.Y.Z/.mcp.json`, sets `CLAUDE_PLUGIN_ROOT=X.Y.Z`, then `node ${CLAUDE_PLUGIN_ROOT}/start.mjs` resolves to a path the auto-update cleaned → `MODULE_NOT_FOUND`.

Per-version `.mcp.json` in plugin cache is redundant legacy. CC plugin manager reads `.claude-plugin/plugin.json` `mcpServers` natively (proven by PR #523's heal — the heal would be pointless if CC ignored that file). The `.mcp.json` write in `cli.ts` upgrade() was added for the #411 era and is now exactly the discovery confusion that causes #609.

Fifth instance of the same sibling-config drift pattern (#411 / #523 / #531 / #604). Addressed architecturally rather than adding another heal layer to chase content.

## Fix

- `src/cli.ts` upgrade() no longer writes `.mcp.json` into the plugin cache dir. Existing Layer 6 `healMcpJsonArgs` drift-check stays in place (no-op when file absent, still catches legacy installs).
- New `sweepStaleMcpJson` in `scripts/heal-installed-plugins.mjs` walks `<pluginCacheRoot>/context-mode/context-mode/<X.Y.Z>/` and deletes any `.mcp.json` whose version dir does not match the running pluginRoot. Same path-traversal guard pattern as sibling heals. Returns null for non-cache layouts (npm-global, dev checkout) so contributors and raw installs are untouched.
- Wired into all three boot/install/upgrade entry points (single-source-of-truth contract shared with `healMcpJsonArgs` / `healPluginJsonMcpServers`):
  - `start.mjs` HEAL per-entry loop
  - `scripts/postinstall.mjs` per-entry loop
  - `src/cli.ts` `upgrade()` after the drift-check block

## Test plan

- [x] `tests/core/cli.test.ts` — replaces the two #411-era tests asserting the now-removed `.mcp.json` write block with:
  - `upgrade does NOT write .mcp.json into plugin cache dir (#609)` — architectural lock against re-introducing the write
  - `upgrade invokes sweepStaleMcpJson to clean prev-version cache dirs (#609)` — import + ordering contract (sweep must run after the drift-check assertion)
- [x] `tests/scripts/asymmetric-drift-assert.test.ts` — extended the contributor-codepath postinstall stub to export `sweepStaleMcpJson` so the new import doesn't SyntaxError.
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean (assert-bundle + assert-asymmetric-drift OK).
- [x] `npx vitest run` — 3331 / 3356 pass, 25 skipped, 0 fail.

## Tradeoffs noted

- Existing users with a stale `.mcp.json` baked into older cache dirs lose that file. It is already broken (points at a cleaned `start.mjs`) so the sweep is removing garbage, not data.
- If a future CC release ever decided to require per-version `.mcp.json` in cache (instead of reading `plugin.json.mcpServers`), this would need to be revisited. Existing PR #523 heal contract implies that is not the current direction.
- Raw `npm install -g context-mode` users are unaffected: `sweepStaleMcpJson` returns `not-cache-layout` for npm-global / dev-checkout paths. `package.json` `files[]` has never shipped `.mcp.json` (see commit `9261377`, "untrack .mcp.json + stop shipping in npm tarball" — same architectural family).