### PR TITLE
fix(server): surrogate-safe preview truncation in ctx_fetch_and_index (#659)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import {
 } from "./runtime.js";
 import { classifyNonZeroExit } from "./exit-classify.js";
 import { startLifecycleGuard } from "./lifecycle.js";
+import { charSafePrefix } from "./truncate.js";
 import { hashProjectDirCanonical, hashProjectDirLegacy, resolveContentStorePath, resolveSessionDbPath, SessionDB } from "./session/db.js";
 import { purgeSession } from "./session/purge.js";
 import {
@@ -2760,7 +2761,7 @@ function indexFetched(f: { url: string; source?: string; markdown: string; heade
   // Track AFTER the FTS5 write succeeds — failed indexes shouldn't inflate the counter.
   trackIndexed(Buffer.byteLength(f.markdown));
   const preview = f.markdown.length > FETCH_PREVIEW_LIMIT
-    ? f.markdown.slice(0, FETCH_PREVIEW_LIMIT) + "\n\n…[truncated — use ctx_search() for full content]"
+    ? charSafePrefix(f.markdown, FETCH_PREVIEW_LIMIT) + "\n\n…[truncated — use ctx_search() for full content]"
     : f.markdown;
   return {
     label: indexed.label,

--- a/src/truncate.ts
+++ b/src/truncate.ts
@@ -44,6 +44,34 @@ function byteSafePrefix(str: string, maxBytes: number): string {
 }
 
 // ─────────────────────────────────────────────────────────
+// Char-count prefix (UTF-16 surrogate-safe)
+// ─────────────────────────────────────────────────────────
+
+/**
+ * Return a prefix of `str` no longer than `maxChars` UTF-16 code units, with
+ * the cut backed off by one unit if it would split a surrogate pair. Mirrors
+ * the surrogate-safety semantics of the internal `byteSafePrefix`, but uses
+ * a character budget rather than a byte budget.
+ *
+ * Use this instead of bare `str.slice(0, n)` whenever the result is later
+ * JSON-encoded for an RFC 8259-strict consumer (e.g. tool_result payloads
+ * sent back to the host LLM API). `JSON.stringify` will emit a lone high
+ * surrogate as a literal `\uD8xx` escape, which is invalid JSON.
+ *
+ * @param str      - Input string.
+ * @param maxChars - Hard cap in UTF-16 code units.
+ */
+export function charSafePrefix(str: string, maxChars: number): string {
+  if (maxChars <= 0) return "";
+  if (str.length <= maxChars) return str;
+
+  let end = maxChars;
+  const code = str.charCodeAt(end - 1);
+  if (code >= 0xd800 && code <= 0xdbff) end -= 1;
+  return str.slice(0, end);
+}
+
+// ─────────────────────────────────────────────────────────
 // JSON truncation
 // ─────────────────────────────────────────────────────────
 

--- a/tests/truncate.test.ts
+++ b/tests/truncate.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, test } from "vitest";
 import { strict as assert } from "node:assert";
-import { truncateJSON, capBytes, escapeXML } from "../src/truncate.js";
+import { truncateJSON, capBytes, escapeXML, charSafePrefix } from "../src/truncate.js";
 
 // ─────────────────────────────────────────────────────────
 // truncateJSON
@@ -264,5 +264,93 @@ describe("truncateJSON — exact-size boundaries", () => {
       Buffer.byteLength(out) <= cap,
       `expected <= ${cap} bytes, got ${Buffer.byteLength(out)}`,
     );
+  });
+});
+
+// ─────────────────────────────────────────────────────────
+// charSafePrefix
+// ─────────────────────────────────────────────────────────
+
+describe("charSafePrefix", () => {
+  test("returns input unchanged when length <= maxChars", () => {
+    assert.equal(charSafePrefix("hello", 10), "hello");
+    assert.equal(charSafePrefix("hello", 5), "hello");
+  });
+
+  test("maxChars <= 0 returns empty string", () => {
+    assert.equal(charSafePrefix("hello", 0), "");
+    assert.equal(charSafePrefix("hello", -1), "");
+  });
+
+  test("ASCII input is sliced exactly at maxChars", () => {
+    const out = charSafePrefix("a".repeat(100), 10);
+    assert.equal(out.length, 10);
+    assert.equal(out, "a".repeat(10));
+  });
+
+  test("backs off one code unit when cut splits a surrogate pair", () => {
+    // "🟡" = U+1F7E1 = high surrogate \uD83D + low surrogate \uDFE1
+    const filler = "a".repeat(99);
+    const input = filler + "🟡extra";
+    // maxChars=100 would land between the two halves of 🟡.
+    const out = charSafePrefix(input, 100);
+    // Result should drop the orphan high surrogate, ending at the filler.
+    assert.equal(out.length, 99);
+    assert.equal(out, filler);
+    // No lone high surrogate at the boundary.
+    const last = out.charCodeAt(out.length - 1);
+    assert.ok(
+      last < 0xd800 || last > 0xdbff,
+      `last code unit ${last.toString(16)} is a lone high surrogate`,
+    );
+  });
+
+  test("cut after a complete surrogate pair leaves the pair intact", () => {
+    // maxChars lands AFTER both halves of 🟡 — should keep the emoji.
+    const filler = "a".repeat(98);
+    const input = filler + "🟡extra";
+    const out = charSafePrefix(input, 100);
+    assert.equal(out.length, 100);
+    assert.equal(out, filler + "🟡");
+  });
+
+  test("survives JSON.stringify round-trip with emoji at boundary", () => {
+    // Regression for #659: bare .slice(0, n) at a surrogate-pair boundary
+    // produces a lone high surrogate that JSON.stringify emits as a literal
+    // \uD8xx escape, breaking RFC 8259-strict consumers.
+    const filler = "a".repeat(99);
+    const input = filler + "🟡status indicator";
+    const sliced = charSafePrefix(input, 100);
+    const body = JSON.stringify({ content: sliced });
+    // No orphan \uD8xx high surrogate followed by anything except a \uDxxx low surrogate.
+    const orphan = /\\uD[89AB][0-9A-Fa-f]{2}(?!\\uD[CDEF])/i.test(body);
+    assert.equal(orphan, false, `JSON body contains orphan high surrogate: ${body}`);
+    // And the body round-trips through a strict parser.
+    assert.doesNotThrow(() => JSON.parse(body));
+  });
+
+  test("survives JSON round-trip when used in preview-construction pattern", () => {
+    // Mirrors src/server.ts fetch-preview construction:
+    //   charSafePrefix(markdown, LIMIT) + "\n\n…[truncated — use ctx_search() for full content]"
+    // Build markdown that puts an emoji exactly at the LIMIT boundary.
+    const LIMIT = 3072;
+    const markdown = "a".repeat(LIMIT - 1) + "🟡 status indicator more text here";
+    const preview = markdown.length > LIMIT
+      ? charSafePrefix(markdown, LIMIT) + "\n\n…[truncated — use ctx_search() for full content]"
+      : markdown;
+    const body = JSON.stringify({ preview });
+    const orphan = /\\uD[89AB][0-9A-Fa-f]{2}(?!\\uD[CDEF])/i.test(body);
+    assert.equal(orphan, false, "preview-construction pattern must not emit orphan surrogate");
+    assert.doesNotThrow(() => JSON.parse(body));
+  });
+
+  test("handles multiple surrogate pairs adjacent to the cut", () => {
+    // Two emoji in a row; cut between them should keep first, drop second's lone high half.
+    const filler = "a".repeat(98);
+    const input = filler + "🟡🔴trailing";
+    // maxChars=101 lands inside the second emoji (after 🟡's pair, mid-🔴).
+    const out = charSafePrefix(input, 101);
+    assert.equal(out.length, 100); // backed off from 101 to 100
+    assert.equal(out, filler + "🟡");
   });
 });


