### PR TITLE
fix(pi): prevent mixed-width TUI over-width crashes (CJK/Korean/emoji)

### DIFF
--- a/src/adapters/pi/mcp-bridge.ts
+++ b/src/adapters/pi/mcp-bridge.ts
@@ -153,7 +153,7 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 const MAX_INIT_RETRIES = 2;
 const INIT_RETRY_DELAY_MS = 1_000;
 
-class PiTextComponent {
+export class PiTextComponent {
   private text: string;
 
   constructor(text = "") {
@@ -177,27 +177,137 @@ class PiTextComponent {
   }
 }
 
-const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
-function truncateAnsiLine(line: string, maxWidth: number): string {
+function extractTerminalEscape(str: string, pos: number): { code: string; length: number } | null {
+  if (pos >= str.length || str[pos] !== "\x1b") return null;
+  const next = str[pos + 1];
+
+  // CSI sequence: ESC [ ... final-byte. Covers SGR plus cursor/control codes.
+  if (next === "[") {
+    let j = pos + 2;
+    while (j < str.length) {
+      const code = str.charCodeAt(j);
+      if (code >= 0x40 && code <= 0x7e) {
+        return { code: str.slice(pos, j + 1), length: j + 1 - pos };
+      }
+      j++;
+    }
+    return null;
+  }
+
+  // OSC/APC sequence: ESC ]/_ ... BEL or ST (ESC \). Stop at the FIRST
+  // terminator so OSC 8 hyperlinks don't swallow visible link text.
+  if (next === "]" || next === "_") {
+    let j = pos + 2;
+    while (j < str.length) {
+      if (str[j] === "\x07") return { code: str.slice(pos, j + 1), length: j + 1 - pos };
+      if (str[j] === "\x1b" && str[j + 1] === "\\") {
+        return { code: str.slice(pos, j + 2), length: j + 2 - pos };
+      }
+      j++;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+function couldBeEmoji(segment: string): boolean {
+  const cp = segment.codePointAt(0) ?? 0;
+  return (
+    (cp >= 0x1f000 && cp <= 0x1fbff) ||
+    (cp >= 0x2300 && cp <= 0x23ff) ||
+    (cp >= 0x2600 && cp <= 0x27bf) ||
+    (cp >= 0x2b50 && cp <= 0x2b55) ||
+    segment.includes("\uFE0F") ||
+    segment.includes("\u200D")
+  );
+}
+
+function isZeroWidthCodePoint(cp: number): boolean {
+  return (
+    cp < 0x20 ||
+    (cp >= 0x7f && cp <= 0x9f) ||
+    (cp >= 0x300 && cp <= 0x36f) ||     // Combining Diacritical Marks
+    (cp >= 0x1ab0 && cp <= 0x1aff) ||   // Combining Diacritical Marks Extended
+    (cp >= 0x1dc0 && cp <= 0x1dff) ||   // Combining Diacritical Marks Supplement
+    (cp >= 0x20d0 && cp <= 0x20ff) ||   // Combining Diacritical Marks for Symbols
+    (cp >= 0xfe00 && cp <= 0xfe0f) ||   // Variation Selectors
+    (cp >= 0xfe20 && cp <= 0xfe2f) ||   // Combining Half Marks
+    cp === 0x200b ||
+    cp === 0x200c ||
+    cp === 0x200d ||
+    cp === 0xfeff
+  );
+}
+
+function isZeroWidthGrapheme(segment: string): boolean {
+  if (segment.length === 0) return true;
+  for (const char of segment) {
+    if (!isZeroWidthCodePoint(char.codePointAt(0) ?? 0)) return false;
+  }
+  return true;
+}
+
+/**
+ * Returns the terminal display width of a code point.
+ * CJK ideographs, Hangul, fullwidth forms, etc. → 2; everything else → 1.
+ * Mirrors the Unicode east-asian-width "W"/"F" categories.
+ */
+function charWidth(cp: number): number {
+  return cp >= 0x1100 && (
+    cp <= 0x115f ||   // Hangul Jamo
+    (cp >= 0xa960 && cp <= 0xa97c) ||   // Hangul Jamo Extended-A
+    cp === 0x2329 || cp === 0x232a ||
+    (cp >= 0x2e80 && cp <= 0xa4cf && cp !== 0x303f) ||  // CJK
+    (cp >= 0xac00 && cp <= 0xd7a3) ||   // Hangul syllables
+    (cp >= 0xd7b0 && cp <= 0xd7fb) ||   // Hangul Jamo Extended-B
+    (cp >= 0xf900 && cp <= 0xfaff) ||   // CJK compat
+    (cp >= 0xfe10 && cp <= 0xfe19) ||   // Vertical forms
+    (cp >= 0xfe30 && cp <= 0xfe6f) ||   // CJK compat forms
+    (cp >= 0xff01 && cp <= 0xff60) ||   // Fullwidth forms
+    (cp >= 0xffe0 && cp <= 0xffe6) ||   // Fullwidth signs
+    (cp >= 0x20000 && cp <= 0x2fffd) || // CJK extensions
+    (cp >= 0x30000 && cp <= 0x3fffd)    // CJK extensions B+
+  ) ? 2 : 1;
+}
+
+function graphemeWidth(segment: string): number {
+  const cp = segment.codePointAt(0);
+  if (cp === undefined) return 0;
+  if (isZeroWidthGrapheme(segment)) return 0;
+  if (couldBeEmoji(segment)) return 2;
+  // Regional indicator symbols render as wide emoji flags in Pi's TUI.
+  if (cp >= 0x1f1e6 && cp <= 0x1f1ff) return 2;
+  return charWidth(cp);
+}
+
+export function truncateAnsiLine(line: string, maxWidth: number): string {
   if (maxWidth <= 0) return "";
   let output = "";
   let visible = 0;
   let index = 0;
-  ANSI_PATTERN.lastIndex = 0;
-  for (;;) {
-    const match = ANSI_PATTERN.exec(line);
-    const end = match?.index ?? line.length;
-    const chunk = line.slice(index, end);
-    for (const char of chunk) {
-      if (visible >= maxWidth) return output;
-      output += char;
-      visible++;
+  while (index < line.length) {
+    const escape = extractTerminalEscape(line, index);
+    if (escape) {
+      output += escape.code;
+      index += escape.length;
+      continue;
     }
-    if (!match) return output;
-    output += match[0];
-    index = ANSI_PATTERN.lastIndex;
+
+    let end = index + 1;
+    while (end < line.length && !extractTerminalEscape(line, end)) end++;
+    const chunk = line.slice(index, end);
+    for (const { segment } of GRAPHEME_SEGMENTER.segment(chunk)) {
+      const w = graphemeWidth(segment);
+      if (visible + w > maxWidth) return output;
+      output += segment;
+      visible += w;
+    }
+    index = end;
   }
+  return output;
 }
 
 interface PiRenderTheme {

--- a/tests/adapters/pi-mcp-bridge.test.ts
+++ b/tests/adapters/pi-mcp-bridge.test.ts
@@ -817,3 +817,235 @@ describe("bootstrapMCPTools — retries on slow initialize (#647)", () => {
     }
   }, 30_000);
 });
+
+// ── Slice 10 — CJK wide-character width-aware truncation (#665) ──
+//
+// Bug: truncateAnsiLine() counted every JS character as width 1, but
+// CJK characters (Chinese, Japanese, Korean) occupy 2 columns in a
+// terminal. This caused PiTextComponent.render() to produce lines whose
+// actual visible width exceeded the requested `width`, triggering a
+// pi-tui crash: "visible width: 162 > terminal width: 147".
+//
+// The fix: truncateAnsiLine() must measure CJK characters as width 2.
+//
+// These tests pin the contract:
+//   1. Pure CJK text does not exceed the requested width.
+//   2. Mixed ASCII + CJK text is correctly truncated.
+//   3. ANSI escape sequences are preserved but NOT counted toward width.
+//   4. The crash line from the real incident is handled correctly.
+describe("truncateAnsiLine / PiTextComponent — CJK width-aware truncation (#665)", () => {
+  const testSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+  function extractTestTerminalEscape(str: string, pos: number): { length: number } | null {
+    if (pos >= str.length || str[pos] !== "\x1b") return null;
+    const next = str[pos + 1];
+    if (next === "[") {
+      let j = pos + 2;
+      while (j < str.length) {
+        const code = str.charCodeAt(j);
+        if (code >= 0x40 && code <= 0x7e) return { length: j + 1 - pos };
+        j++;
+      }
+      return null;
+    }
+    if (next === "]" || next === "_") {
+      let j = pos + 2;
+      while (j < str.length) {
+        if (str[j] === "\x07") return { length: j + 1 - pos };
+        if (str[j] === "\x1b" && str[j + 1] === "\\") return { length: j + 2 - pos };
+        j++;
+      }
+      return null;
+    }
+    return null;
+  }
+
+  function stripTestTerminalEscapes(str: string): string {
+    let stripped = "";
+    let i = 0;
+    while (i < str.length) {
+      const escape = extractTestTerminalEscape(str, i);
+      if (escape) {
+        i += escape.length;
+        continue;
+      }
+      stripped += str[i];
+      i++;
+    }
+    return stripped;
+  }
+
+  function testZeroWidthCodePoint(cp: number): boolean {
+    return (
+      cp < 0x20 ||
+      (cp >= 0x7f && cp <= 0x9f) ||
+      (cp >= 0x300 && cp <= 0x36f) ||
+      (cp >= 0x1ab0 && cp <= 0x1aff) ||
+      (cp >= 0x1dc0 && cp <= 0x1dff) ||
+      (cp >= 0x20d0 && cp <= 0x20ff) ||
+      (cp >= 0xfe00 && cp <= 0xfe0f) ||
+      (cp >= 0xfe20 && cp <= 0xfe2f) ||
+      cp === 0x200b ||
+      cp === 0x200c ||
+      cp === 0x200d ||
+      cp === 0xfeff
+    );
+  }
+
+  function testWideCodePoint(cp: number): boolean {
+    return cp >= 0x1100 && (
+      cp <= 0x115f ||
+      (cp >= 0xa960 && cp <= 0xa97c) ||
+      cp === 0x2329 || cp === 0x232a ||
+      (cp >= 0x2e80 && cp <= 0xa4cf && cp !== 0x303f) ||
+      (cp >= 0xac00 && cp <= 0xd7a3) ||
+      (cp >= 0xd7b0 && cp <= 0xd7fb) ||
+      (cp >= 0xf900 && cp <= 0xfaff) ||
+      (cp >= 0xfe10 && cp <= 0xfe19) ||
+      (cp >= 0xfe30 && cp <= 0xfe6f) ||
+      (cp >= 0xff01 && cp <= 0xff60) ||
+      (cp >= 0xffe0 && cp <= 0xffe6) ||
+      (cp >= 0x20000 && cp <= 0x2fffd) ||
+      (cp >= 0x30000 && cp <= 0x3fffd)
+    );
+  }
+
+  function testCouldBeEmoji(segment: string): boolean {
+    const cp = segment.codePointAt(0) ?? 0;
+    return (
+      (cp >= 0x1f000 && cp <= 0x1fbff) ||
+      (cp >= 0x2300 && cp <= 0x23ff) ||
+      (cp >= 0x2600 && cp <= 0x27bf) ||
+      (cp >= 0x2b50 && cp <= 0x2b55) ||
+      segment.includes("\uFE0F") ||
+      segment.includes("\u200D")
+    );
+  }
+
+  // Test oracle modelled after Pi TUI's visibleWidth contract: strip terminal
+  // control sequences, segment graphemes, count CJK/fullwidth/emoji as wide,
+  // and treat mark-only clusters as zero-width.
+  function visibleWidth(s: string): number {
+    const stripped = stripTestTerminalEscapes(s.replace(/\t/g, "   "));
+    let w = 0;
+    for (const { segment } of testSegmenter.segment(stripped)) {
+      const cps = [...segment].map((ch) => ch.codePointAt(0) ?? 0);
+      if (cps.every(testZeroWidthCodePoint)) continue;
+      const cp = cps.find((c) => !testZeroWidthCodePoint(c)) ?? cps[0] ?? 0;
+      w += testCouldBeEmoji(segment) || (cp >= 0x1f1e6 && cp <= 0x1f1ff) || testWideCodePoint(cp) ? 2 : 1;
+    }
+    return w;
+  }
+
+  it("pure CJK line does not exceed requested width", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    // 10 Chinese characters → visible width 20
+    comp.setText("媒体上传一律用数据删除检查不做协议");
+    const lines = comp.render(15);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(15);
+    }
+  });
+
+  it("mixed ASCII + CJK line is width-aware truncated", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    // "AB" = 2, "媒体上传" = 8, "CD" = 2 → total 12
+    comp.setText("AB媒体上传CD");
+    const lines = comp.render(8);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(8);
+    }
+  });
+
+  it("ANSI escape sequences are preserved and not counted toward width", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    // Red color codes around CJK text
+    const red = "\x1b[31m";
+    const reset = "\x1b[0m";
+    comp.setText(`${red}媒体上传一律用数据删除检查不做协议${reset}`);
+    const lines = comp.render(10);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(10);
+      // ANSI codes must survive
+      expect(line).toContain(red);
+    }
+  });
+
+  it("the real crash line (CJK mixed with ASCII) fits within terminal width", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    // The actual line that caused the crash in pi-crash.log:
+    // visible width was 161, terminal was 147
+    const crashLine =
+      "  - **媒体上传**: 一律用 data URL / base64。删除 `KimiFiles` 和 `isinstance(chat_provider, Kimi)` 检查。不做 `MediaUploader` 协议，除非未来出现真实 provider 需求。";
+    comp.setText(crashLine);
+    const lines = comp.render(147);
+    for (const line of lines) {
+      const w = visibleWidth(line);
+      expect(w).toBeLessThanOrEqual(147);
+    }
+  });
+
+  it("does not keep an emoji when it would exceed the render width", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    // Pi's TUI counts RGI emoji as width 2. Keeping the emoji here would
+    // render as width 6 in a width-5 component and trip the TUI guard.
+    comp.setText("AAAA😀");
+    expect(comp.render(5)).toEqual(["AAAA"]);
+  });
+
+  it("does not emit a dangling escape byte when truncating before an APC sequence", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    comp.setText("AAAA\x1b_marker\x07B");
+    expect(comp.render(5)).toEqual(["AAAA\x1b_marker\x07B"]);
+  });
+
+  it("counts visible text between OSC 8 ST-terminated hyperlink sequences", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    const open = "\x1b]8;;https://example.com\x1b\\";
+    const close = "\x1b]8;;\x1b\\";
+    comp.setText(`AAAA${open}B${close}C`);
+    expect(comp.render(5)).toEqual([`AAAA${open}B${close}`]);
+  });
+
+  it("does not count standalone combining marks toward render width", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    // Pi's visibleWidth treats mark-only grapheme clusters as zero-width.
+    comp.setText("\u0301ABCDE");
+    expect(comp.render(5)).toEqual(["\u0301ABCDE"]);
+  });
+
+  it("truncateAnsiLine returns empty for maxWidth 0 or negative", async () => {
+    const mod = await import("../../src/adapters/pi/mcp-bridge.js");
+    const { truncateAnsiLine } = mod as unknown as {
+      truncateAnsiLine: (line: string, maxWidth: number) => string;
+    };
+    expect(truncateAnsiLine("媒体上传", 0)).toBe("");
+    expect(truncateAnsiLine("媒体上传", -1)).toBe("");
+  });
+
+  it("Hangul Extended-A/B characters are correctly width-aware (#665)", async () => {
+    const { PiTextComponent } = await import("../../src/adapters/pi/mcp-bridge.js");
+    const comp = new PiTextComponent();
+    // Hangul Jamo Extended-A: U+A960..U+A97C (ꥠ..ꥼ)
+    // Hangul Jamo Extended-B: U+D7B0..U+D7FB (ퟀ..ퟻ)
+    // Mix with ASCII: "A" = 1, "ꥠꥡퟰퟱ" = 8, "B" = 1 → total 10
+    const hangulExtA = "\uA960\uA961"; // ꥠꥡ
+    const hangulExtB = "\uD7B0\uD7B1"; // ퟰퟱ
+    comp.setText(`A${hangulExtA}${hangulExtB}B`);
+    const lines = comp.render(4);
+    for (const line of lines) {
+      expect(visibleWidth(line)).toBeLessThanOrEqual(4);
+    }
+    // Must actually truncate (total width 6 > 4)
+    const totalW = lines.reduce((sum, l) => sum + visibleWidth(l), 0);
+    expect(totalW).toBeLessThanOrEqual(4);
+  });
+});

