### PR TITLE
fix(server): add z.preprocess coercions to ctx_fetch_and_index force and requests params

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2793,13 +2793,15 @@ server.registerTool(
           "Label for the indexed content when using single `url` (e.g., 'React useEffect docs', 'Supabase Auth API'). For batch, put source in each requests entry.",
         ),
       requests: z
-        .array(
-          z.object({
-            url: z.string().describe("URL to fetch"),
-            source: z.string().optional().describe("Label for this URL's indexed content"),
-          }),
+        .preprocess(
+          coerceJsonArray,
+          z.array(
+            z.object({
+              url: z.string().describe("URL to fetch"),
+              source: z.string().optional().describe("Label for this URL's indexed content"),
+            }),
+          ).min(1),
         )
-        .min(1)
         .optional()
         .describe(
           "Batch shape: array of {url, source?} entries. Use with concurrency>1 for parallel fetch. " +
@@ -2819,7 +2821,7 @@ server.registerTool(
           "Indexing is always serial regardless — only fetches race.",
         ),
       force: z
-        .boolean()
+        .preprocess(coerceBoolean, z.boolean())
         .optional()
         .describe("Skip cache and re-fetch even if content was recently indexed"),
     }),

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3347,8 +3347,10 @@ describe("ctx_fetch_and_index batch refactor", () => {
   test("schema accepts both legacy {url} and batch {requests}", () => {
     expect(fetchHandlerSrc).toContain('url: z.string().optional()');
     expect(fetchHandlerSrc).toContain('requests: z');
-    // Zod array of {url, source?}
-    expect(fetchHandlerSrc).toContain("z.object({\n            url: z.string()");
+    // Zod array of {url, source?} wrapped with preprocess for native plugin coercion
+    expect(fetchHandlerSrc).toContain('z.preprocess(');
+    expect(fetchHandlerSrc).toContain('coerceJsonArray');
+    expect(fetchHandlerSrc).toContain('url: z.string()');
     expect(fetchHandlerSrc).toContain('source: z.string().optional()');
   });
 
@@ -3453,6 +3455,20 @@ describe("ctx_fetch_and_index batch refactor", () => {
     expect(block).toContain("store.indexJSON");
     expect(block).toContain("store.indexPlainText");
     expect(block).toContain("store.index");
+  });
+
+  test("force and requests parameters coerce string types from in-process native plugins", () => {
+    // OpenCode/Kilo in-process plugin bridge stringifies primitive types
+    // (boolean → "false", array → "[]"). z.preprocess(coerceBoolean/coerceJsonArray)
+    // defends against this in the Zod parse step. This test verifies those
+    // preprocess wrappers are present (issue #627 follow-up).
+    const fetchBlockMatch = fetchHandlerSrc.match(/registerTool\(\s*"ctx_fetch_and_index"[\s\S]+?registerTool\(\s*"ctx_batch_execute"/);
+    expect(fetchBlockMatch).not.toBeNull();
+    const block = fetchBlockMatch![0];
+    // force must coerce "false"/"true" strings → boolean
+    expect(block).toMatch(/force:\s*z\s*\n?\s*\.preprocess\(\s*coerceBoolean\s*,\s*z\.boolean\(\)\)/);
+    // requests must coerce JSON-stringified arrays
+    expect(block).toMatch(/requests:\s*z\s*\n?\s*\.preprocess\(\s*coerceJsonArray\s*,/);
   });
 });
 


### PR DESCRIPTION
## What / Why / How

The OpenCode/Kilo in-process native plugin bridge stringifies primitive types when passing arguments to MCP tools: boolean `false` becomes `"false"` and array `[]` becomes `"[]"`.

Other tools (`ctx_execute`, `ctx_search`, `ctx_batch_execute`, `ctx_purge`) already use `z.preprocess(coerceBoolean/coerceJsonArray)` to handle this coercion in their inputSchema. However, `ctx_fetch_and_index` was missing these wrappers on its `force` and `requests` parameters, causing validation failures like:

```
"code": "invalid_type", "expected": "boolean", "received": "string", "path": ["force"]
```

This is a follow-up to the fix pattern established in issue #627, which added `coerceBoolean` and `coerceJsonArray` preprocessors — `ctx_fetch_and_index` was simply missed.

### Changes

- **src/server.ts**: Wrapped `force` with `z.preprocess(coerceBoolean, ...)` and `requests` with `z.preprocess(coerceJsonArray, ...)`
- **tests/core/server.test.ts**: Added schema-level assertion verifying preprocess wrappers are present. Updated existing schema tests to match the new structure.

## Affected platforms

- [x] OpenCode
- [x] KiloCode
- [x] All platforms (z.preprocess is a no-op when types are correct — fully backwards-compatible)

## Test plan

- Added test: "force and requests parameters coerce string types from in-process native plugins"
- Updated: "schema accepts both legacy {url} and batch {requests}"
- Full test suite: 259/260 passing (1 pre-existing JetBrains test failure unrelated to this change)

## Checklist

- [x] Tests added/updated (TDD)
- [x] npm test passes (existing failures unrelated)
- [x] No Windows path regressions
- [x] Targets next branch