### PR DESCRIPTION
## What / Why / How

**What:** Adds a `charSafePrefix(str, maxChars)` export to `src/truncate.ts` and uses it at the fetch-preview construction in `src/server.ts` (line ~2763) instead of bare `.slice(0, FETCH_PREVIEW_LIMIT)`.

**Why:** Fixes #659. The bare `.slice` truncates at a UTF-16 code-unit boundary, which can split an astral-plane character (e.g. 🟡 = `🟡`) into a lone high surrogate. `JSON.stringify` then emits that as a literal `\uD83D` escape in the tool_result payload, and the host LLM API rejects the next request with `400 The request body is not valid JSON: no low surrogate in string` (RFC 8259). The session cannot recover until the bad message is removed from the transcript.

**How:** `charSafePrefix` mirrors the existing internal `byteSafePrefix` in this file: cap by UTF-16 code units, back off one unit if the cut would split a surrogate pair. Marker handling stays in the caller, preserving the existing `slice + "\n\n…[truncated…]"` shape exactly (zero behavior change for non-emoji content).

Fixes #659.

## Affected platforms

The bug fires on any host that JSON-encodes tool_result with RFC 8259-strict validation. Anthropic's API is the confirmed reporter; other adapters likely affected equivalently.

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

Added a new `describe("charSafePrefix", ...)` block to `tests/truncate.test.ts` with 8 tests covering:

- Pass-through when `length <= maxChars` and `maxChars <= 0` edge cases.
- ASCII slice is exact.
- Backs off one code unit when the cut splits a surrogate pair (the actual bug).
- Cut after a complete surrogate pair leaves the pair intact (no over-correction).
- Multiple adjacent surrogate pairs at the cut.
- **JSON round-trip regression** — constructs the exact `charSafePrefix(input, LIMIT) + "\n\n…[truncated…]"` pattern from `server.ts` with an emoji at position `LIMIT - 1`, JSON-encodes the result, and asserts the body contains no orphan high surrogate and parses back through a strict `JSON.parse`. This is the test the issue actually demands; without it a future refactor could reintroduce the bare `.slice` and the helper would sit unused.

Local results:

- `npm run typecheck` — pass
- `npx vitest run tests/truncate.test.ts` — 37/37 pass (29 baseline + 8 new)
- `npx vitest run tests/truncate-removal.test.ts` — 4/4 pass (source-level exports still valid)

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (typecheck + targeted vitest passes locally; full suite has two pre-existing failures in `tests/core/server.test.ts` related to a `npx tsc --silent` subprocess call that fail identically on clean `main` — verified by re-running with my changes stashed)
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (no doc changes required)
- [x] No Windows path regressions (pure-string helper, no path code)
- [x] Targets `next` branch

## Notes on scope

This PR fixes only the **`FETCH_PREVIEW_LIMIT = 3072`** site in `src/server.ts` (line 2763) — the path that produced the reported 400s. The issue swept five other `.slice(0, N)` sites in the bundle (bounds 47/37/19/80/97). Those map to short label/error/timestamp truncations in `src/cli.ts`, `src/server.ts`, `src/store.ts`, `src/session/extract.ts` whose inputs are unlikely to land an emoji at the boundary AND which mostly don't flow into host-API JSON. Happy to extend `charSafePrefix` coverage to those sites in a follow-up if you want to remove the class of bug — keeping this PR minimal so the surgical fix lands fast.