### PR TITLE
fix(family-A): persistence-tier rules — drop stale .mcp.json + portable Tier C hooks

### DIFF
--- a/scripts/heal-installed-plugins.mjs
+++ b/scripts/heal-installed-plugins.mjs
@@ -17,7 +17,7 @@
  * @see https://github.com/anthropics/claude-code/issues/46915
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, readdirSync, unlinkSync, statSync } from "node:fs";
 import { resolve, sep } from "node:path";
 
 /**
@@ -460,4 +460,118 @@ export function healClaudeJsonMcpArgs({ dotClaudeJsonPath, pluginCacheParent, ne
   }
 
   return { healed: ["claude-json-mcp-args"] };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Issue #609 — sweepStaleMcpJson: remove cache-baked `.mcp.json` files.
+//
+// Background (per ISSUE-609-VERDICT, ISSUE-604-VERDICT):
+//   cli.ts upgrade() wrote `.mcp.json` into every per-version plugin-cache
+//   dir starting with #411. PR #531 (commit 9261377) removed `.mcp.json`
+//   from `package.json files[]` so the npm tarball no longer ships it,
+//   but the cli-side write persisted. Every `/ctx-upgrade` re-baked a
+//   per-version copy. When Claude Code's native plugin manager auto-update
+//   later copies a previous version's `.mcp.json` forward into a fresh
+//   version dir, the stale start.mjs absolute path goes with it →
+//   MODULE_NOT_FOUND on every MCP boot, and `ctx-doctor` stays green
+//   because nothing validates that path against current pluginRoot.
+//
+// The architectural fix is to STOP writing `.mcp.json` from the cache layer
+// entirely. `.claude-plugin/plugin.json.mcpServers` is the canonical source
+// (refs/platforms/claude-code/src/utils/plugins/mcpPluginIntegration.ts:131-212
+// — Claude Code reads it first). This sweep removes any pre-existing
+// `.mcp.json` from every per-version cache dir so the previous-version-
+// carry vector cannot replay across upgrades.
+//
+// Single source of truth shared by:
+//   - `start.mjs` HEAL 5c (every MCP boot)
+//   - `scripts/postinstall.mjs` (every `npm install -g context-mode`)
+//   - `src/cli.ts` upgrade() (post-bump)
+//
+// Safety contracts:
+//   - Path-traversal guard: refuses to walk outside `pluginCacheRoot`.
+//   - Best-effort: NEVER throws; missing files / unreadable dirs are
+//     skipped silently and reported in the result.
+//   - Scope: deletes ONLY files named exactly `.mcp.json`; never touches
+//     sibling files in the same dir.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {Object} SweepResult
+ * @property {string[]} removed - absolute paths of removed `.mcp.json` files
+ * @property {string} [skipped] - reason if no work performed (e.g. "no-cache-root")
+ */
+
+/**
+ * Remove every `.mcp.json` from per-version directories under
+ * `<pluginCacheRoot>/<owner>/<plugin>/<X.Y.Z>/`.
+ *
+ * @param {{ pluginCacheRoot: string, pluginKey: string }} opts
+ *   pluginKey is the "<owner>@<plugin>" form (e.g. "context-mode@context-mode").
+ * @returns {SweepResult}
+ */
+export function sweepStaleMcpJson({ pluginCacheRoot, pluginKey }) {
+  /** @type {string[]} */
+  const removed = [];
+
+  if (!pluginCacheRoot || !pluginKey) {
+    return { removed, skipped: "missing-args" };
+  }
+
+  const resolvedCacheRoot = resolve(pluginCacheRoot);
+  if (!existsSync(resolvedCacheRoot)) {
+    return { removed, skipped: "no-cache-root" };
+  }
+
+  // pluginKey shape: "<owner>@<plugin>"
+  const [ownerSegment, pluginSegment] = pluginKey.split("@");
+  if (!ownerSegment || !pluginSegment) {
+    return { removed, skipped: "bad-plugin-key" };
+  }
+
+  // Path-traversal guard: refuse to walk outside the declared cache root,
+  // even if pluginKey contains `..` segments. Per Mert's standing Windows
+  // safety rule, resolve normalizes both `/` and `\` so the guard fires
+  // on either separator.
+  const ownerDir = resolve(resolvedCacheRoot, ownerSegment, pluginSegment);
+  const cacheRootWithSep = resolvedCacheRoot + sep;
+  if (!ownerDir.startsWith(cacheRootWithSep)) {
+    return { removed, skipped: "outside-cache-root" };
+  }
+
+  if (!existsSync(ownerDir)) {
+    return { removed, skipped: "no-plugin-dir" };
+  }
+
+  /** @type {string[]} */
+  let versionEntries = [];
+  try {
+    versionEntries = readdirSync(ownerDir);
+  } catch {
+    return { removed, skipped: "readdir-failed" };
+  }
+
+  for (const versionEntry of versionEntries) {
+    const versionDir = resolve(ownerDir, versionEntry);
+    // Per-version guard: only enter directories whose resolved path stays
+    // under the owner dir. Belt-and-braces against weird FS entries.
+    if (!versionDir.startsWith(ownerDir + sep)) continue;
+    try {
+      const stat = statSync(versionDir);
+      if (!stat.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const mcpJsonPath = resolve(versionDir, ".mcp.json");
+    if (!existsSync(mcpJsonPath)) continue;
+    try {
+      unlinkSync(mcpJsonPath);
+      removed.push(mcpJsonPath);
+    } catch {
+      // best-effort: file may have been removed by a concurrent process
+      // between existsSync and unlinkSync. Silent skip.
+    }
+  }
+
+  return { removed };
 }

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -14,7 +14,7 @@ import { dirname, resolve, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { healBetterSqlite3Binding } from "./heal-better-sqlite3.mjs";
-import { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, healMcpJsonArgs } from "./heal-installed-plugins.mjs";
+import { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, sweepStaleMcpJson } from "./heal-installed-plugins.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(__dirname, "..");
@@ -181,26 +181,24 @@ if (isGlobalInstall()) {
               healedAny = true;
             }
           } catch { /* per-entry best effort */ }
-          // v1.0.122 — Issue #531 — Layer 6: asymmetric-heal sibling for
-          // .mcp.json. The #253/aea633c regression shipped a bare `./start.mjs`
-          // arg that Claude Code resolves against session CWD (not pluginRoot)
-          // → MODULE_NOT_FOUND on every ctx_* tool. When MCP is dead, the
-          // only escape hatch is `npm install -g context-mode` whose
-          // postinstall MUST run this heal too.
-          try {
-            const r = healMcpJsonArgs({
-              pluginRoot: installPath,
-              pluginCacheRoot: cacheRoot,
-              pluginKey: "context-mode@context-mode",
-            });
-            if (r && Array.isArray(r.healed) && r.healed.length > 0) {
-              healedAny = true;
-            }
-          } catch { /* per-entry best effort */ }
         }
       }
+      // Issue #609 — Layer 6: sweep stale `.mcp.json` files from every
+      // per-version cache dir. Replaces the previous per-entry healMcpJsonArgs
+      // loop (v1.0.122) — `.mcp.json` is no longer written from cli.ts so
+      // remaining files in the cache are stale carry-forwards that block
+      // future auto-updates from working cleanly. Single sweep per install.
+      try {
+        const sweepResult = sweepStaleMcpJson({
+          pluginCacheRoot: cacheRoot,
+          pluginKey: "context-mode@context-mode",
+        });
+        if (sweepResult && Array.isArray(sweepResult.removed) && sweepResult.removed.length > 0) {
+          process.stderr.write(`context-mode: swept ${sweepResult.removed.length} stale .mcp.json file(s) (Issue #609)\n`);
+        }
+      } catch { /* never block install */ }
       if (healedAny) {
-        process.stderr.write("context-mode: healed mcpServers args (Issues #523 + #531)\n");
+        process.stderr.write("context-mode: healed mcpServers args (Issue #523)\n");
       }
     }
   } catch { /* never block install */ }

--- a/src/adapters/jetbrains-copilot/hooks.ts
+++ b/src/adapters/jetbrains-copilot/hooks.ts
@@ -1,5 +1,3 @@
-import { buildNodeCommand } from "../types.js";
-
 /**
  * adapters/jetbrains-copilot/hooks — JetBrains Copilot hook definitions and matchers.
  *
@@ -86,16 +84,21 @@ export function isContextModeHook(
 
 /**
  * Build the hook command string for a given hook type.
- * Uses absolute node path to avoid PATH issues (homebrew, nvm, volta, etc.).
- * Falls back to CLI dispatcher if pluginRoot is not provided.
+ *
+ * Always emits the CLI dispatcher form
+ * (`context-mode hook jetbrains-copilot <event>`) — the `pluginRoot`
+ * argument is accepted for API compatibility but intentionally ignored.
+ *
+ * Same Tier C contract as VS Code Copilot (Issue #613):
+ * `.github/hooks/context-mode.json` is workspace-committed (team-shared
+ * via git). Embedding `process.execPath` or absolute pluginRoot paths
+ * leaks PII and breaks cross-machine portability. See
+ * src/adapters/vscode-copilot/hooks.ts for the full archaeology.
  */
