### PR TITLE
fix(codex): bump MCP startup_timeout_sec to 60s for prewarm headroom (#634)

### DIFF
--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -3,7 +3,8 @@
     "context-mode": {
       "command": "node",
       "args": ["./start.mjs"],
-      "cwd": "."
+      "cwd": ".",
+      "startup_timeout_sec": 60
     }
   }
 }

--- a/tests/plugins/codex-manifest.test.ts
+++ b/tests/plugins/codex-manifest.test.ts
@@ -66,6 +66,22 @@ describe(".codex-plugin/mcp.json", () => {
     expect(entry.cwd).toBe(".");
   });
 
+  it("ships `startup_timeout_sec` >= 60s to survive Codex's prewarm stack (#634)", () => {
+    // Codex's default `startup_timeout_sec` is 30s (codex-rs/config/src/mcp_types.rs
+    // RawMcpServerConfig.try_from). Before the first turn, Codex serializes a
+    // ~15s `startup_prewarm_resolve` websocket prewarm against chatgpt.com.
+    // On slower networks (macOS Wi-Fi in particular) the cumulative time from
+    // codex spawn → context-mode MCP `InitializeResult` exceeds 30s and Codex
+    // drops the MCP child with "MCP client for `context-mode` timed out after
+    // 30 seconds". Bumping this in the plugin manifest is propagated by
+    // codex's plugin-installer into `[mcp_servers.context-mode]` so users
+    // never see the failure on a fresh install.
+    const servers = mcp.mcpServers as Record<string, { startup_timeout_sec?: number }>;
+    const entry = servers["context-mode"];
+    expect(entry.startup_timeout_sec).toBeTypeOf("number");
+    expect(entry.startup_timeout_sec).toBeGreaterThanOrEqual(60);
+  });
+
   it("does NOT use `${CODEX_PLUGIN_ROOT}` placeholders (no var expansion happens)", () => {
     const raw = readFileSync(resolve(REPO_ROOT, ".codex-plugin/mcp.json"), "utf8");
     expect(raw).not.toMatch(/\$\{[^}]*PLUGIN_ROOT[^}]*\}/);


### PR DESCRIPTION
## Summary

Closes #634.

Codex CLI 0.131.0 defaults the per-MCP-server `startup_timeout_sec` to 30s. Before the first turn it serializes a ~15s `startup_prewarm_resolve` websocket prewarm against chatgpt.com, then attempts the MCP child handshake. On macOS Wi-Fi the cumulative spawn → `InitializeResult` window crosses 30s and Codex drops the MCP child with:

```
MCP client for `context-mode` timed out after 30 seconds.
```

context-mode itself answers MCP `initialize` in ~300 ms in isolation — this is purely Codex's spawn-budget being too tight for its own prewarm stack. Bumping the manifest-side hint to 60s gives the prewarm + handshake stack room to land cleanly.

## Why

`.codex-plugin/mcp.json` is loaded by Codex via `PluginMcpServersFile` and passed verbatim through `RawMcpServerConfig::try_from` (codex-rs/config/src/mcp_types.rs), which already deserializes `startup_timeout_sec` as an optional `Duration` field. Shipping the bump in the plugin manifest lets new users land on a working install without having to learn about the workaround after their first failed launch.

Measured on Linux/Node v22 + codex 0.131.0 + context-mode 1.0.141 (3 consecutive runs):

| | Codex `startup_prewarm_resolve` | context-mode MCP `InitializeResult` arrival | Headroom |
|--|--|--|--|
| 30s default | timed_out @ ~15s | ~27s after codex start | ~3s |
| 60s (this PR) | timed_out @ ~15s | ~29s after codex start | ~31s |

## Coverage added

`tests/plugins/codex-manifest.test.ts` already pins every other field of the shipped `.codex-plugin/mcp.json` (camelCase `mcpServers` key, `command`/`args`/`cwd`, no `${CODEX_PLUGIN_ROOT}` placeholders). The new case extends the same contract:

```ts
it("ships `startup_timeout_sec` >= 60s to survive Codex's prewarm stack (#634)", () => {
  const entry = servers["context-mode"];
  expect(entry.startup_timeout_sec).toBeTypeOf("number");
  expect(entry.startup_timeout_sec).toBeGreaterThanOrEqual(60);
});
```

Confirmed red→green by stashing the `.codex-plugin/mcp.json` edit before re-running the test (red), then restoring (green).

## Test plan

- [x] `npx vitest run tests/plugins/codex-manifest.test.ts` → 11/11 pass
- [x] `npm run typecheck` → clean
- [x] Reverted the manifest edit only and re-ran the same vitest filter → the new case fails as expected, proving the test would have caught the missing field
- [x] Manual install via `codex plugin marketplace add /tmp/cm-codex-fix/work` + `codex plugin add context-mode@context-mode` → installed `.codex-plugin/mcp.json` contains `\"startup_timeout_sec\": 60` in `~/.codex/plugins/cache/context-mode/context-mode/1.0.141/.codex-plugin/mcp.json`

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms