### PR TITLE
feat(opencode): streamline installation process and improve CLI upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,13 +410,7 @@ Full configs: [`configs/cursor/hooks.json`](configs/cursor/hooks.json) | [`confi
 
 **Install:**
 
-1. Install context-mode globally:
-
-   ```bash
-   npm install -g context-mode
-   ```
-
-2. Add to `opencode.json` in your project root (or `~/.config/opencode/opencode.json` for global):
+1. Add to `opencode.json` in your project root (or `~/.config/opencode/opencode.json` for global):
 
    ```json
    {
@@ -427,7 +421,7 @@ Full configs: [`configs/cursor/hooks.json`](configs/cursor/hooks.json) | [`confi
 
    The `plugin` entry registers all 11 `ctx_*` tools natively and enables hooks — OpenCode calls context-mode's TypeScript plugin in-process, so there is no redundant stdio MCP child per session.
 
-3. *(Optional)* Copy the routing rules file. The model needs an `AGENTS.md` file for routing awareness:
+2. *(Optional)* Copy the routing rules file. The model needs an `AGENTS.md` file for routing awareness:
 
    ```bash
    cp node_modules/context-mode/configs/opencode/AGENTS.md AGENTS.md
@@ -435,7 +429,7 @@ Full configs: [`configs/cursor/hooks.json`](configs/cursor/hooks.json) | [`confi
 
    This tells the model which tools to use and which commands are blocked. Without it, hooks still enforce routing — but the model won't know *why* a command was denied.
 
-4. Restart OpenCode.
+3. Restart OpenCode.
 
 **Verify:** In the OpenCode session, type `ctx stats`. Context-mode tools should appear and respond.
 
@@ -456,13 +450,7 @@ Full configs: [`configs/opencode/opencode.json`](configs/opencode/opencode.json)
 
 **Install:**
 
-1. Install context-mode globally:
-
-   ```bash
-   npm install -g context-mode
-   ```
-
-2. Add to `kilo.json` in your project root (or `~/.config/kilo/kilo.json` for global):
+1. Add to `kilo.json` in your project root (or `~/.config/kilo/kilo.json` for global):
 
    ```json
    {
@@ -473,13 +461,13 @@ Full configs: [`configs/opencode/opencode.json`](configs/opencode/opencode.json)
 
    The `plugin` entry registers all 11 `ctx_*` tools natively and enables hooks — KiloCode calls context-mode's TypeScript plugin in-process, so there is no redundant stdio MCP child per session.
 
-3. *(Optional)* Copy the routing rules file. KiloCode shares the OpenCode plugin architecture, so the model needs an `AGENTS.md` file for routing awareness:
+2. *(Optional)* Copy the routing rules file. KiloCode shares the OpenCode plugin architecture, so the model needs an `AGENTS.md` file for routing awareness:
 
    ```bash
    cp node_modules/context-mode/configs/opencode/AGENTS.md AGENTS.md
    ```
 
-4. Restart KiloCode.
+3. Restart KiloCode.
 
 **Verify:** In the KiloCode session, type `ctx stats`. Context-mode tools should appear and respond.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1402,20 +1402,20 @@ async function upgrade(opts?: { platform?: string }) {
               color.dim("\n  Try (fallback): /context-mode:ctx-doctor"),
           );
         }
-      }
-
-      // Update global npm
-      s.start("Updating npm global package");
-      try {
-        npmExecFile(["install", "-g", pluginRoot, "--no-audit", "--no-fund"], {
-          stdio: "pipe",
-          timeout: 30000,
-        });
-        s.stop(color.green("npm global updated"));
-        changes.push("Updated npm global package");
-      } catch {
-        s.stop(color.yellow("npm global update skipped"));
-        p.log.info(color.dim("  Could not update global npm — may need sudo or standalone install"));
+        
+        // Update global npm
+        s.start("Updating npm global package");
+        try {
+          npmExecFile(["install", "-g", pluginRoot, "--no-audit", "--no-fund"], {
+            stdio: "pipe",
+            timeout: 30000,
+          });
+          s.stop(color.green("npm global updated"));
+          changes.push("Updated npm global package");
+        } catch {
+          s.stop(color.yellow("npm global update skipped"));
+          p.log.info(color.dim("  Could not update global npm — may need sudo or standalone install"));
+        }
       }
 
       // Cleanup

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,6 +139,9 @@ async function hookDispatch(platform: string, event: string): Promise<void> {
  * Entry point
  * ------------------------------------------------------- */
 
+const IN_PROCESS_PLUGIN_PLATFORMS = new Set(["opencode", "kilo"]);
+const isInProcessPluginPlatform = (p: string | undefined) =>
+  p ? IN_PROCESS_PLUGIN_PLATFORMS.has(p) : false;
 const args = process.argv.slice(2);
 
 if (args[0] === "doctor") {
@@ -278,7 +281,7 @@ function cachePluginRoot(platform: string): string {
 
 function getPluginRoot(): string {
   const platform = detectPlatform().platform;
-  if (platform === 'opencode' || platform === 'kilo') {
+  if (isInProcessPluginPlatform(platform)) {
     return cachePluginRoot(platform);
   }
   return defaultPluginRoot();
@@ -1320,7 +1323,7 @@ async function upgrade(opts?: { platform?: string }) {
       });
       s.stop("Dependencies ready");
 
-      if (detection.platform !== 'opencode' && detection.platform !== 'kilo') {
+      if (!isInProcessPluginPlatform(detection.platform)) {
         // Verify native addons through the same bootstrap start.mjs imports.
         // On modern Node, the ABI-specific cache file is the compatibility marker;
         // the active binding alone may be stale from a previous Node ABI.

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -1713,17 +1713,10 @@ describe("Plugin root detection (#PR refactor/opencode-improvements)", () => {
     expect(cacheRootBody).toContain("homedir");
   });
 
-  test("getPluginRoot uses cache path for opencode platform", () => {
+  test("getPluginRoot uses cache path for opencode/kilo platform", () => {
     const getPluginRootStart = CLI_SOURCE.indexOf("function getPluginRoot");
     const getPluginRootBody = CLI_SOURCE.slice(getPluginRootStart, getPluginRootStart + 300);
-    expect(getPluginRootBody).toContain("'opencode'");
-    expect(getPluginRootBody).toContain("cachePluginRoot");
-  });
-
-  test("getPluginRoot uses cache path for kilo platform", () => {
-    const getPluginRootStart = CLI_SOURCE.indexOf("function getPluginRoot");
-    const getPluginRootBody = CLI_SOURCE.slice(getPluginRootStart, getPluginRootStart + 300);
-    expect(getPluginRootBody).toContain("'kilo'");
+    expect(getPluginRootBody).toContain("isInProcessPluginPlatform(platform)");
     expect(getPluginRootBody).toContain("cachePluginRoot");
   });
 });

--- a/tests/util/cli-upgrade-verification.test.ts
+++ b/tests/util/cli-upgrade-verification.test.ts
@@ -117,6 +117,26 @@ describe("cli.ts upgrade() pre-bump verification (v1.0.114 hotfix)", () => {
     expect(stopIdx).toBeLessThan(throwIdx);
     expect(throwIdx).toBeLessThan(updateIdx);
   });
+
+  test("upgrade() gates 'npm install -g' behind the opencode/kilo exclusion (PR #650)", () => {
+    const upgradeIdx = cliSrc.indexOf("async function upgrade");
+    const upgradeBody = cliSrc.slice(upgradeIdx, upgradeIdx + 30000);
+
+    const gateIdx = upgradeBody.indexOf("!isInProcessPluginPlatform(detection.platform)");
+    const npmGIdx = upgradeBody.indexOf('"install", "-g"');
+
+    // Gate must exist, and the '-g' call must sit AFTER it (i.e. inside the block).
+    expect(gateIdx).toBeGreaterThan(0);
+    expect(npmGIdx).toBeGreaterThan(gateIdx);
+
+    // The closing brace of the gate must come AFTER the '-g' call,
+    // not between the ABI verifier and the global install (the pre-PR shape).
+    const closeBefore = upgradeBody.lastIndexOf(
+      "      }",
+      upgradeBody.indexOf("// Cleanup"),
+    );
+    expect(closeBefore).toBeGreaterThan(npmGIdx);
+  });
 });
 
 describe("cli.ts upgrade() post-write registry consistency check (v1.0.114 hotfix)", () => {


### PR DESCRIPTION

## What / Why / How

Remove redundant global npm install step from installation instructions for both OpenCode and KiloCode integrations. Refactor CLI upgrade command to omit global package updates for these platforms.

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [x] OpenCode
- [x] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Added test for regression detection

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