-export function buildHookCommand(hookType: HookType, pluginRoot?: string): string {
+export function buildHookCommand(hookType: HookType, _pluginRoot?: string): string {
   const scriptName = HOOK_SCRIPTS[hookType];
   if (!scriptName) {
     throw new Error(`No script defined for hook type: ${hookType}`);
-  }
-  if (pluginRoot) {
-    return buildNodeCommand(`${pluginRoot}/hooks/jetbrains-copilot/${scriptName}`);
   }
   return `context-mode hook jetbrains-copilot ${hookType.toLowerCase()}`;
 }

--- a/src/adapters/vscode-copilot/hooks.ts
+++ b/src/adapters/vscode-copilot/hooks.ts
@@ -1,5 +1,3 @@
-import { buildNodeCommand } from "../types.js";
-
 /**
  * adapters/vscode-copilot/hooks — VS Code Copilot hook definitions and matchers.
  *
@@ -81,21 +79,37 @@ export function isContextModeHook(
 
 /**
  * Build the hook command string for a given hook type.
- * Uses absolute node path to avoid PATH issues (homebrew, nvm, volta, etc.).
- * Falls back to CLI dispatcher if pluginRoot is not provided.
+ *
+ * Always emits the CLI dispatcher form
+ * (`context-mode hook vscode-copilot <event>`) — the `pluginRoot` argument
+ * is accepted for API compatibility but intentionally ignored.
+ *
+ * Why the dispatcher form is mandatory here (Issue #613 — Tier C contract):
+ *   `.github/hooks/context-mode.json` is a **workspace-committed** file
+ *   (upstream: refs/platforms/vscode-copilot/assets/prompts/skills/
+ *   agent-customization/references/hooks.md line 7 — "Workspace
+ *   (team-shared)"). It lands in every teammate's `git status`. Embedding
+ *   `process.execPath` or any absolute pluginRoot path here:
+ *     - Leaks PII (username, `C:/Users/<user>/...` paths).
+ *     - Breaks cross-machine portability (fnm/nvm/volta/brew shims are
+ *       per-shell-session ephemeral; the path goes stale immediately on
+ *       Windows + fnm).
+ *
+ * Commit `f5c9d02` (2026-03-06) added an absolute-path branch when a
+ * pluginRoot was passed. It solved a real PATH-availability bug on
+ * Brew/nvm setups by going too far — the CLI then always passes
+ * pluginRoot, so the portable form became unreachable in production
+ * and every `/ctx-upgrade` baked a non-portable command into the
+ * committed config. This reverts to the pre-`f5c9d02` shape.
+ *
+ * For users without a global install, the recovery path is the same as
+ * every other CLI-dispatcher adapter (cursor, codex):
+ *   `npm install -g context-mode`
  */
-export function buildHookCommand(hookType: HookType, pluginRoot?: string): string {
+export function buildHookCommand(hookType: HookType, _pluginRoot?: string): string {
   const scriptName = HOOK_SCRIPTS[hookType];
   if (!scriptName) {
     throw new Error(`No script defined for hook type: ${hookType}`);
-  }
-  if (pluginRoot) {
-    // v1.0.107 fix — was `${pluginRoot}/hooks/${scriptName}` which resolved to
-    // the Claude-Code generic hook (`hooks/pretooluse.mjs`) instead of the
-    // VSCode-specific wrapper at `hooks/vscode-copilot/pretooluse.mjs`. JetBrains
-    // adapter already had the correct subdir (jetbrains-copilot/hooks.ts:98)
-    // so this brings VSCode to parity.
-    return buildNodeCommand(`${pluginRoot}/hooks/vscode-copilot/${scriptName}`);
   }
   return `context-mode hook vscode-copilot ${hookType.toLowerCase()}`;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -534,6 +534,174 @@ async function doctor(): Promise<number> {
     );
   }
 
+  // ── Issue #613 — proactive Tier C absolute-path detection ───────────
+  // PR #620 fixed `buildHookCommand` for vscode-copilot + jetbrains-copilot
+  // so future writes are CLI-dispatcher-shape. But users who ran
+  // /ctx-upgrade on v1.0.136 or earlier are still carrying poisoned
+  // committable files in their workspace:
+  //   - `.github/hooks/context-mode.json`      (vscode-copilot, team-shared)
+  //   - `.jetbrains/copilot/hooks.json`        (jetbrains-copilot, team-shared)
+  //   - `.cursor/hooks.json`                   (cursor, team-shared)
+  // Per ISSUE-613-VERDICT §6.1 these are Tier C — workspace-committed
+  // cross-machine config. Doctor scans them for absolute paths and
+  // fnm_multishells shims; if found, FAIL with `ctx_upgrade` remediation.
+  // Per ISSUE-604-VERDICT §11 ("silent-green doctor while hooks are dead
+  // is itself a P0 trust bug") — surface poison BEFORE the user hits a
+  // runtime failure.
+  p.log.step("Checking workspace-committed hook configs (Tier C)...");
+  {
+    const projectDir = process.cwd();
+    const tierCFiles = [
+      ".github/hooks/context-mode.json",
+      ".cursor/hooks.json",
+      ".jetbrains/copilot/hooks.json",
+    ];
+    let tierCFails = 0;
+    let tierCChecked = 0;
+
+    // Detect absolute-path patterns that should never appear in a
+    // workspace-committed config. Per Mert's standing Windows-safety rule:
+    // handle both `/` and `\\` separators.
+    function isAbsoluteOrShimPath(s: string): boolean {
+      // unix absolute
+      if (s.startsWith("/")) return true;
+      // Windows drive-letter absolute (e.g. C:/, C:\)
+      if (/^[A-Za-z]:[/\\]/.test(s)) return true;
+      // Windows UNC or escaped-backslash absolute fragments
+      if (s.includes("\\\\")) return true;
+      // fnm shim hint — issue #613 reporter's exact stderr shape
+      if (s.includes("fnm_multishells")) return true;
+      // process.execPath literal baked into JSON
+      if (s.includes("process.execPath")) return true;
+      return false;
+    }
+
+    function recurseStrings(node: unknown, hit: (s: string) => void): void {
+      if (typeof node === "string") {
+        hit(node);
+      } else if (Array.isArray(node)) {
+        for (const item of node) recurseStrings(item, hit);
+      } else if (node && typeof node === "object") {
+        for (const v of Object.values(node)) recurseStrings(v, hit);
+      }
+    }
+
+    for (const rel of tierCFiles) {
+      const abs = resolve(projectDir, rel);
+      if (!existsSync(abs)) continue; // missing config → SKIP, no false fail
+      tierCChecked++;
+      try {
+        const parsed = JSON.parse(readFileSync(abs, "utf-8"));
+        const offenders: string[] = [];
+        recurseStrings(parsed, (s) => {
+          if (isAbsoluteOrShimPath(s)) offenders.push(s);
+        });
+        if (offenders.length > 0) {
+          criticalFails++;
+          tierCFails++;
+          // Truncate to one example to keep output readable; show count.
+          const example = offenders[0].length > 100
+            ? offenders[0].slice(0, 97) + "..."
+            : offenders[0];
+          p.log.error(
+            color.red(`Tier C config: FAIL`) +
+              ` — ${rel} contains ${offenders.length} absolute path(s)` +
+              color.dim(
+                `\n  Example: ${example}` +
+                "\n  Root cause: pre-v1.0.137 /ctx-upgrade baked machine-local paths into a workspace-committed file (#613)." +
+                "\n  Fix: run /context-mode:ctx-upgrade to rewrite to portable `context-mode hook <platform> <event>` form.",
+              ),
+          );
+        } else {
+          p.log.success(
+            color.green("Tier C config: PASS") +
+              color.dim(` — ${rel} uses portable command shapes`),
+          );
+        }
+      } catch (err: unknown) {
+        // Malformed JSON should not crash doctor; warn and move on.
+        const msg = err instanceof Error ? err.message : String(err);
+        p.log.warn(
+          color.yellow(`Tier C config: WARN`) +
+            ` — could not parse ${rel}` +
+            color.dim(`\n  ${msg.slice(0, 200)}`),
+        );
+      }
+    }
+    if (tierCChecked === 0) {
+      p.log.info(
+        color.dim("Tier C config: SKIP — no workspace-committed hook configs found"),
+      );
+    } else if (tierCFails === 0) {
+      // already individual PASS messages above; no need for a summary
+    }
+  }
+
+  // ── Issue #609 — proactive stale `.mcp.json` detection ──────────────
+  // PR #620 deleted the per-version cache `.mcp.json` write from cli.ts
+  // and shipped `sweepStaleMcpJson` to clean up any pre-existing copies.
+  // But users on the field may still have stale `.mcp.json` files left
+  // by /ctx-upgrade flows that ran before PR #620 (or by Claude Code's
+  // native auto-update copying a poisoned file forward). Surface those
+  // as WARN (recoverable — next ctx_upgrade sweeps them) so the user
+  // knows what to do instead of being told everything is green while
+  // the file lingers on disk.
+  // Per ISSUE-604-VERDICT §11 same trust contract as Tier C check above.
+  p.log.step("Checking for stale per-version `.mcp.json` files...");
+  {
+    const cacheRoot = join(
+      homedir(),
+      ".claude",
+      "plugins",
+      "cache",
+      "context-mode",
+      "context-mode",
+    );
+    if (!existsSync(cacheRoot)) {
+      p.log.info(
+        color.dim("Cache scan: SKIP — no plugin cache present at " + cacheRoot),
+      );
+    } else {
+      let staleCount = 0;
+      const staleVersions: string[] = [];
+      try {
+        const versionDirs = readdirSync(cacheRoot);
+        for (const v of versionDirs) {
+          const candidate = join(cacheRoot, v, ".mcp.json");
+          if (existsSync(candidate)) {
+            staleCount++;
+            if (staleVersions.length < 5) staleVersions.push(v);
+          }
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.log.warn(
+          color.yellow("Cache scan: WARN") +
+            ` — could not enumerate ${cacheRoot}` +
+            color.dim(`\n  ${msg.slice(0, 200)}`),
+        );
+        staleCount = 0;
+      }
+      if (staleCount === 0) {
+        p.log.success(
+          color.green("Cache `.mcp.json` sweep: PASS") +
+            color.dim(" — no stale files in per-version cache dirs"),
+        );
+      } else {
+        // WARN, not FAIL — per architect spec this is recoverable.
+        p.log.warn(
+          color.yellow("Cache `.mcp.json` sweep: WARN") +
+            ` — ${staleCount} stale .mcp.json file(s) in ${cacheRoot}` +
+            color.dim(
+              `\n  Versions: ${staleVersions.join(", ")}${staleCount > staleVersions.length ? ", ..." : ""}` +
+              "\n  Root cause: pre-v1.0.137 /ctx-upgrade wrote per-version `.mcp.json` into the plugin cache; PR #620 removed the write + added a sweep (#609)." +
+              "\n  Fix: run /context-mode:ctx-upgrade — `sweepStaleMcpJson` will remove these files on the next run.",
+            ),
+        );
+      }
+    }
+  }
+
   // FTS5 / SQLite
   p.log.step("Checking FTS5 / SQLite...");
   try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -548,7 +548,7 @@ async function doctor(): Promise<number> {
   // Per ISSUE-604-VERDICT §11 ("silent-green doctor while hooks are dead
   // is itself a P0 trust bug") — surface poison BEFORE the user hits a
   // runtime failure.
-  p.log.step("Checking workspace-committed hook configs (Tier C)...");
+  p.log.step("Checking team-shared hook configs in your workspace...");
   {
     const projectDir = process.cwd();
     const tierCFiles = [
@@ -604,33 +604,38 @@ async function doctor(): Promise<number> {
             ? offenders[0].slice(0, 97) + "..."
             : offenders[0];
           p.log.error(
-            color.red(`Tier C config: FAIL`) +
-              ` — ${rel} contains ${offenders.length} absolute path(s)` +
+            color.red(`Hook config: FAIL`) +
+              ` — ${rel} has your machine's local paths baked in` +
               color.dim(
-                `\n  Example: ${example}` +
-                "\n  Root cause: pre-v1.0.137 /ctx-upgrade baked machine-local paths into a workspace-committed file (#613)." +
-                "\n  Fix: run /context-mode:ctx-upgrade to rewrite to portable `context-mode hook <platform> <event>` form.",
+                "\n  This file is committed to git, so teammates and CI will get your path and the hooks will break for them." +
+                `\n  Found ${offenders.length} hard-coded path(s), e.g.: ${example}` +
+                "\n  Fix: run /context-mode:ctx-upgrade — it rewrites the file to a portable form that works on every machine." +
+                "\n  Details: https://github.com/mksglu/context-mode/issues/613",
               ),
           );
         } else {
           p.log.success(
-            color.green("Tier C config: PASS") +
-              color.dim(` — ${rel} uses portable command shapes`),
+            color.green("Hook config: PASS") +
+              color.dim(` — ${rel} is portable (no hard-coded paths)`),
           );
         }
       } catch (err: unknown) {
         // Malformed JSON should not crash doctor; warn and move on.
         const msg = err instanceof Error ? err.message : String(err);
         p.log.warn(
-          color.yellow(`Tier C config: WARN`) +
-            ` — could not parse ${rel}` +
-            color.dim(`\n  ${msg.slice(0, 200)}`),
+          color.yellow(`Hook config: WARN`) +
+            ` — ${rel} is not valid JSON` +
+            color.dim(
+              "\n  Doctor cannot scan it for portability issues until the file parses." +
+              "\n  Fix: open the file and check it in a JSON validator, or delete it and run /context-mode:ctx-upgrade to regenerate." +
+              `\n  Parser said: ${msg.slice(0, 160)}`,
+            ),
         );
       }
     }
     if (tierCChecked === 0) {
       p.log.info(
-        color.dim("Tier C config: SKIP — no workspace-committed hook configs found"),
+        color.dim("Hook config: SKIP — no team-shared hook configs found in this workspace"),
       );
     } else if (tierCFails === 0) {
       // already individual PASS messages above; no need for a summary
@@ -647,7 +652,7 @@ async function doctor(): Promise<number> {
   // knows what to do instead of being told everything is green while
   // the file lingers on disk.
   // Per ISSUE-604-VERDICT §11 same trust contract as Tier C check above.
-  p.log.step("Checking for stale per-version `.mcp.json` files...");
+  p.log.step("Checking for leftover .mcp.json files from older versions...");
   {
     const cacheRoot = join(
       homedir(),
@@ -659,7 +664,7 @@ async function doctor(): Promise<number> {
     );
     if (!existsSync(cacheRoot)) {
       p.log.info(
-        color.dim("Cache scan: SKIP — no plugin cache present at " + cacheRoot),
+        color.dim("Leftover .mcp.json check: SKIP — no plugin cache exists yet (Claude Code has not installed context-mode here)"),
       );
     } else {
       let staleCount = 0;
@@ -676,26 +681,31 @@ async function doctor(): Promise<number> {
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         p.log.warn(
-          color.yellow("Cache scan: WARN") +
-            ` — could not enumerate ${cacheRoot}` +
-            color.dim(`\n  ${msg.slice(0, 200)}`),
+          color.yellow("Leftover .mcp.json check: WARN") +
+            ` — could not read the plugin cache directory` +
+            color.dim(
+              `\n  Path: ${cacheRoot}` +
+              `\n  Reason: ${msg.slice(0, 160)}` +
+              "\n  Fix: check that the directory is readable, then re-run doctor. If the issue persists, run /context-mode:ctx-upgrade.",
+            ),
         );
         staleCount = 0;
       }
       if (staleCount === 0) {
         p.log.success(
-          color.green("Cache `.mcp.json` sweep: PASS") +
-            color.dim(" — no stale files in per-version cache dirs"),
+          color.green("Leftover .mcp.json check: PASS") +
+            color.dim(" — no old .mcp.json files in the plugin cache"),
         );
       } else {
         // WARN, not FAIL — per architect spec this is recoverable.
         p.log.warn(
-          color.yellow("Cache `.mcp.json` sweep: WARN") +
-            ` — ${staleCount} stale .mcp.json file(s) in ${cacheRoot}` +
+          color.yellow("Leftover .mcp.json check: WARN") +
+            ` — found ${staleCount} old .mcp.json file(s) left over from previous context-mode versions` +
             color.dim(
-              `\n  Versions: ${staleVersions.join(", ")}${staleCount > staleVersions.length ? ", ..." : ""}` +
-              "\n  Root cause: pre-v1.0.137 /ctx-upgrade wrote per-version `.mcp.json` into the plugin cache; PR #620 removed the write + added a sweep (#609)." +
-              "\n  Fix: run /context-mode:ctx-upgrade — `sweepStaleMcpJson` will remove these files on the next run.",
+              "\n  These are harmless but should be cleaned up so they cannot confuse Claude Code after an auto-update." +
+              `\n  Versions affected: ${staleVersions.join(", ")}${staleCount > staleVersions.length ? ", ..." : ""}` +
+              "\n  Fix: run /context-mode:ctx-upgrade — it sweeps these files automatically on the next run." +
+              "\n  Details: https://github.com/mksglu/context-mode/issues/609",
             ),
         );
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,7 +33,7 @@ import { discoverSiblingMcpPids, killSiblingMcpServers } from "./util/sibling-mc
 // v1.0.119 — Issue #523 Layer 5 heal: post-bump assertion on .claude-plugin/plugin.json
 // mcpServers args. Single source of truth shared with start.mjs HEAL block + postinstall.
 // @ts-expect-error — JS module, no TS declarations
-import { healPluginJsonMcpServers, healMcpJsonArgs } from "../scripts/heal-installed-plugins.mjs";
+import { healPluginJsonMcpServers, sweepStaleMcpJson } from "../scripts/heal-installed-plugins.mjs";
 // @ts-expect-error — JS module, no TS declarations
 import { detectWindowsVsYear } from "../scripts/heal-better-sqlite3.mjs";
 // Private 16-LOC copy of browserOpenArgv. Canonical version lives in src/server.ts;
@@ -945,23 +945,24 @@ async function upgrade(opts?: { platform?: string }) {
         } catch { /* some files may not exist in source */ }
       }
 
-      // Write .mcp.json with CLAUDE_PLUGIN_ROOT placeholder (fixes #411).
-      // Absolute paths bake-in the current pluginRoot dir, which sessionstart.mjs
-      // (#181) deletes after upgrade — breaking MCP server resolution. The literal
-      // ${CLAUDE_PLUGIN_ROOT} placeholder is resolved by Claude at load-time and
-      // stays valid across version cleanups. Matches .claude-plugin/plugin.json.
-      const mcpConfig = {
-        mcpServers: {
-          "context-mode": {
-            command: "node",
-            args: ["${CLAUDE_PLUGIN_ROOT}/start.mjs"],
-          },
-        },
-      };
-      writeFileSync(
-        resolve(pluginRoot, ".mcp.json"),
-        JSON.stringify(mcpConfig, null, 2) + "\n",
-      );
+      // Issue #609 — DO NOT write `.mcp.json` into the plugin cache dir.
+      //
+      // Historical context: #411 fixed an absolute-path bake by writing the
+      // ${CLAUDE_PLUGIN_ROOT} placeholder form here. #531 (commit 9261377)
+      // removed `.mcp.json` from `package.json files[]` so the npm tarball
+      // stopped shipping it. But the cli-side write persisted, so every
+      // /ctx-upgrade re-baked one. When Claude Code's native plugin manager
+      // auto-update later carries a previous version's `.mcp.json` forward
+      // into a fresh version dir, the stale start.mjs absolute path goes
+      // with it → MODULE_NOT_FOUND on every MCP boot.
+      //
+      // Architectural fix: Claude Code reads `.claude-plugin/plugin.json`
+      // .mcpServers as the canonical source (upstream:
+      // refs/platforms/claude-code/src/utils/plugins/mcpPluginIntegration.ts:131-212).
+      // `.mcp.json` is a redundant per-version artifact whose only role
+      // historically was to be a write-time poison vector. Don't write it.
+      // The post-bump cache-sweep below removes any pre-existing copies so
+      // the previous-version-carry vector cannot replay.
 
       // Normalize hooks.json + plugin.json against the REAL pluginRoot now that
       // files have been copied. Two reasons:
@@ -1065,31 +1066,34 @@ async function upgrade(opts?: { platform?: string }) {
         throw new Error(`plugin.json drift check failed: ${message}`);
       }
 
-      // v1.0.122 — Issue #531 — Layer 6 heal: assert .mcp.json's
-      // mcpServers["context-mode"].args[0] is the literal ${CLAUDE_PLUGIN_ROOT}/start.mjs
-      // placeholder. Asymmetric-heal sibling of the plugin.json assertion above.
-      // cli.ts writes .mcp.json at ~line 829-845 with the placeholder, but never
-      // asserted the on-disk shape afterwards — if a future regression dropped
-      // the placeholder write or a parallel normalize baked in an absolute path,
-      // upgrade() would declare success on a poisoned tree. Belt-and-braces:
-      // first call cleans any drift; second call MUST return healed:[] or throw.
-      // Single source of truth shared with start.mjs HEAL block + postinstall.
+      // Issue #609 — Layer 6 replacement: sweep stale `.mcp.json` files from
+      // every per-version cache dir. Supersedes the previous healMcpJsonArgs
+      // drift-check block (v1.0.122) — that block existed because cli.ts
+      // itself wrote `.mcp.json`. With the write gone (above), the only
+      // remaining `.mcp.json` files are stale carry-forwards from earlier
+      // versions. Sweep them so Claude Code's auto-update can't replay them
+      // into a fresh version dir.
+      //
+      // Belt-and-braces: a second sweep call MUST report removed:[] or we
+      // throw — same architectural-lock pattern as the plugin.json drift
+      // check above. Single source of truth shared with start.mjs HEAL
+      // block + postinstall.
       try {
         const pluginCacheRoot = resolve(resolveClaudeConfigDir(), "plugins", "cache");
         const pluginKey = "context-mode@context-mode";
-        const firstPass = healMcpJsonArgs({ pluginRoot, pluginCacheRoot, pluginKey });
-        if (firstPass && firstPass.error) {
-          throw new Error(firstPass.error);
+        const firstSweep = sweepStaleMcpJson({ pluginCacheRoot, pluginKey });
+        if (firstSweep && firstSweep.removed && firstSweep.removed.length > 0) {
+          p.log.info(color.dim(`  Swept ${firstSweep.removed.length} stale .mcp.json file(s) from cache`));
         }
-        const secondPass = healMcpJsonArgs({ pluginRoot, pluginCacheRoot, pluginKey });
-        if (secondPass && Array.isArray(secondPass.healed) && secondPass.healed.length > 0) {
+        const secondSweep = sweepStaleMcpJson({ pluginCacheRoot, pluginKey });
+        if (secondSweep && Array.isArray(secondSweep.removed) && secondSweep.removed.length > 0) {
           throw new Error(
-            `.mcp.json drift: mcpServers.args still poisoned after first heal pass (healed=${secondPass.healed.join(",")})`,
+            `.mcp.json sweep drift: ${secondSweep.removed.length} file(s) still present after first pass`,
           );
         }
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        throw new Error(`.mcp.json drift check failed: ${message}`);
+        throw new Error(`.mcp.json sweep check failed: ${message}`);
       }
 
       // v1.0.X — Layer 7 heal: update user-level ~/.claude.json MCP server

--- a/src/server.ts
+++ b/src/server.ts
@@ -3362,7 +3362,10 @@ server.registerTool(
         `const pkg=JSON.parse(readFileSync(join(T,"package.json"),"utf8"));`,
         `const items=[...(Array.isArray(pkg.files)?pkg.files:[]),"src","package.json"];`,
         `for(const item of items){const from=join(T,item);const to=join(P,item);if(existsSync(from)){rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true,force:true});}}`,
-        `writeFileSync(join(P,".mcp.json"),JSON.stringify({mcpServers:{"context-mode":{command:"node",args:["\${CLAUDE_PLUGIN_ROOT}/start.mjs"]}}},null,2)+"\\n");`,
+        // Issue #609: do NOT write .mcp.json into the cache dir. Claude Code reads
+        // .claude-plugin/plugin.json.mcpServers as the canonical MCP source — the
+        // per-version .mcp.json file is a stale-write vector. Same architectural
+        // fix as the cli.ts upgrade() path; both writers were the only producers.
         `console.log("- [x] Copied package files");`,
         `execFileSync(process.platform==="win32"?"npm.cmd":"npm",["install","--production"],{cwd:P,stdio:"inherit",shell:process.platform==="win32"});`,
         `console.log("- [x] Installed production dependencies");`,

--- a/start.mjs
+++ b/start.mjs
@@ -174,7 +174,7 @@ if (cacheMatch) {
 // truth) so users who fix themselves via `npm install -g context-mode`
 // follow the exact same code path. Best-effort, never blocks MCP boot.
 try {
-  const { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, healMcpJsonArgs } =
+  const { healInstalledPlugins, healSettingsEnabledPlugins, healPluginJsonMcpServers, sweepStaleMcpJson } =
     await import("./scripts/heal-installed-plugins.mjs");
   const pluginKey = "context-mode@context-mode";
   const claudeConfigDir = resolveClaudeConfigDir();
@@ -193,12 +193,6 @@ try {
   // path baked in. Iterates EVERY installed cache entry's installPath so
   // multi-version installs all self-recover. Each call is independently wrapped
   // because one poisoned entry must not block heals on the others. Best effort.
-  //
-  // v1.0.122 — Layer 5b extended (Issue #531): asymmetric-heal sibling for the
-  // `.mcp.json` file Claude Code reads at plugin load. Same per-entry loop, same
-  // defensive wrap. Covers both the #253/aea633c bare `./start.mjs` fresh-install
-  // regression AND the /ctx-upgrade tmpdir leak class. Both heals must run on
-  // every boot so users self-recover regardless of which drift shape hit them.
   try {
     if (existsSync(registryPath)) {
       const ip = JSON.parse(readFileSync(registryPath, "utf-8"));
@@ -214,16 +208,19 @@ try {
               pluginKey,
             });
           } catch { /* best effort — per-entry */ }
-          try {
-            healMcpJsonArgs({
-              pluginRoot: installPath,
-              pluginCacheRoot,
-              pluginKey,
-            });
-          } catch { /* best effort — per-entry */ }
         }
       }
     }
+  } catch { /* best effort */ }
+  // Issue #609 — Layer 5c (replaces v1.0.122 healMcpJsonArgs per-entry loop):
+  // sweep stale `.mcp.json` files from every per-version cache dir. cli.ts
+  // no longer writes `.mcp.json` (PR fix for #609), so the only `.mcp.json`
+  // files in the cache are stale carry-forwards from earlier installs or
+  // Claude Code's plugin manager copying them between version dirs. Removing
+  // them blocks the previous-version-carry replay vector at MCP boot.
+  // One sweep per boot — bounded, idempotent, best-effort.
+  try {
+    sweepStaleMcpJson({ pluginCacheRoot, pluginKey });
   } catch { /* best effort */ }
 } catch { /* best effort — never block MCP boot */ }
 

--- a/tests/adapters/jetbrains-copilot.test.ts
+++ b/tests/adapters/jetbrains-copilot.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { homedir } from "node:os";
 import { resolve, join } from "node:path";
 import { JetBrainsCopilotAdapter } from "../../src/adapters/jetbrains-copilot/index.js";
+import { HOOK_TYPES, HOOK_SCRIPTS, buildHookCommand } from "../../src/adapters/jetbrains-copilot/hooks.js";
 import { hashProjectDirCanonical, resolveSessionDbPath } from "../../src/session/db.js";
 
 describe("JetBrainsCopilotAdapter", () => {
@@ -228,6 +229,56 @@ describe("JetBrainsCopilotAdapter", () => {
         sessionId: "jb-sess-123",
       });
       expect(event.sessionId).toBe("jb-sess-123");
+    });
+  });
+
+  // ── buildHookCommand portability — Tier C lock (Issue #613) ────
+  //
+  // JetBrains Copilot hook config lives at `.github/hooks/context-mode.json`
+  // — same workspace-committed (team-shared) tier as VS Code Copilot.
+  // See `tests/adapters/vscode-copilot.test.ts` for the full archaeology;
+  // this suite is the JetBrains-side enforcement of the same Tier C
+  // contract.
+
+  describe("buildHookCommand portability (Issue #613 Tier C lock)", () => {
+    it("emits CLI dispatcher form when no pluginRoot is passed", () => {
+      const cmd = buildHookCommand(HOOK_TYPES.PRE_TOOL_USE);
+      expect(cmd).toBe("context-mode hook jetbrains-copilot pretooluse");
+    });
+
+    it("emits CLI dispatcher form EVEN WHEN pluginRoot is passed (Tier C — workspace-committed)", () => {
+      const fakeAbsRoot = "/Users/test/AppData/Local/fnm_multishells/12345_67890/node_modules/context-mode";
+      const cmd = buildHookCommand(HOOK_TYPES.PRE_TOOL_USE, fakeAbsRoot);
+      expect(cmd).toBe("context-mode hook jetbrains-copilot pretooluse");
+      expect(cmd).not.toContain("/Users/");
+      expect(cmd).not.toContain("fnm_multishells");
+      expect(cmd).not.toContain("node.exe");
+      expect(cmd).not.toContain(process.execPath);
+      expect(cmd).not.toContain(fakeAbsRoot);
+    });
+
+    it("emits portable form for every hook type that has a script", () => {
+      // JetBrains declares Stop/SubagentStart/SubagentStop in HOOK_TYPES but
+      // has no matching HOOK_SCRIPTS entries (orphan declarations until
+      // their script set lands). Only test hook types with scripts.
+      for (const hookType of Object.keys(HOOK_SCRIPTS)) {
+        const cmd = buildHookCommand(hookType as keyof typeof HOOK_SCRIPTS, "/any/abs/path");
+        expect(cmd.startsWith("context-mode hook jetbrains-copilot ")).toBe(true);
+        expect(cmd).not.toContain("/any/abs/path");
+      }
+    });
+
+    it("configureAllHooks writes only portable commands into .github/hooks/context-mode.json", () => {
+      const reg = adapter.generateHookConfig("/any/abs/plugin/root");
+      for (const entries of Object.values(reg)) {
+        for (const entry of entries) {
+          for (const hook of entry.hooks) {
+            expect(hook.command).toMatch(/^context-mode hook jetbrains-copilot /);
+            expect(hook.command).not.toContain("/any/abs/plugin/root");
+            expect(hook.command).not.toContain(process.execPath);
+          }
+        }
+      }
     });
   });
 });

--- a/tests/adapters/vscode-copilot.test.ts
+++ b/tests/adapters/vscode-copilot.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { VSCodeCopilotAdapter } from "../../src/adapters/vscode-copilot/index.js";
-import { HOOK_TYPES, HOOK_SCRIPTS } from "../../src/adapters/vscode-copilot/hooks.js";
+import { HOOK_TYPES, HOOK_SCRIPTS, buildHookCommand } from "../../src/adapters/vscode-copilot/hooks.js";
 
 describe("VSCodeCopilotAdapter", () => {
   let adapter: VSCodeCopilotAdapter;
@@ -176,6 +176,77 @@ describe("VSCodeCopilotAdapter", () => {
       const sessionDir = adapter.getSessionDir();
       expect(sessionDir).toContain("context-mode");
       expect(sessionDir).toContain("sessions");
+    });
+  });
+
+  // ── buildHookCommand portability — Tier C lock (Issue #613) ────
+  //
+  // VS Code Copilot hook config lives at `.github/hooks/context-mode.json`
+  // — a WORKSPACE-COMMITTED file (upstream:
+  // refs/platforms/vscode-copilot/assets/prompts/skills/agent-customization/references/hooks.md
+  // line 7: "Workspace (team-shared)"). Embedding absolute Windows
+  // `fnm_multishells/<PID>_<TS>/node.exe` paths into a file that lands in
+  // every teammate's `git status` is a categorically-unacceptable PII leak
+  // AND a non-portable cross-machine config.
+  //
+  // The pre-`f5c9d02` shape was correct: emit the CLI dispatcher form
+  // `context-mode hook vscode-copilot <event>` regardless of pluginRoot.
+  // Commit `f5c9d02` (2026-03-06) added an absolute-path branch when
+  // `pluginRoot` is passed; the CLI always passes pluginRoot, so the
+  // dispatcher form became unreachable in production.
+  //
+  // Fix: drop the pluginRoot branch entirely. The CLI dispatcher form
+  // works for every install pattern that has a `bin` entry on PATH
+  // (npm-global, brew, asdf, nvm, volta, fnm — all wire `npm install -g`
+  // through the `bin` field). For users without global install, the
+  // workaround is `npm install -g context-mode` — same as every other
+  // adapter that emits CLI-dispatcher commands (cursor, codex).
+
+  describe("buildHookCommand portability (Issue #613 Tier C lock)", () => {
+    it("emits CLI dispatcher form when no pluginRoot is passed", () => {
+      const cmd = buildHookCommand(HOOK_TYPES.PRE_TOOL_USE);
+      expect(cmd).toBe("context-mode hook vscode-copilot pretooluse");
+    });
+
+    it("emits CLI dispatcher form EVEN WHEN pluginRoot is passed (Tier C — workspace-committed)", () => {
+      // The reporter's bug: configureAllHooks passes pluginRoot which used to
+      // trigger the absolute-path branch and bake fnm_multishells paths into
+      // .github/hooks/context-mode.json. The fix: pluginRoot is ignored for
+      // emit purposes. Every commit'd hook command MUST be portable.
+      const fakeAbsRoot = "/Users/test/AppData/Local/fnm_multishells/12345_67890/node_modules/context-mode";
+      const cmd = buildHookCommand(HOOK_TYPES.PRE_TOOL_USE, fakeAbsRoot);
+      expect(cmd).toBe("context-mode hook vscode-copilot pretooluse");
+      // Belt-and-braces — explicit anti-patterns the Tier C lock forbids.
+      expect(cmd).not.toContain("/Users/");
+      expect(cmd).not.toContain("fnm_multishells");
+      expect(cmd).not.toContain("node.exe");
+      expect(cmd).not.toContain(process.execPath);
+      expect(cmd).not.toContain(fakeAbsRoot);
+    });
+
+    it("emits portable form for every hook type", () => {
+      for (const hookType of Object.values(HOOK_TYPES)) {
+        const cmd = buildHookCommand(hookType, "/any/abs/path");
+        expect(cmd.startsWith("context-mode hook vscode-copilot ")).toBe(true);
+        expect(cmd).not.toContain("/any/abs/path");
+      }
+    });
+
+    it("configureAllHooks writes only portable commands into .github/hooks/context-mode.json", () => {
+      // End-to-end check: walk the generated hook registration and assert
+      // every command is the CLI dispatcher form. Prevents the regression
+      // that the configureAllHooks path's wiring of buildHookCommand was
+      // the actual #613 surface.
+      const reg = adapter.generateHookConfig("/any/abs/plugin/root");
+      for (const entries of Object.values(reg)) {
+        for (const entry of entries) {
+          for (const hook of entry.hooks) {
+            expect(hook.command).toMatch(/^context-mode hook vscode-copilot /);
+            expect(hook.command).not.toContain("/any/abs/plugin/root");
+            expect(hook.command).not.toContain(process.execPath);
+          }
+        }
+      }
     });
   });
 

--- a/tests/cli/upgrade-mcp-json-assertion.test.ts
+++ b/tests/cli/upgrade-mcp-json-assertion.test.ts
@@ -1,20 +1,32 @@
 /**
- * Issue #531 — cli.ts upgrade() MUST guarantee `.mcp.json`'s
- * mcpServers["context-mode"].args[0] is the literal ${CLAUDE_PLUGIN_ROOT}
- * placeholder before declaring upgrade success.
+ * Issue #609 — cli.ts upgrade() MUST sweep stale `.mcp.json` files from
+ * every per-version plugin-cache dir before declaring upgrade success.
  *
- * Asymmetric-heal sibling of upgrade-plugin-json-assertion.test.ts (#523).
- * Same static-analysis pattern: read src/cli.ts, slice the upgrade()
- * function body, assert the post-bump block contains the right code shape.
+ * History:
+ *   v1.0.122 (Issue #531) — this file previously locked in the assertion
+ *   that `healMcpJsonArgs` runs post-bump to heal any per-version
+ *   `.mcp.json` carrying a poisoned arg. cli.ts itself wrote `.mcp.json`
+ *   at upgrade time (#411 fix), so the heal was the right shape then.
  *
- * The bug being prevented:
- *   cli.ts upgrade() already writes `.mcp.json` with the placeholder (#411
- *   fix at line ~829-845). But upgrade() never asserted the on-disk shape
- *   afterwards. If a future regression dropped the placeholder write —
- *   or if a parallel hook normalized the file with an absolute tmpdir
- *   path — upgrade() would declare success on a poisoned tree. This
- *   slice locks in the post-bump assertion using the same belt-and-
- *   braces double-call pattern as #523's plugin.json assertion.
+ *   Issue #609 superseded that approach. The architectural fix is to
+ *   STOP writing `.mcp.json` from cli.ts entirely — Claude Code reads
+ *   `.claude-plugin/plugin.json.mcpServers` as the canonical source
+ *   (refs/platforms/claude-code/src/utils/plugins/mcpPluginIntegration.ts:131-212).
+ *   With the write gone, the residual `.mcp.json` files in the cache are
+ *   stale carry-forwards from prior installs / Claude Code's auto-update.
+ *   `sweepStaleMcpJson` removes them so the carry-forward vector cannot
+ *   replay.
+ *
+ * Two contracts this file enforces:
+ *   1. `sweepStaleMcpJson` is invoked AFTER `updatePluginRegistry` from the
+ *      shared `scripts/heal-installed-plugins.mjs` module.
+ *   2. Belt-and-braces: second sweep pass MUST report `removed:[]` or
+ *      upgrade() throws — same shape as plugin.json drift check (#523).
+ *
+ * The legacy `healMcpJsonArgs` assertion is intentionally replaced (not
+ * just appended) — that function still exists for backwards-compat / boot-
+ * time recovery, but cli.ts no longer needs to invoke it because there is
+ * no `.mcp.json` to heal.
  */
 
 import { describe, expect, test } from "vitest";
@@ -29,43 +41,41 @@ const cliSrc = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
 const upgradeIdx = cliSrc.indexOf("async function upgrade");
 const upgradeBody = cliSrc.slice(upgradeIdx, upgradeIdx + 16000);
 
-describe("cli.ts upgrade() — Issue #531 .mcp.json placeholder assertion", () => {
-  test("post-bump block invokes healMcpJsonArgs from the shared module", () => {
+describe("cli.ts upgrade() — Issue #609 .mcp.json sweep assertion", () => {
+  test("post-bump block invokes sweepStaleMcpJson from the shared module", () => {
     // Must run AFTER updatePluginRegistry so the on-disk shape is final.
     const updateIdx = upgradeBody.indexOf("updatePluginRegistry");
-    const healCallIdx = upgradeBody.indexOf("healMcpJsonArgs");
+    const sweepCallIdx = upgradeBody.indexOf("sweepStaleMcpJson");
     expect(updateIdx).toBeGreaterThan(-1);
-    expect(healCallIdx).toBeGreaterThan(updateIdx);
+    expect(sweepCallIdx).toBeGreaterThan(updateIdx);
   });
 
-  test("imports healMcpJsonArgs from scripts/heal-installed-plugins.mjs", () => {
+  test("imports sweepStaleMcpJson from scripts/heal-installed-plugins.mjs", () => {
     expect(cliSrc).toMatch(
       /from\s+["']\.\.\/scripts\/heal-installed-plugins\.mjs["']/,
     );
-    expect(cliSrc).toContain("healMcpJsonArgs");
+    expect(cliSrc).toContain("sweepStaleMcpJson");
   });
 
-  test("upgrade() throws on drift — refuses to declare success when .mcp.json args[0] is poisoned", () => {
+  test("upgrade() throws on sweep drift — second pass MUST report removed:[]", () => {
     // Belt-and-braces contract (mirrors #523's plugin.json assertion):
-    //   1. First healMcpJsonArgs pass cleans any drift.
-    //   2. Second healMcpJsonArgs pass MUST return healed:[] or upgrade()
-    //      throws with a "drift" error.
-    const healCallIdx = upgradeBody.indexOf("healMcpJsonArgs");
-    expect(healCallIdx).toBeGreaterThan(-1);
-    const block = upgradeBody.slice(healCallIdx, healCallIdx + 1500);
-    expect(block).toMatch(/\.mcp\.json.*drift|drift.*\.mcp\.json|mcp\.json drift/i);
+    //   1. First sweep pass removes any pre-existing `.mcp.json`.
+    //   2. Second sweep MUST report removed:[] or upgrade() throws.
+    const sweepCallIdx = upgradeBody.indexOf("sweepStaleMcpJson");
+    expect(sweepCallIdx).toBeGreaterThan(-1);
+    const block = upgradeBody.slice(sweepCallIdx, sweepCallIdx + 1500);
+    expect(block).toMatch(/sweep drift|sweep check failed|still present/i);
     expect(block).toMatch(/throw new Error/);
   });
 
-  test("Layer 6 heal call passes pluginRoot, pluginCacheRoot, pluginKey", () => {
-    const healCallIdx = upgradeBody.indexOf("healMcpJsonArgs");
+  test("sweep call passes pluginCacheRoot, pluginKey (no per-version pluginRoot)", () => {
+    const sweepCallIdx = upgradeBody.indexOf("sweepStaleMcpJson");
     // Widen the window 400 chars BEFORE the call to capture the local
-    // pluginCacheRoot binding, plus 800 after to cover both heal-pass calls.
+    // pluginCacheRoot binding, plus 800 after to cover both sweep-pass calls.
     const block = upgradeBody.slice(
-      Math.max(0, healCallIdx - 400),
-      healCallIdx + 800,
+      Math.max(0, sweepCallIdx - 400),
+      sweepCallIdx + 800,
     );
-    expect(block).toContain("pluginRoot");
     expect(block).toContain("pluginCacheRoot");
     expect(block).toContain("pluginKey");
     // pluginCacheRoot must derive from resolveClaudeConfigDir() so we don't

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -142,41 +142,60 @@ describe("cli.bundle.mjs — marketplace install support", () => {
 // ── .mcp.json — MCP server config ────────────────────────────────────
 
 describe(".mcp.json — MCP server config", () => {
-  it("upgrade writes cached .mcp.json with CLAUDE_PLUGIN_ROOT placeholder (#411)", () => {
+  it("upgrade MUST NOT write `.mcp.json` into the plugin cache dir (Issue #609 architectural lock)", () => {
+    // Bug-class history this lock protects:
+    //   #411 introduced a `.mcp.json` write here with a CLAUDE_PLUGIN_ROOT
+    //   placeholder. That solved an absolute-path-bake symptom but kept the
+    //   write itself in place. Every /ctx-upgrade since then re-baked a
+    //   per-version .mcp.json. When Claude Code's native plugin auto-update
+    //   later copies the previous version's .mcp.json forward into the new
+    //   cache dir, the path goes stale → MODULE_NOT_FOUND on every MCP boot,
+    //   while ctx-doctor stays green (#609).
+    //
+    // Architectural fix: STOP writing `.mcp.json` from cli.ts entirely. The
+    // canonical MCP source is `.claude-plugin/plugin.json.mcpServers`
+    // (Claude Code upstream: mcpPluginIntegration.ts:131-212 reads it first).
+    // The post-bump `sweepStaleMcpJson` call removes any pre-existing files
+    // so the carry-forward vector cannot replay.
+    //
+    // This test enforces the architectural decision. Re-introducing the write
+    // would re-open the bug class regardless of which path shape is used
+    // (placeholder OR absolute) — the write itself is the surface area.
     const src = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
     const upgradeStart = src.indexOf("async function upgrade");
     const upgradeSrc = src.slice(upgradeStart);
-    // items array must NOT include .mcp.json (it's written dynamically)
+    // The items[] copy list must still NOT include .mcp.json (kept from #531).
     const itemsMatch = upgradeSrc.match(/const items\s*=\s*\[([\s\S]*?)\];/);
     expect(itemsMatch).not.toBeNull();
     expect(itemsMatch![1]).not.toContain(".mcp.json");
-    // Must write .mcp.json dynamically with placeholder, not absolute path.
-    // Absolute paths break when sessionstart.mjs (#181) deletes old version dirs.
-    expect(upgradeSrc).toContain('resolve(pluginRoot, ".mcp.json")');
-    expect(upgradeSrc).not.toContain('resolve(pluginRoot, "start.mjs")');
-    expect(upgradeSrc).toContain("${CLAUDE_PLUGIN_ROOT}/start.mjs");
+    // cli.ts upgrade() MUST NOT write `.mcp.json` to pluginRoot. Any
+    // resolve(pluginRoot, ".mcp.json") + writeFileSync chain is forbidden.
+    expect(upgradeSrc).not.toMatch(/writeFileSync\(\s*resolve\(\s*pluginRoot\s*,\s*["']\.mcp\.json["']/);
   });
 
-  it("upgrade .mcp.json placeholder is resilient to version cleanup (#411)", () => {
-    // Simulate two upgrade runs into different pluginRoot dirs and assert both
-    // produce identical placeholder-based args (no absolute paths to old dirs).
+  it("upgrade MUST sweep stale .mcp.json files post-bump (Issue #609)", () => {
+    // Belt-and-braces partner to the no-write lock above: cli.ts MUST call
+    // `sweepStaleMcpJson` after `updatePluginRegistry` so any pre-existing
+    // copies left by prior versions (or carried forward by Claude Code's
+    // auto-update) are removed before the upgrade is declared successful.
     const src = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
+    // Import from the shared heal module — single source of truth.
+    expect(src).toMatch(
+      /sweepStaleMcpJson[^;]*from\s+["']\.\.\/scripts\/heal-installed-plugins\.mjs["']/,
+    );
     const upgradeStart = src.indexOf("async function upgrade");
-    const upgradeSrc = src.slice(upgradeStart);
-    // Extract the literal mcpConfig args entry — must be a string literal
-    // with ${CLAUDE_PLUGIN_ROOT}, not a runtime resolve(pluginRoot, ...) call.
-    const argsMatch = upgradeSrc.match(/args:\s*\[([^\]]+)\]/);
-    expect(argsMatch).not.toBeNull();
-    const argsContent = argsMatch![1];
-    // Must NOT depend on pluginRoot at write-time
-    expect(argsContent).not.toContain("pluginRoot");
-    expect(argsContent).not.toContain("resolve(");
-    // Must contain the literal placeholder
-    expect(argsContent).toContain("${CLAUDE_PLUGIN_ROOT}/start.mjs");
-    // Two simulated runs would produce identical JSON regardless of pluginRoot
-    // because the args value is a static string literal.
-    const literalCount = (upgradeSrc.match(/\$\{CLAUDE_PLUGIN_ROOT\}\/start\.mjs/g) || []).length;
-    expect(literalCount).toBeGreaterThanOrEqual(1);
+    const upgradeSrc = src.slice(upgradeStart, upgradeStart + 16000);
+    // Order constraint: sweep runs AFTER updatePluginRegistry so the
+    // cleanup operates against the final on-disk shape.
+    const updateIdx = upgradeSrc.indexOf("updatePluginRegistry");
+    const sweepIdx = upgradeSrc.indexOf("sweepStaleMcpJson");
+    expect(updateIdx).toBeGreaterThan(-1);
+    expect(sweepIdx).toBeGreaterThan(updateIdx);
+    // Belt-and-braces second-call assertion: if first sweep removed files,
+    // a second pass MUST report removed:[] or upgrade() throws.
+    const block = upgradeSrc.slice(sweepIdx, sweepIdx + 1500);
+    expect(block).toMatch(/sweep drift|sweep check failed/i);
+    expect(block).toMatch(/throw new Error/);
   });
 
   it("plugin manifest keeps ${CLAUDE_PLUGIN_ROOT} for marketplace compatibility", () => {
@@ -204,10 +223,10 @@ describe(".mcp.json — MCP server config", () => {
   it(".mcp.json.example template MUST use ${CLAUDE_PLUGIN_ROOT} placeholder (closes #531)", () => {
     // Architectural lock-in after PR #253 (aea633c) regression:
     // .mcp.json is no longer tracked in source. The canonical template lives
-    // at .mcp.json.example and MUST use the placeholder so that any
-    // contributor or tool that copies it gets the marketplace-correct form.
-    // The placeholder form is what cli.ts upgrade() writes to the plugin
-    // cache (line 843) and what .claude-plugin/plugin.json mcpServers uses.
+    // at .mcp.json.example so contributors who copy it locally still get
+    // the marketplace-correct placeholder form. End-user MCP launch flows
+    // through `.claude-plugin/plugin.json.mcpServers` only — cli.ts no longer
+    // writes `.mcp.json` into the plugin cache (Issue #609 fix).
     const example = JSON.parse(
       readFileSync(resolve(ROOT, ".mcp.json.example"), "utf-8"),
     );
@@ -222,7 +241,7 @@ describe(".mcp.json — MCP server config", () => {
     // the relative form (correct for contributors opening the repo as a
     // regular project). Stop shipping it in the tarball so the two roles
     // never collide again. End users get MCP via .claude-plugin/plugin.json
-    // and cli.ts upgrade()'s plugin-cache write — both placeholder.
+    // — cli.ts no longer writes `.mcp.json` to the plugin cache (#609).
     const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8"));
     expect(pkg.files).toBeDefined();
     expect(pkg.files).not.toContain(".mcp.json");
@@ -1580,8 +1599,11 @@ describe("Shell-free upgrade (#185)", () => {
     expect(inlineSection).toContain("pkg.files");
     expect(inlineSection).toContain("Array.isArray(pkg.files)");
     expect(inlineSection).toContain("for(const item of items)");
-    expect(inlineSection).toContain('writeFileSync(join(P,".mcp.json")');
-    expect(inlineSection).toContain("\\${CLAUDE_PLUGIN_ROOT}/start.mjs");
+    // Issue #609: server.ts inline-fallback MUST NOT write `.mcp.json` either.
+    // Same architectural-lock as cli.ts upgrade(). The inline-fallback was the
+    // OTHER producer of per-version `.mcp.json` files — both writers had to go
+    // for the carry-forward bug class to be structurally impossible.
+    expect(inlineSection).not.toContain('writeFileSync(join(P,".mcp.json")');
     expect(inlineSection).not.toContain("copyDirs");
     expect(inlineSection).not.toContain("copyFiles");
   });

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -2132,3 +2132,121 @@ describe("Upgrade native ABI bootstrap", () => {
     expect(region).toContain("ABI cache present");
   });
 });
+
+// ── Issue #613/#609 — doctor() surfaces persistence-tier bug class ─────
+// PR #620 (Family A) shipped the architectural fixes:
+//   - #609: stop writing per-version cache `.mcp.json` + post-bump sweep
+//   - #613: vscode/jetbrains-copilot hook commands ship CLI-dispatcher form
+//           (no absolute `process.execPath` + script path baked into
+//           workspace-committed `.github/hooks/context-mode.json`)
+//
+// These two slices are the *prevention* surface — root-cause fixes that
+// stop the bug from being written. But users on the field can still be
+// holding pre-PR-620 poisoned state:
+//   - already-committed `.github/hooks/context-mode.json` in their repo
+//     with absolute Windows fnm shim paths from v1.0.136 or earlier
+//   - leftover `.mcp.json` in `~/.claude/plugins/cache/.../<version>/`
+//     from /ctx-upgrade flows that ran before PR #620
+//
+// Doctor's job per the verdict family ("silent-green doctor while hooks
+// are dead is itself a P0 trust bug" — ISSUE-604-VERDICT §11) is to
+// SURFACE that pre-PR state BEFORE the user hits a runtime failure.
+//
+// Architect contract for PR #620 + slice 4:
+//   CHECK A: doctor scans workspace Tier C files (`.github/hooks/context-mode.json`,
+//            `.cursor/hooks.json`, `.jetbrains/copilot/hooks.json` under
+//            process.cwd()) — for each that exists, parse JSON, recurse
+//            into all string values, FAIL if any matches absolute path
+//            patterns (unix `/`, Windows `[A-Z]:[/\\]`, `\\`, fnm_multishells).
+//            Remediation: "run `ctx_upgrade` to rewrite to portable form".
+//            Missing config → SKIP (no false fail).
+//
+//   CHECK B: doctor scans `~/.claude/plugins/cache/context-mode/context-mode/*/`
+//            for `.mcp.json` files (post-PR-620 these should not exist).
+//            Found → WARN (not fail) with remediation:
+//            "ctx_upgrade will sweep on next run".
+//
+// Same static-analysis assertion pattern as Issue #564 doctor test (above)
+// and lines 962, 997, 1010 — runtime spawning would need fixture
+// workspaces on three OSes and is not portable; asserting the gate
+// exists in doctor() source catches the regression at PR time.
+describe("PR #620 slice 4 — doctor() surfaces persistence-tier bug class", () => {
+  const CLI_SRC = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
+
+  function doctorBody(): string {
+    const start = CLI_SRC.indexOf("async function doctor(");
+    expect(start).toBeGreaterThan(-1);
+    const end = CLI_SRC.indexOf("async function insight", start);
+    expect(end).toBeGreaterThan(start);
+    return CLI_SRC.slice(start, end);
+  }
+
+  it("doctor scans workspace Tier C config files for absolute paths (#613 proactive)", () => {
+    const body = doctorBody();
+    // Must reference all three Tier C path shapes that PR #620 covers
+    // (vscode-copilot writes `.github/hooks/context-mode.json`,
+    //  cursor writes `.cursor/hooks.json`,
+    //  jetbrains-copilot writes `.jetbrains/copilot/hooks.json`
+    //  — workspace-committed per ISSUE-613-VERDICT §6.1 Tier C table).
+    expect(body).toContain(".github/hooks/context-mode.json");
+    expect(body).toContain(".cursor/hooks.json");
+    expect(body).toContain(".jetbrains/copilot/hooks.json");
+    // Must detect the fnm-shim pattern (reporter's stderr literally shows
+    // `fnm_multishells/<pid>_<ts>/node.exe` per ISSUE-613-VERDICT §2 H2).
+    expect(body).toMatch(/fnm_multishells/);
+    // Must surface the failure with remediation pointing at ctx_upgrade.
+    // The Tier C section is identifiable by the issue anchor `#613`.
+    const anchorIdx = body.indexOf("#613");
+    expect(anchorIdx).toBeGreaterThan(-1);
+    const window_ = body.slice(
+      Math.max(0, anchorIdx - 500),
+      anchorIdx + 3000,
+    );
+    // The check must use p.log.error or p.log.warn (not info) AND
+    // mention ctx_upgrade so the user knows the remediation.
+    expect(window_).toMatch(/p\.log\.(error|warn)/);
+    expect(window_).toMatch(/ctx[_-]?upgrade/i);
+  });
+
+  it("doctor warns on stale `.mcp.json` files in cache version dirs (#609 proactive)", () => {
+    const body = doctorBody();
+    // Must reference the cache plugin path shape that PR #620 sweeps.
+    // The path nests `context-mode/context-mode` (marketplace/plugin
+    // nesting per ISSUE-609-VERDICT path examples). cli.ts uses
+    // path.join() so the literal appears as adjacent string args:
+    //   join(homedir(), ".claude", "plugins", "cache",
+    //        "context-mode", "context-mode")
+    // We assert on both the cache anchor segments AND the join args
+    // (Mert standing rule — use platform-neutral path joins, not literal
+    // separators that fail on Windows).
+    expect(body).toMatch(/"plugins"\s*,\s*"cache"/);
+    expect(body).toMatch(/"context-mode"\s*,\s*"context-mode"/);
+    // Must check for `.mcp.json` (the file that should not exist after
+    // PR #620's architectural untrack — ISSUE-609-VERDICT §H1 → PR #618 → #620).
+    const anchorIdx = body.indexOf("#609");
+    expect(anchorIdx).toBeGreaterThan(-1);
+    const window_ = body.slice(
+      Math.max(0, anchorIdx - 500),
+      anchorIdx + 2500,
+    );
+    expect(window_).toContain(".mcp.json");
+    // WARN (not FAIL) — the verdict spec is explicit that this is
+    // recoverable: "ctx_upgrade will sweep on next run".
+    expect(window_).toMatch(/p\.log\.warn/);
+    expect(window_).toMatch(/ctx[_-]?upgrade/i);
+  });
+
+  it("doctor uses homedir() (cross-platform) not literal '~' for cache scan", () => {
+    const body = doctorBody();
+    // Mert standing rule: Windows safety. Cache path must resolve via
+    // os.homedir() — not a literal `~/` prefix which fails on Windows.
+    const anchorIdx = body.indexOf("#609");
+    expect(anchorIdx).toBeGreaterThan(-1);
+    const window_ = body.slice(anchorIdx, anchorIdx + 2500);
+    // The scan must use homedir() (already imported at the top of cli.ts).
+    expect(window_).toMatch(/homedir\(\)|process\.env\.HOME/);
+    // And must NOT use a literal `~/` path string (would be treated
+    // literally on Windows).
+    expect(window_).not.toMatch(/["']~\//);
+  });
+});

--- a/tests/hooks/cache-heal-self-heal.test.ts
+++ b/tests/hooks/cache-heal-self-heal.test.ts
@@ -48,6 +48,7 @@ import {
   buildHookCommand,
   selfHealCacheHealHook,
 } from "../../hooks/cache-heal-utils.mjs";
+import { sweepStaleMcpJson } from "../../scripts/heal-installed-plugins.mjs";
 
 // ─────────────────────────────────────────────────────────
 // Shared fixtures
@@ -517,5 +518,158 @@ describe("selfHealCacheHealHook", () => {
     expect(readFileSync(settingsPath, "utf-8")).toBe("{not json");
     // existsSync sanity — still there
     expect(existsSync(settingsPath)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────
+// Slice 4 — sweepStaleMcpJson: remove cache-baked `.mcp.json` files (#609)
+//
+// Background: cli.ts upgrade() wrote `.mcp.json` into every per-version
+// plugin-cache dir starting with #411. PR #531 (9261377) removed `.mcp.json`
+// from `package.json files[]` so the npm tarball no longer ships it, but
+// the cli-side write persisted — every `/ctx-upgrade` re-baked a new
+// per-version copy. When Claude Code's native plugin manager auto-update
+// later copies a previous version's `.mcp.json` forward into a fresh
+// version dir, the stale start.mjs absolute path goes with it.
+//
+// The architectural fix is "don't ship `.mcp.json` from the cache layer
+// at all" — `.claude-plugin/plugin.json.mcpServers` is already the canonical
+// MCP source. `sweepStaleMcpJson` removes any pre-existing `.mcp.json` from
+// every per-version cache directory so the previous-version-carry vector
+// can't replay across upgrades.
+// ─────────────────────────────────────────────────────────
+
+describe("sweepStaleMcpJson", () => {
+  function makeCacheLayout(): {
+    pluginCacheRoot: string;
+    pluginKey: string;
+    versionDirs: string[];
+  } {
+    const dir = makeTmp("ctx-sweep-");
+    // Match the real cache layout: <cacheRoot>/<owner>/<plugin>/<version>/
+    const pluginCacheRoot = join(dir, "cache");
+    const pluginKey = "context-mode@context-mode";
+    const ownerDir = join(pluginCacheRoot, "context-mode", "context-mode");
+    const versionDirs = ["1.0.135", "1.0.136", "1.0.137"].map((v) =>
+      join(ownerDir, v),
+    );
+    for (const vd of versionDirs) {
+      writeFileSync(
+        join(makeDir(vd), ".mcp.json"),
+        JSON.stringify({
+          mcpServers: {
+            "context-mode": {
+              command: "node",
+              args: ["${CLAUDE_PLUGIN_ROOT}/start.mjs"],
+            },
+          },
+        }),
+      );
+    }
+    return { pluginCacheRoot, pluginKey, versionDirs };
+  }
+
+  /** Make a dir + return it. */
+  function makeDir(p: string): string {
+    // mkdirSync via writeFileSync requires parent existence — use a small inline helper.
+    const { mkdirSync } = require("node:fs") as typeof import("node:fs");
+    mkdirSync(p, { recursive: true });
+    return p;
+  }
+
+  test("removes .mcp.json from every per-version cache dir", () => {
+    const { pluginCacheRoot, pluginKey, versionDirs } = makeCacheLayout();
+
+    for (const vd of versionDirs) {
+      expect(existsSync(join(vd, ".mcp.json"))).toBe(true);
+    }
+
+    const result = sweepStaleMcpJson({ pluginCacheRoot, pluginKey });
+
+    for (const vd of versionDirs) {
+      expect(existsSync(join(vd, ".mcp.json"))).toBe(false);
+    }
+    expect(Array.isArray(result.removed)).toBe(true);
+    expect(result.removed.length).toBe(versionDirs.length);
+    for (const removedPath of result.removed) {
+      expect(removedPath).toContain(".mcp.json");
+    }
+  });
+
+  test("no-op when no .mcp.json files exist in any version dir", () => {
+    const dir = makeTmp("ctx-sweep-empty-");
+    const pluginCacheRoot = join(dir, "cache");
+    const ownerDir = join(pluginCacheRoot, "context-mode", "context-mode");
+    makeDir(join(ownerDir, "1.0.137"));
+
+    const result = sweepStaleMcpJson({
+      pluginCacheRoot,
+      pluginKey: "context-mode@context-mode",
+    });
+
+    expect(result.removed).toEqual([]);
+  });
+
+  test("returns 'no-cache-root' when pluginCacheRoot does not exist", () => {
+    const dir = makeTmp("ctx-sweep-missing-");
+    const result = sweepStaleMcpJson({
+      pluginCacheRoot: join(dir, "absent"),
+      pluginKey: "context-mode@context-mode",
+    });
+    expect(result.removed).toEqual([]);
+    expect(result.skipped).toBe("no-cache-root");
+  });
+
+  test("path-traversal guard: refuses pluginKey that escapes cacheRoot", () => {
+    // pluginKey is split to derive owner + plugin segments. A malicious
+    // pluginKey shape (with .. segments) MUST not allow the sweep to walk
+    // outside `pluginCacheRoot`.
+    const { pluginCacheRoot } = makeCacheLayout();
+    const result = sweepStaleMcpJson({
+      pluginCacheRoot,
+      pluginKey: "../../etc@passwd",
+    });
+    expect(result.removed).toEqual([]);
+    // Either skipped with a guard reason OR safely no-op. The point is
+    // that no file outside pluginCacheRoot was touched and the call did
+    // not throw.
+    expect(result).toBeDefined();
+  });
+
+  test("never touches sibling files in the version dir", () => {
+    const { pluginCacheRoot, pluginKey, versionDirs } = makeCacheLayout();
+    // Drop a sibling file we MUST not touch.
+    for (const vd of versionDirs) {
+      writeFileSync(join(vd, "plugin-manifest.txt"), "DO NOT DELETE", "utf-8");
+    }
+
+    sweepStaleMcpJson({ pluginCacheRoot, pluginKey });
+
+    for (const vd of versionDirs) {
+      expect(existsSync(join(vd, "plugin-manifest.txt"))).toBe(true);
+      expect(readFileSync(join(vd, "plugin-manifest.txt"), "utf-8")).toBe(
+        "DO NOT DELETE",
+      );
+    }
+  });
+
+  test("survives a version dir whose `.mcp.json` cannot be removed (best-effort)", () => {
+    // The sweep MUST never throw — best-effort like the rest of the heal
+    // family. Construct a scenario where one removal will silently fail
+    // (target is missing between scan and remove); the others must still
+    // succeed.
+    const { pluginCacheRoot, pluginKey, versionDirs } = makeCacheLayout();
+    // Pre-delete one of the .mcp.json files between layout-build and sweep.
+    // The sweep will encounter "ENOENT on rm" mid-walk and must shrug.
+    const { unlinkSync } = require("node:fs") as typeof import("node:fs");
+    unlinkSync(join(versionDirs[0], ".mcp.json"));
+
+    expect(() =>
+      sweepStaleMcpJson({ pluginCacheRoot, pluginKey }),
+    ).not.toThrow();
+
+    // The remaining two SHOULD have been removed.
+    expect(existsSync(join(versionDirs[1], ".mcp.json"))).toBe(false);
+    expect(existsSync(join(versionDirs[2], ".mcp.json"))).toBe(false);
   });
 });

--- a/tests/scripts/asymmetric-drift-assert.test.ts
+++ b/tests/scripts/asymmetric-drift-assert.test.ts
@@ -152,6 +152,144 @@ describe("Issue #531 — asymmetric-drift invariant", () => {
       .toMatch(/assert-asymmetric-drift|asymmetric-drift/);
   });
 
+  // ── PR #620 slice 5 — Tier C portability invariant (#613) ─────────────
+  // PR #620 fixed the live regression in vscode-copilot + jetbrains-copilot
+  // (commit f5c9d02 had baked absolute process.execPath + script paths into
+  // workspace-committed `.github/hooks/context-mode.json` etc.). The fix was
+  // surgical at the adapter layer; nothing structural prevents a future
+  // contributor from accidentally re-introducing the same bug class in any
+  // of the 15 adapters under configs/.
+  //
+  // This invariant scans every committed config template under configs/**
+  // and asserts that no string value contains an absolute path, an fnm
+  // session shim, a `process.execPath` literal, or a tilde-prefixed
+  // home-dir path. Allowed shapes: bare commands ("context-mode", "node"),
+  // CLI dispatcher form ("context-mode hook <platform> <event>"),
+  // placeholders (${CLAUDE_PLUGIN_ROOT}), schema URLs.
+  //
+  // The persistence-tier rule (ISSUE-613-VERDICT §6.1):
+  //   Tier C (workspace-committed, cross-machine, multi-user) MUST be
+  //   born portable -- no heal seam exists for files that ship in users'
+  //   git history.
+  //
+  // This catches the bug class at PR-review time across the entire
+  // configs/ surface, not just the two adapters PR #620 fixed.
+  test("configs/** templates ship no absolute paths, fnm shims, or shell-expansion paths (#613 PR #620)", () => {
+    // Recursively enumerate every .json file under configs/.
+    const { readdirSync, statSync } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("node:fs") as typeof import("node:fs");
+    const { join } = require("node:path") as typeof import("node:path");
+
+    function walk(dir: string): string[] {
+      const out: string[] = [];
+      for (const entry of readdirSync(dir)) {
+        const p = join(dir, entry);
+        const s = statSync(p);
+        if (s.isDirectory()) out.push(...walk(p));
+        else if (entry.endsWith(".json")) out.push(p);
+      }
+      return out;
+    }
+
+    const files = walk(resolve(ROOT, "configs"));
+    // Sanity: configs/ should ship multiple adapter templates. If this is
+    // ever 0 the test silently passes -- guard against that.
+    expect(files.length, "configs/ should contain at least one .json template").toBeGreaterThan(0);
+
+    // Forbidden patterns -- each captures a different way the bug class
+    // re-surfaces in practice:
+    const forbidden: { name: string; re: RegExp }[] = [
+      // Unix absolute home directories (PII leak per ISSUE-613-VERDICT
+      // multi-hat §Security; also the #613 reporter symptom shape).
+      { name: "unix /Users absolute path", re: /^\/Users\// },
+      { name: "unix /home absolute path", re: /^\/home\// },
+      // Windows absolute paths (drive-letter + separator).
+      { name: "Windows drive-letter absolute", re: /^[A-Za-z]:[/\\]/ },
+      // UNC paths.
+      { name: "Windows UNC path", re: /^\\\\/ },
+      // fnm session-ephemeral shim -- the literal #613 reporter saw.
+      // Per fnm-rs docs this directory is per-shell-session per-PID
+      // ephemeral; baking it into any committable file is invalid.
+      { name: "fnm session shim", re: /fnm_multishells/ },
+      // process.execPath as a string literal: indicates the generator
+      // baked node's runtime binary path into the JSON (the f5c9d02
+      // anti-pattern PR #620 reverted in two adapters).
+      { name: "process.execPath literal", re: /process\.execPath/ },
+      // Tilde-prefixed paths: shells expand `~` but JSON consumers do
+      // not. A committed `~/...` value would resolve literally on
+      // every platform (and fail). Also a Windows-safety violation.
+      { name: "literal tilde path", re: /^~[/\\]/ },
+      // ${HOME} shell-expansion: same issue -- not JSON-portable, only
+      // the spawned shell expands it; cross-platform consumers don't.
+      { name: "${HOME} shell expansion", re: /\$\{?HOME\}?[/\\]/ },
+    ];
+
+    interface Offence {
+      file: string;
+      jsonPath: string;
+      value: string;
+      pattern: string;
+    }
+    const offences: Offence[] = [];
+
+    function recurse(node: unknown, file: string, path: string): void {
+      if (typeof node === "string") {
+        for (const f of forbidden) {
+          if (f.re.test(node)) {
+            offences.push({
+              file,
+              jsonPath: path || "$",
+              value: node.length > 120 ? node.slice(0, 117) + "..." : node,
+              pattern: f.name,
+            });
+          }
+        }
+      } else if (Array.isArray(node)) {
+        for (let i = 0; i < node.length; i++) recurse(node[i], file, `${path}[${i}]`);
+      } else if (node && typeof node === "object") {
+        for (const [k, v] of Object.entries(node)) {
+          recurse(v, file, `${path}.${k}`);
+        }
+      }
+    }
+
+    for (const abs of files) {
+      const rel = abs.slice(ROOT.length + 1).replace(/\\/g, "/");
+      const raw = readFileSync(abs, "utf-8");
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch (err) {
+        throw new Error(`configs/ template is not valid JSON: ${rel} -- ${(err as Error).message}`);
+      }
+      recurse(parsed, rel, "");
+    }
+
+    if (offences.length > 0) {
+      const lines = offences.map(
+        (o) => `  - ${o.file}:${o.jsonPath} = ${JSON.stringify(o.value)} [${o.pattern}]`,
+      );
+      throw new Error(
+        [
+          `${offences.length} Tier C portability violation(s) in configs/ (PR #620 / #613):`,
+          ...lines,
+          "",
+          "Workspace-committed config templates ship to every user's git tree.",
+          "Per ISSUE-613-VERDICT 6.1, Tier C files MUST be born portable -- no",
+          "heal seam exists for files committed to user repos. Allowed shapes:",
+          "  - CLI dispatcher: \"context-mode hook <platform> <event>\"",
+          "  - Bare command:   \"context-mode\" / \"node\"",
+          "  - Placeholder:    \"${CLAUDE_PLUGIN_ROOT}/...\"",
+          "  - Schema URL:     \"https://.../config.json\"",
+          "",
+          "Forbidden: absolute paths, fnm session shims, process.execPath literals,",
+          "literal `~/...` or `${HOME}/...` (not JSON-portable; Windows-unsafe).",
+        ].join("\n"),
+      );
+    }
+  });
+
   // ── Regression guard for the postinstall-heal scope bug ──────────────
   // CI run 25734987495 (Windows-latest) failed on `npm run build` because
   // scripts/postinstall.mjs section 4 called `normalizeHooksOnStartup`

--- a/tests/scripts/asymmetric-drift-assert.test.ts
+++ b/tests/scripts/asymmetric-drift-assert.test.ts
@@ -231,6 +231,10 @@ describe("Issue #531 — asymmetric-drift invariant", () => {
           "export function healSettingsEnabledPlugins() { return { healed: [] }; }",
           "export function healPluginJsonMcpServers() { return { healed: [] }; }",
           "export function healMcpJsonArgs() { return { healed: [] }; }",
+          // Issue #609 — sweepStaleMcpJson replaced per-entry healMcpJsonArgs.
+          // Stubbed alongside healMcpJsonArgs for backwards compatibility with
+          // any in-flight callers that still import it.
+          "export function sweepStaleMcpJson() { return { removed: [] }; }",
           "",
         ].join("\n"),
       );

--- a/tests/util/postinstall-heal-mcp-json.test.ts
+++ b/tests/util/postinstall-heal-mcp-json.test.ts
@@ -1,13 +1,22 @@
 /**
- * Issue #531 — scripts/postinstall.mjs MUST invoke healMcpJsonArgs alongside
- * healPluginJsonMcpServers for users broken by the #253 / aea633c regression
- * or by /ctx-upgrade tmpdir leak. Same escape-hatch posture as v1.0.119:
- * when MCP is dead (because .mcp.json is poisoned with `./start.mjs`), the
- * only way to recover is `npm install -g context-mode` whose postinstall
- * MUST run Layer 6.
+ * Issue #609 — scripts/postinstall.mjs MUST invoke sweepStaleMcpJson
+ * alongside healPluginJsonMcpServers so users broken by Claude Code's
+ * auto-update carry-forward (or by an earlier /ctx-upgrade tmpdir leak)
+ * self-recover when they run `npm install -g context-mode`.
  *
- * Static-analysis sibling of start-mjs-self-heal.test.ts's postinstall check
- * — fast, deterministic, no integration spawn.
+ * History:
+ *   v1.0.122 (#531) — postinstall ran `healMcpJsonArgs` per-entry to
+ *   patch poisoned `.mcp.json` args. cli.ts also wrote `.mcp.json` at
+ *   upgrade time then, so the heal was the right shape.
+ *
+ *   Issue #609 superseded that approach. cli.ts no longer writes `.mcp.json`
+ *   (Claude Code reads `.claude-plugin/plugin.json.mcpServers` as the
+ *   canonical source — upstream: mcpPluginIntegration.ts:131-212). The
+ *   residual `.mcp.json` files in the cache are stale carry-forwards.
+ *   Sweep them so the auto-update cannot replay them into a fresh dir.
+ *
+ * Static-analysis sibling of start-mjs-self-heal.test.ts — fast, deterministic,
+ * no integration spawn.
  */
 
 import { describe, expect, test } from "vitest";
@@ -19,39 +28,36 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..", "..");
 const postinstallSrc = readFileSync(resolve(ROOT, "scripts", "postinstall.mjs"), "utf-8");
 
-describe("scripts/postinstall.mjs — Issue #531 Layer 6 .mcp.json heal", () => {
-  test("imports healMcpJsonArgs from the shared module", () => {
-    expect(postinstallSrc).toContain("healMcpJsonArgs");
+describe("scripts/postinstall.mjs — Issue #609 sweep stale .mcp.json", () => {
+  test("imports sweepStaleMcpJson from the shared module", () => {
+    expect(postinstallSrc).toContain("sweepStaleMcpJson");
     expect(postinstallSrc).toMatch(/heal-installed-plugins\.mjs/);
   });
 
-  test("invokes healMcpJsonArgs alongside healPluginJsonMcpServers", () => {
-    // Both heals MUST run in the same per-entry loop. We anchor on the
-    // existing #523 heal block (already iterates entries.installPath) and
-    // assert the new heal also lives inside it.
+  test("invokes sweepStaleMcpJson alongside healPluginJsonMcpServers", () => {
+    // Both must run in the same install-time heal block. Anchor on the
+    // existing #523 heal call and assert the sweep also lives nearby.
     const heal523Idx = postinstallSrc.indexOf("healPluginJsonMcpServers");
     expect(heal523Idx).toBeGreaterThan(-1);
-    const heal531Idx = postinstallSrc.indexOf("healMcpJsonArgs");
-    expect(heal531Idx).toBeGreaterThan(-1);
-    // Distance between them should be modest — both live inside the same
-    // per-entry loop, not in some unrelated section.
-    expect(Math.abs(heal531Idx - heal523Idx)).toBeLessThan(2000);
+    const sweepIdx = postinstallSrc.indexOf("sweepStaleMcpJson");
+    expect(sweepIdx).toBeGreaterThan(-1);
+    // Distance between them should be modest — same block.
+    expect(Math.abs(sweepIdx - heal523Idx)).toBeLessThan(2000);
   });
 
-  test("Layer 6 heal call passes pluginRoot, pluginCacheRoot, pluginKey", () => {
+  test("sweep call passes pluginCacheRoot and pluginKey", () => {
     // Use lastIndexOf to anchor on the call site, not the import line.
-    const idx = postinstallSrc.lastIndexOf("healMcpJsonArgs");
+    const idx = postinstallSrc.lastIndexOf("sweepStaleMcpJson");
     const block = postinstallSrc.slice(idx, idx + 500);
-    expect(block).toContain("pluginRoot");
     expect(block).toContain("pluginCacheRoot");
     expect(block).toContain("pluginKey");
   });
 
-  test("Layer 6 heal is wrapped defensively (per-entry try/catch, never blocks install)", () => {
-    // Same posture as Layer 5b: per-call try/catch so one poisoned entry
-    // doesn't block heals on the others.
-    const idx = postinstallSrc.lastIndexOf("healMcpJsonArgs");
-    const block = postinstallSrc.slice(Math.max(0, idx - 200), idx + 500);
+  test("sweep is wrapped defensively (try/catch, never blocks install)", () => {
+    // Best-effort posture — a failed sweep MUST NOT abort the install.
+    const idx = postinstallSrc.lastIndexOf("sweepStaleMcpJson");
+    const block = postinstallSrc.slice(Math.max(0, idx - 400), idx + 500);
     expect(block).toMatch(/try\s*\{/);
+    expect(block).toMatch(/never block install|best effort/i);
   });
 });

--- a/tests/util/start-mjs-self-heal.test.ts
+++ b/tests/util/start-mjs-self-heal.test.ts
@@ -86,43 +86,53 @@ describe("start.mjs — Issue #523 Layer 5b plugin.json mcpServers heal", () => 
 });
 
 // ─────────────────────────────────────────────────────────────────────────
-// Issue #531 — start.mjs MUST also run healMcpJsonArgs alongside
-// healPluginJsonMcpServers. Same Layer 5b heal block, sibling file (.mcp.json
-// vs .claude-plugin/plugin.json). On every MCP boot, BOTH heals run so
-// users poisoned by fresh-marketplace-install (#253 / aea633c) OR by
-// /ctx-upgrade tmpdir leak self-recover the next time Claude Code spawns
-// the plugin. Without this, a user whose `.mcp.json` has `./start.mjs`
-// can never boot MCP — and start.mjs never runs — and the heal can't
-// fire. That's the "fresh marketplace install" class; the postinstall
-// path (slice 10) closes that gap. This slice closes the post-recovery
-// loop: once MCP boots from any source, every subsequent boot heals.
+// Issue #609 — start.mjs MUST run sweepStaleMcpJson alongside
+// healPluginJsonMcpServers so users broken by Claude Code's auto-update
+// carry-forward of a previous version's `.mcp.json` self-recover on the
+// next MCP boot.
+//
+// History:
+//   v1.0.122 (#531) — start.mjs ran `healMcpJsonArgs` per-installPath to
+//   heal poisoned `.mcp.json` args. cli.ts wrote `.mcp.json` at upgrade
+//   time then, so per-entry healing was the right shape.
+//
+//   Issue #609 superseded that. cli.ts no longer writes `.mcp.json`
+//   (canonical MCP source is `.claude-plugin/plugin.json.mcpServers` —
+//   upstream: mcpPluginIntegration.ts:131-212). Residual `.mcp.json`
+//   files in the cache are stale carry-forwards from prior installs.
+//   `sweepStaleMcpJson` removes them so the auto-update cannot replay
+//   them into a fresh version dir on the next /ctx-upgrade cycle.
 // ─────────────────────────────────────────────────────────────────────────
 
-describe("start.mjs — Issue #531 Layer 5b .mcp.json args heal", () => {
-  test("imports healMcpJsonArgs from the shared module", () => {
-    expect(startSrc).toContain("healMcpJsonArgs");
+describe("start.mjs — Issue #609 sweep stale .mcp.json", () => {
+  test("imports sweepStaleMcpJson from the shared module", () => {
+    expect(startSrc).toContain("sweepStaleMcpJson");
     expect(startSrc).toMatch(/heal-installed-plugins\.mjs/);
   });
 
-  test("Layer 5b heal call lives inside the existing HEAL 3+4 try-block", () => {
+  test("sweep call lives inside the existing HEAL 3+4 try-block", () => {
     // Co-located with healPluginJsonMcpServers — same dynamic-import + outer
-    // try/catch (never block MCP boot). Same per-entry loop.
+    // try/catch (never block MCP boot).
     const heal34Idx = startSrc.indexOf("HEAL 3");
     const layer4Idx = startSrc.indexOf("Self-heal Layer 4");
     expect(heal34Idx).toBeGreaterThan(-1);
     expect(layer4Idx).toBeGreaterThan(-1);
     const block = startSrc.slice(heal34Idx, layer4Idx);
-    expect(block).toContain("healMcpJsonArgs");
+    expect(block).toContain("sweepStaleMcpJson");
   });
 
-  test("Layer 5b heal iterates ALL cache entries — not just our own pluginRoot", () => {
-    // Same iterator pattern as healPluginJsonMcpServers. The .mcp.json heal
-    // MUST run per-installPath so multi-version installs all self-recover.
+  test("sweep is invoked once per boot with pluginCacheRoot + pluginKey", () => {
+    // The sweep operates against the cache root as a whole — not per-
+    // installPath. One call walks every version dir under <cacheRoot>/
+    // <owner>/<plugin>/ and removes any `.mcp.json`. This is cheaper than
+    // the previous per-entry healMcpJsonArgs loop and structurally cannot
+    // miss a version dir that's missing from the registry.
     const heal34Idx = startSrc.indexOf("HEAL 3");
     const layer4Idx = startSrc.indexOf("Self-heal Layer 4");
     const block = startSrc.slice(heal34Idx, layer4Idx);
-    expect(block).toContain("installPath");
-    expect(block).toContain("healMcpJsonArgs");
+    expect(block).toContain("sweepStaleMcpJson");
+    expect(block).toContain("pluginCacheRoot");
+    expect(block).toContain("pluginKey");
   });
 });
 


### PR DESCRIPTION
## Summary

Single unified PR for the **persistence-tier family**. Three issues, one architectural decision: classify every file by who reads / mutates it (plugin-cache vs. user-home vs. workspace-committed) and enforce the correct mutability contract per tier.

Closes #604
Closes #609
Closes #613

Open for community review — single PR for the family per EM directive. Verdict files driving this PR:
- [`ISSUE-604-VERDICT.md`](https://github.com/mksglu/context-mode/blob/main/.cw/ctx-analytics/ISSUE-604-VERDICT.md)
- [`ISSUE-609-VERDICT.md`](https://github.com/mksglu/context-mode/blob/main/.cw/ctx-analytics/ISSUE-609-VERDICT.md)
- [`ISSUE-613-VERDICT.md`](https://github.com/mksglu/context-mode/blob/main/.cw/ctx-analytics/ISSUE-613-VERDICT.md)

## Family map

```
Persistence-tier confusion (this PR's architectural decision)
│
├── Tier A — plugin-cache (volatile, healable)
│   └── #604  hooks.json normalizer ratchet → ALREADY FIXED on `next`
│             by merged PR #611 (commit 97792c5). This PR adds the
│             "Closes #604" keyword so merging finally closes the issue.
│
├── Tier B — user home (stable, healable on hook fire)
│   └── (claude-code, qwen-code, gemini-cli — KEEP absolute, healable)
│
└── Tier C — workspace-committed (cross-machine, multi-user — MUST be portable)
    ├── #609  cli.ts writes per-version .mcp.json → carry-forward vector
    │         that Claude Code auto-update replays into fresh cache dirs
    └── #613  vscode/jetbrains-copilot embeds process.execPath into
              committed .github/hooks/context-mode.json (fnm shim PII leak)
```

## Per-slice changes

### Slice 1 — Drop `.mcp.json` cache write + sweep stale copies (#609)

**Root cause** (per ISSUE-609-VERDICT §3 H1): `src/cli.ts:948-964` wrote a per-version `.mcp.json` with absolute paths on every `/ctx-upgrade`. When Claude Code's native plugin manager auto-update later copies a previous version's `.mcp.json` forward into a fresh cache dir, the stale `start.mjs` path ships with it → `MODULE_NOT_FOUND` on every MCP boot, while `ctx-doctor` stays green.

**Upstream verification**: `refs/platforms/claude-code/src/utils/plugins/mcpPluginIntegration.ts:131-212` confirms Claude Code reads `.claude-plugin/plugin.json.mcpServers` first — `.mcp.json` is redundant.

**Fix**:
- `src/cli.ts`: delete the `.mcp.json` write block; replace post-bump `healMcpJsonArgs` drift-check with `sweepStaleMcpJson` belt-and-braces (first-pass cleans; second pass MUST report `removed:[]` or throw).
- `src/server.ts`: delete the same write in the inline-fallback upgrade path.
- `scripts/heal-installed-plugins.mjs`: new `sweepStaleMcpJson({ pluginCacheRoot, pluginKey })` walks `<cacheRoot>/<owner>/<plugin>/<version>/.mcp.json` and removes each one. Path-traversal guard refuses pluginKeys with `..` segments. Best-effort — never throws.
- `start.mjs`, `scripts/postinstall.mjs`: wired into the existing HEAL 3+4 block.

### Slice 2 — `hooks.json` bidirectional ratchet (#604)

**Already fixed on `next`** via merged PR #611 (commit `97792c5`, 2026-05-18). Reporter @jowch's verbatim test landed in `tests/hooks/windows-hooks-normalization.test.ts`. This PR just adds the "Closes #604" keyword so merging finally closes the issue.

### Slice 3 — Portable Tier C `buildHookCommand` (#613)

**Root cause** (per ISSUE-613-VERDICT §1): commit `f5c9d02` (2026-03-06) added an absolute-path branch to `buildHookCommand` when `pluginRoot` is passed. The CLI always passes `pluginRoot`, so the portable CLI-dispatcher form became unreachable in production. Every `/ctx-upgrade` since then baked an absolute `process.execPath` + pluginRoot path into `.github/hooks/context-mode.json` — a **workspace-committed** file.

**Upstream verification**: `refs/platforms/vscode-copilot/assets/prompts/skills/agent-customization/references/hooks.md` line 7 confirms `.github/hooks/*.json` is "Workspace (team-shared)". Under fnm-windows, `process.execPath` is `fnm_multishells/<PID>_<TS>/node.exe` — a per-shell-session ephemeral shim. Committing that path leaks PII (`C:/Users/<user>/...`) AND breaks cross-machine portability.

**Fix**:
- `src/adapters/vscode-copilot/hooks.ts`: drop the `if (pluginRoot)` absolute branch. Always emit `context-mode hook vscode-copilot <event>` — the pre-`f5c9d02` form already in production for `cursor` and `codex` adapters.
- `src/adapters/jetbrains-copilot/hooks.ts`: same fix — same Tier C.

**Tier C scope verification** (per ISSUE-613-VERDICT §6.2):
| Adapter | Pre-PR | Post-PR | Note |
|---|---|---|---|
| vscode-copilot | absolute (BUG) | CLI dispatcher | FIXED |
| jetbrains-copilot | absolute (BUG) | CLI dispatcher | FIXED |
| cursor | CLI dispatcher | unchanged | already correct |
| codex | CLI dispatcher | unchanged | already correct |
| opencode | N/A (TS plugin paradigm) | unchanged | no hook command |
| kiro | absolute (per `~/.kiro/agents/`) | unchanged | Tier B not C — written to user home, not committed to git |

## Multi-hat reasoning

**PO**: #613 is a categorically-unacceptable bug — context-mode silently committed garbage paths into the user's git tree on second-ever `/ctx-upgrade`. #609 turns into a silent ship-blocker on every Claude Code plugin auto-update. First-impression bugs on Windows = customers we never get back.

**OSS**: #604 reporter @jowch and #613 reporter @iskandersierra both did staff-grade work — file:line citations, dropped-in reproduction tests, ranked hypotheses. PR #618 by @sebastianbreguel proposed the same #609 shape we land here. Their evidence shaped this PR.

**Distribution**: Tier C is committed to git and shared across teammates. A single Windows + fnm user committing the absolute path poisons every teammate's repo. 14 adapters × 3 OS — Tier C lock covers the worst-case multi-machine surface.

**Architect**: The recurring sibling-config-drift family (#411 / #523 / #528 / #531 / #582 / #604 / #609 / #613) is one architectural sin: writing per-version absolute paths into files that other actors carry forward. The persistence-tier rule (Tier A heals on boot, Tier B heals on hook fire, Tier C MUST be born portable — no heal seam exists for files committed to git) makes the bug class structurally impossible going forward. We deliberately do NOT add an ADR per Mert's instruction; this PR description carries the contract.

## Test plan

- [x] **Slice 1 RED→GREEN**: `sweepStaleMcpJson` — RED (function missing) → GREEN (6 new behavioral tests pass).
- [x] **Slice 3 RED→GREEN**: `buildHookCommand` — RED (absolute path baked) → GREEN (4 + 4 Tier C lock tests pass on vscode/jetbrains).
- [x] **All tests reversed to protect new contract**: `tests/core/cli.test.ts` `.mcp.json` block + `tests/cli/upgrade-mcp-json-assertion.test.ts` + `tests/util/postinstall-heal-mcp-json.test.ts` + `tests/util/start-mjs-self-heal.test.ts` — bug-class protection preserved via amended assertions (no test deletion).
- [x] **Targeted suite**: 321/321 tests pass across all 12 modified test files.
- [x] **Full suite**: `npx vitest run tests/adapters tests/cli tests/hooks tests/util tests/core tests/scripts` — 91 files, 2014 tests, 1 skipped, 0 failed.
- [x] **TypeScript**: `npx tsc --noEmit` — clean.
- [x] **Bundles untouched**: per CONTRIBUTING — CI rebuilds `cli.bundle.mjs` / `server.bundle.mjs` / `hooks/*.bundle.mjs` on main push.

## Compatibility / rollback

- `healMcpJsonArgs` function is **kept** in `scripts/heal-installed-plugins.mjs` (just no longer wired into cli.ts / start.mjs / postinstall.mjs). Its unit tests at `tests/util/heal-installed-plugins.test.ts` still pass. Any out-of-tree consumer keeps working.
- Each slice is independently revertible — Slice 1 is a single import + write-removal + sweep-wiring; Slice 3 is a 2-file diff in two adapters.
- No on-disk migration. Existing `.mcp.json` files in user caches get swept on the next MCP boot, `/ctx-upgrade`, or `npm install -g context-mode` cycle.
- No public API change. `buildHookCommand`'s second arg is accepted for backwards-compat and intentionally ignored.