### PR TITLE
fix(pi): normalise context_mode_ prefix and path→file_path for event extraction

### DIFF
--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -388,8 +388,14 @@ export default function piExtension(pi: any): void {
       if (!_sessionId) return;
 
       const rawToolName = String(event?.toolName ?? event?.tool_name ?? "");
-      const mappedToolName =
+      let mappedToolName =
         PI_TOOL_MAP[rawToolName.toLowerCase()] ?? rawToolName;
+
+      // Pi namespaces MCP-registered tools with the "context_mode_" prefix;
+      // the extract functions expect the "mcp__" prefix for MCP tool calls.
+      if (/^context_mode_/.test(rawToolName)) {
+        mappedToolName = rawToolName.replace(/^context_mode_/, "mcp__context_mode__");
+      }
 
       // Normalize result to string
       const rawResult = event?.result ?? event?.output;
@@ -403,9 +409,17 @@ export default function piExtension(pi: any): void {
       // Detect errors
       const hasError = Boolean(event?.error || event?.isError);
 
+      // Pi sends file tool parameters as "path"; the extract functions
+      // expect "file_path" (Claude Code convention). Normalise before
+      // passing to extractEvents so file reads/writes/edits are tracked.
+      const rawInput = { ...(event?.params ?? event?.input ?? {}) };
+      if (rawInput.path !== undefined && rawInput.file_path === undefined) {
+        rawInput.file_path = String(rawInput.path);
+      }
+
       const hookInput: HookInput = {
         tool_name: mappedToolName,
-        tool_input: event?.params ?? event?.input ?? {},
+        tool_input: rawInput,
         tool_response: resultStr,
         tool_output: hasError ? { isError: true } : undefined,
       };

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -146,6 +146,30 @@ describe("Pi Extension", () => {
         tool_result: "ok",
       });
     });
+
+    it("maps 'context_mode_' prefix to 'mcp__context_mode__' so MCP tool calls get extracted", async () => {
+      await registerPiExtension(api);
+      await api._trigger("session_start", {
+        session_id: "test-fix1",
+        project_dir: tempDir,
+      });
+
+      // Pi prefixes MCP-registered tools with "context_mode_". Without
+      // normalisation the extract functions (P, F) silently drop all
+      // events because they gate on e.startsWith("mcp__").
+      await api._trigger("tool_result", {
+        tool_name: "context_mode_ctx_execute",
+        params: { language: "javascript", code: "console.log(1)" },
+        result: "1",
+      });
+
+      // Verify via ctx-stats that events include "mcp" category
+      // (meaning they were extracted, not just the generic fallback).
+      const stats = (await api._getCommand("ctx-stats")!.handler!({})) as {
+        text: string;
+      };
+      expect(stats.text).toContain("mcp");
+    });
   });
 
   // ═══════════════════════════════════════════════════════════
@@ -174,6 +198,31 @@ describe("Pi Extension", () => {
         tool_input: { file_path: "/src/index.ts" },
         tool_result: "export const hello = 'world';",
       });
+    });
+
+    it("extracts file_read event when Pi passes 'path' instead of 'file_path'", async () => {
+      await registerPiExtension(api);
+      await api._trigger("session_start", {
+        session_id: "test-fix2",
+        project_dir: tempDir,
+      });
+
+      // Pi's native Read tool sends { path: "..." } rather than
+      // { file_path: "..." } (Claude Code convention). Without
+      // normalisation the extractor reads n.file_path → undefined,
+      // producing file_read events with an empty path.
+      await api._trigger("tool_result", {
+        tool_name: "read",
+        params: { path: "/src/index.ts" },
+        result: "export const hello = 'world';",
+      });
+
+      // Verify the file_read event was captured by checking
+      // ctx-stats shows "file" category events.
+      const stats = (await api._getCommand("ctx-stats")!.handler!({})) as {
+        text: string;
+      };
+      expect(stats.text).toContain("file");
     });
 
     it("extracts cwd event from cd command", async () => {


### PR DESCRIPTION
## What / Why / How

Two silent-data-loss bugs in the Pi adapter tool_result handler that prevent MCP tool calls and file operations from being captured in session events.

**Bug 1 — `context_mode_` prefix not normalised to `mcp__`**

Pi namespaces MCP-registered tools with the `context_mode_` prefix (e.g. `context_mode_ctx_execute`). The shared event extractors (`P()` and `F()` in `session/extract.ts`) gate on `e.tool_name.startsWith("mcp__")` and silently return `[]` for anything else. Result: every `ctx_execute`, `ctx_search`, `ctx_batch_execute` call from Pi produces zero extracted events — no `mcp` category, no `mcp_tool_call` category. Only the generic JSON fallback fires, losing all semantic information about which tools were called.

Fix: normalise `context_mode_` → `mcp__context_mode__` before the extractor prefix check.

**Bug 2 — Pi sends `path` but extractors expect `file_path`**

Pi's native Read/Write/Edit tools send parameters as `{path: "..."}` while the extractors read `n.file_path` (Claude Code convention). Without normalisation, `n.file_path` is always `undefined`, so every file_read/file_edit/file_write event is recorded with an empty path — you cannot tell what files the LLM accessed.

Fix: spread raw input and copy `path` → `file_path` when the latter is absent.

Both fixes were verified end-to-end on Pi via the compiled adapter and are now tested in the TypeScript source with unit tests.

Fixes: neither has been filed as an issue (fix-first approach per CONTRIBUTING.md).

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [x] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Two new tests in existing `tests/pi-extension.test.ts` (CONTRIBUTING L275 — no new test files):

1. **context_mode_ prefix**: trigger tool_result with `tool_name: "context_mode_ctx_execute"`, verify `ctx-stats` shows `mcp` category events.
2. **path → file_path**: trigger tool_result with `tool_name: "read"` + `params: {path: "/src/index.ts"}`, verify `ctx-stats` shows `file` category events.

All 54 pi-extension tests pass (52 baseline + 2 new).

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (pi-extension: 54/54)
- [ ] `npm run typecheck` — pre-existing errors across all adapters (missing `@types/node` in fresh clone, same on `next` baseline)
- [ ] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch

<details>
<summary><strong>Cross-platform notes</strong></summary>

Both fixes are Pi-adapter-specific (only Pi uses the `context_mode_` prefix and `path` param). No cross-platform impact.

</details>