### PR TITLE
docs: Replace outdated Smart Truncation with FTS5 externalization

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -9,7 +9,7 @@
 |--------|-------|
 | Total scenarios | 21 |
 | Tools benchmarked | `ctx_execute_file` (summarize) + `ctx_index`/`ctx_search` (knowledge retrieval) |
-| Smart truncation | Head + tail preservation (60/40 split) |
+| Large output handling | Auto-externalize to FTS5 (>100 KB → pointer) |
 | Total raw data processed | 376 KB |
 | Total context consumed | 16.5 KB |
 | Overall context savings | **96%** |
@@ -74,35 +74,28 @@
 - `ctx_execute_file` on React docs: `"5 code blocks, 3 sections about cleanup"` → **useless for coding**
 - `ctx_index + ctx_search` on React docs: returns the full `useEffect(() => { ... }, [deps])` block → **actually useful**
 
-## Part 3: Smart Truncation
+## Part 3: Large Output Externalization (FTS5 Pointer)
 
-*When output exceeds the limit, context-mode keeps the first 60% + last 40% of lines — preserving both initial context and final error messages.*
+*When output exceeds 100 KB, context-mode auto-indexes the full content into FTS5 and returns a pointer message instead of raw content. No data is discarded — the LLM queries it on demand via `ctx_search()`.*
 
-| Before (v0.2) | After (v0.3) |
+| Before | After |
 |---|---|
-| Blindly keeps first N bytes | Keeps head (60%) + tail (40%) |
-| Cuts mid-line, corrupts UTF-8 | Snaps to line boundaries |
-| Error messages at end: **LOST** | Error messages at end: **PRESERVED** |
-| `"... [output truncated]"` | `"[47 lines / 3.2KB truncated — showing first 12 + last 8 lines]"` |
+| Raw output floods context window | Output indexed into FTS5, pointer returned |
+| LLM sees truncated/partial content | Full content preserved, queryable on demand |
+| Large logs: **LOST** | Large logs: **FULLY INDEXED** |
+| `"... [output truncated]"` | `"Indexed N sections from: execute:shell\nUse ctx_search(...) to query."` |
 
 ### Example
 
 ```
-line 0: data initialization
-line 1: loading config
-line 2: starting server
-...
+# ctx_execute output > 100 KB:
 
-... [47 lines / 3.2KB truncated — showing first 12 + last 8 lines] ...
-
-line 92: connection timeout
-line 93: retry attempt 3 failed
-line 94: FATAL: database unreachable
-line 95: Stack trace: Error at connect()
-line 96: exit code: 1
+Indexed 42 sections (12 with code) from: execute:shell
+Use ctx_search(queries: ["..."]) to query this content.
+Use source: "execute:shell" to scope results.
 ```
 
-The LLM can now see **both** the setup context (head) and the actual error (tail).
+The LLM retrieves only the relevant sections via `ctx_search()` — no context budget wasted on raw output.
 
 ## Context Window Impact
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -742,7 +742,7 @@ Self-update from GitHub:
 | Total context consumed | 16.5 KB |
 | Overall context savings | 96% |
 | Code examples preserved | 100% |
-| Smart truncation strategy | Head 60% + tail 40% |
+| Large output handling | Auto-externalize to FTS5 (>100 KB → pointer) |
 
 ## Edge Cases and Constraints
 
@@ -752,7 +752,7 @@ Self-update from GitHub:
 - **Binary output:** Decoded as UTF-8 (may produce replacement characters).
 - **Timeout:** Returns partial stdout collected before kill + timeout message with elapsed time.
 - **Hard cap exceeded (>100 MB):** Process tree killed immediately, stderr appended with `"[output capped at 100MB -- process killed]"`.
-- **Smart truncation message format:** `"... [N lines / X.XKB truncated -- showing first M + last K lines] ..."`.
+- **Large output externalization (>100 KB):** Full stdout auto-indexed into FTS5; pointer message returned: `"Indexed N sections from: execute:<lang>\nUse ctx_search(...) to query."`.
 
 ### Search Constraints
 


### PR DESCRIPTION
BENCHMARK.md and docs/llms-full.txt still described the old 60/40 head+tail truncation strategy. The actual implementation (server.ts, LARGE_OUTPUT_THRESHOLD = 100KB) auto-indexes large outputs into FTS5 and returns a pointer — no truncation occurs.

- BENCHMARK.md: update Overview row, replace Part 3 section
- docs/llms-full.txt: update Aggregate Metrics row and Edge Cases entry

## What / Why / How

<!-- Brief: what changed, why, and implementation approach. Link issue: Fixes #000 -->

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