--- a/tests/scripts/asymmetric-drift-assert.test.ts
+++ b/tests/scripts/asymmetric-drift-assert.test.ts
@@ -121,12 +121,20 @@ describe("Issue #531 — asymmetric-drift invariant", () => {
   });
 
   test("npm pack dry-run contains the Claude manifest, runtime bundles, start.mjs, and skills (#658)", () => {
-    const r = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+    const isWin = process.platform === "win32";
+    const r = spawnSync(isWin ? "npm.cmd" : "npm", ["pack", "--dry-run", "--json"], {
       cwd: ROOT,
       encoding: "utf-8",
       timeout: 30_000,
+      ...(isWin ? { shell: true } : {}),
     });
-    expect(r.status, `npm pack failed: stderr=${r.stderr} stdout=${r.stdout}`).toBe(0);
+    const spawnErr = r.error
+      ? `${r.error.name}: ${r.error.message}`
+      : "(none)";
+    expect(
+      r.status,
+      `npm pack failed: status=${String(r.status)} signal=${String(r.signal)} error=${spawnErr} stderr=${String(r.stderr)} stdout=${String(r.stdout)}`,
+    ).toBe(0);
     const pack = JSON.parse(r.stdout) as Array<{ files: Array<{ path: string }> }>;
     const files = new Set(pack[0]?.files?.map((f) => f.path) ?? []);
     expect(files).toContain(".claude-plugin/plugin.json");


### PR DESCRIPTION
## Summary
This PR fixes Pi TUI crashes caused by mixed-width lines where rendered visible width exceeded terminal width (issue #665).

It updates Pi bridge truncation to be width-aware for:
- Chinese/CJK full-width text
- Korean (including Hangul Extended-A/B ranges)
- Emoji and grapheme clusters
- ANSI/OSC/APC control sequences (including OSC 8 ST-terminated hyperlinks)
- Zero-width combining marks

## Root Cause
PiTextComponent truncation in src/adapters/pi/mcp-bridge.ts used simplified character counting that could diverge from Pi TUI visible-width rules, allowing lines to overflow the terminal width guard.

## Changes
- Switched truncation logic to grapheme-aware iteration (Intl.Segmenter)
- Added a terminal escape scanner for CSI/OSC/APC sequences to avoid dangling/incomplete escapes
- Added width handling for emoji and zero-width graphemes
- Preserved terminal-safe truncation behavior while keeping ANSI control sequences intact

## Tests
Added and updated regression tests in tests/adapters/pi-mcp-bridge.test.ts for:
- Real crash scenario from #665
- Emoji boundary truncation
- APC truncation safety (no dangling escape byte)
- OSC 8 ST hyperlink handling
- Zero-width combining marks
- CJK + Hangul width-aware truncation

## Verification
- pnpm exec vitest run tests/adapters/pi-mcp-bridge.test.ts
- pnpm run typecheck
- pnpm exec vitest run tests/adapters

Closes #665