### PR TITLE
fix(server): comprehensive ctx_* tool description audit + WebFetch refusal (substitutes #654)

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ npm install -g context-mode
 | `ctx_execute_file` | Process files in sandbox. Raw content never leaves. | 45 KB → 155 B |
 | `ctx_index` | Chunk markdown into FTS5 with BM25 ranking. | 60 KB → 40 B |
 | `ctx_search` | Query indexed content with multiple queries in one call. | On-demand retrieval |
-| `ctx_fetch_and_index` | Fetch URL, chunk and index. 24h TTL cache — repeat calls skip network. `force: true` to bypass. Pass `requests: [{url, source}, ...]` + `concurrency: 1-8` for parallel multi-URL. | 60 KB → 40 B |
+| `ctx_fetch_and_index` | Fetch URL, chunk and index. Cache reuses content within TTL (default 24h, override per-call with `ttl: <ms>`). `ttl: 0` or `force: true` to bypass. Pass `requests: [{url, source}, ...]` + `concurrency: 1-8` for parallel multi-URL. | 60 KB → 40 B |
 | `ctx_stats` | Show context savings, call counts, and session statistics. | — |
 | `ctx_doctor` | Diagnose installation: runtimes, hooks, FTS5, versions. | — |
 | `ctx_upgrade` | Upgrade to latest version from GitHub, rebuild, reconfigure hooks. | — |
@@ -1036,11 +1036,12 @@ Search results use intelligent extraction instead of truncation. Instead of retu
 
 ### TTL Cache
 
-Indexed content persists in a per-project SQLite database at `~/.context-mode/content/`. When `ctx_fetch_and_index` is called for a URL that was already indexed within the last 24 hours, the fetch is skipped entirely. The model searches the existing index directly.
+Indexed content persists in a per-project SQLite database at `~/.context-mode/content/`. When `ctx_fetch_and_index` is called for a URL that was already indexed within its TTL window, the fetch is skipped entirely and the model searches the existing index directly.
 
-- **Fresh (<24h):** Returns a cache hint (0.3KB) instead of re-fetching (48KB+). Model proceeds to `ctx_search`.
-- **Stale (>24h):** Re-fetches silently. No user action needed.
-- **`force: true`:** Bypasses cache and re-fetches regardless of TTL.
+- **Default TTL:** 24 hours. Override per-call with `ttl: <milliseconds>` (PR #666). Longer for stable specs, shorter for changelogs you want re-checked often.
+- **Cache hit (within TTL):** Returns a cache hint (~0.3KB) instead of re-fetching (48KB+). Model proceeds to `ctx_search`.
+- **Cache miss (TTL expired):** Re-fetches silently. No user action needed.
+- **`ttl: 0`** or **`force: true`:** Bypasses cache and re-fetches regardless of freshness.
 - **14-day cleanup:** Content databases and sources older than 14 days are removed on startup.
 
 This means `--continue` sessions preserve indexed docs across restarts. No re-fetching, no wasted context tokens.

--- a/docs/adr/0002-tool-description-style.md
+++ b/docs/adr/0002-tool-description-style.md
@@ -45,23 +45,91 @@ All `ctx_*` tool descriptions registered via `server.registerTool()`
 **MUST** follow this structure:
 
 ```text
-<1-line role definition>
+<1-line headline, <= 120 chars, imperative-positive>
 
 WHEN:
   - <bulleted positive trigger conditions>
 
-WHEN NOT (optional):
+WHEN NOT:
   - <bulleted positive disambiguation from sibling tools>
 
 RETURNS:
-  <what the agent sees back>
+  <what the agent sees back, 1-3 lines>
 
-EXAMPLE:
-  <one concrete call with realistic params>
+EXAMPLE: <one canonical call with realistic params>
 ```
 
 The legacy alias `WHEN TO USE:` is accepted as a transitional form (see
 `ctx_index`) but new tools MUST use `WHEN:`.
+
+### Canonical structure (locked rubric — PR #683 WS3)
+
+Future contributors do **not** get to re-invent section names. The
+contract test in `tests/core/server.test.ts` enforces every rule below
+on every commit; this section is the source of truth.
+
+1. **Section order MUST be**
+   `WHEN -> WHEN NOT -> RETURNS -> EXAMPLE`.
+   Positive selection cues precede negative disambiguation (audit
+   rubric #2). A tool MAY omit `WHEN NOT:` when it has no sibling-tool
+   ambiguity, but every other canonical section is mandatory.
+
+2. **Bullets MUST use markdown `- ` only.** Numeric (`1.`, `1-`),
+   asterisk (`* `), and unicode (`•`) bullets are rejected. Numbering
+   inside a routing-target description is also rejected because each
+   bullet should be independently true, not sequenced. Numbered
+   hierarchies live in `hooks/routing-block.mjs` (priority order in a
+   system-prompt injection is a different prompt surface, governed by
+   ADR-0003 sibling concerns).
+
+3. **Section headers MUST be UPPERCASE + colon at the start of a
+   line.** The token uniformity matters because GPT, Gemini, Llama,
+   and Claude tokenize lowercase / mixed-case section names
+   differently — uppercase headers are the only shape that hits a
+   single token across families.
+
+4. **Two-space bullet indent under each header.** Example shape:
+   ```
+   WHEN:
+     - First positive cue
+     - Second positive cue
+   ```
+   The contract test does not assert the literal indent count (LLMs
+   are tolerant of 2 vs 4) but every shipped description in
+   `src/server.ts` uses two-space indent for visual uniformity.
+
+5. **One blank line between sections.**
+
+6. **One canonical `EXAMPLE:` per tool.** Tools with two valid input
+   shapes (e.g. `ctx_purge` per-session vs per-project) MAY include
+   two EXAMPLE lines back-to-back. Keep them adjacent so the
+   description does not interleave examples with other sections.
+
+7. **Carve-outs (per-tool, allow-listed in the contract test):**
+   - `ctx_purge`: `DESTRUCTIVE`, `SCOPES`, `CONTRACT`. Justified by
+     Probe 4 empirical evidence — heavy framing on this tool
+     preserves parameter fidelity on small models. `DESTRUCTIVE` here
+     is accurate user-facing signaling, distinct from the
+     cross-LLM-bias negative framing the rubric forbids.
+
+### Cross-LLM rationale
+
+The audit ran 38 A/B trials × 6 probes across Haiku and Sonnet. The
+canonical structure above is the lowest common denominator that:
+
+- Hits a single token across **Claude, GPT, Gemini, Llama** families
+  for every section header (uppercase + colon).
+- Avoids tokens flagged by Constitutional AI-style RLHF priors
+  (`FORBIDDEN`, `BLOCKED`, `NEVER`, `MANDATORY`).
+- Eliminates negative-example leakage (emoji bullets — rubric #4,
+  Probe 3).
+- Leaves room for accurate signaling where empirically required
+  (Probe 4 `ctx_purge` carve-out).
+
+The structure is locked to make future PRs ungameable: a contributor
+proposing a new tool either adheres to it (contract test passes) or
+opens a new ADR amending this one (contract test fails until the
+allow-list is updated).
 
 ### Forbidden tokens
 
@@ -100,10 +168,12 @@ Descriptions SHOULD be ≤ 1,000 characters. Hard cap 1,500.
   by design (diagnostic / GUI affordances, not routing targets).
 - `ctx_upgrade` — `MUST` is permitted per the post-call obligation rule
   above.
-- `ctx_purge` — rewrite deferred per Probe 4 empirical evidence (see
-  Consequences). A naïve rewrite would regress parameter fidelity on
-  Haiku (5/5 → 3/5). The follow-up rewrite PR must run a tri-LLM probe
-  (Haiku / Sonnet / Opus) and gate merge on that probe.
+- `ctx_purge` — rewritten in PR #683 WS2 with carve-outs (`DESTRUCTIVE`,
+  `SCOPES`, `CONTRACT`) that preserve the parameter-fidelity discipline
+  Probe 4 measured (5/5 vs 3/5 on Haiku). The rewrite still meets the
+  canonical `WHEN / WHEN NOT / RETURNS / EXAMPLE` structure; the carve-out
+  headers coexist with it. The empirical-validation gate is documented in
+  `tests/core/server.test.ts` `ALLOWED_EXTRA_SECTIONS`.
 
 ## Consequences
 
@@ -119,9 +189,12 @@ Descriptions SHOULD be ≤ 1,000 characters. Hard cap 1,500.
   lives in `hooks/routing-block.mjs` and `CLAUDE.md`, not in tool
   descriptions. That layer is correct because it runs as system-prompt
   injection, where exhortations belong.
-- `ctx_purge` rewrite is a separate PR with a tri-LLM probe gate.
-  Documented inline in `EXEMPT_FROM_FORBIDDEN_TOKENS` so future authors
-  see the empirical rationale, not just a quiet skip.
+- `ctx_purge` is rewritten in PR #683 WS2 with carve-out headers
+  (`DESTRUCTIVE`, `SCOPES`, `CONTRACT`) allow-listed by the contract
+  test's `ALLOWED_EXTRA_SECTIONS`. The rewrite preserves Probe 4's
+  parameter-fidelity discipline (accurate DESTRUCTIVE signal + explicit
+  SCOPES + CONTRACT block) while still meeting the canonical
+  `WHEN / WHEN NOT / RETURNS / EXAMPLE` structure.
 - New `ctx_*` tools added in future PRs MUST cite this ADR in the PR
   description and pass the contract test.
 

--- a/docs/adr/0002-tool-description-style.md
+++ b/docs/adr/0002-tool-description-style.md
@@ -1,0 +1,147 @@
+# ADR-0002 — Tool description voice and structure
+
+- **Status**: Accepted
+- **Date**: 2026-05-24
+- **PR**: #683 (substitutes #654)
+- **Supersedes**: organic, undocumented description drift
+- **Reviewers**: owner Mert, empirical A/B (38 trials × 6 probes on Haiku + Sonnet)
+
+## Context
+
+`context-mode` registers 11 `ctx_*` MCP tools via `server.registerTool()` in
+`src/server.ts`. Each tool description is read by every host LLM
+(Claude / GPT / Gemini / Llama / …) at tool-selection time. Over many releases
+the corpus drifted toward forbidding language — `MANDATORY:`, `NEVER`,
+`Do NOT`, `REFUSAL RULES`, `DESTRUCTIVE`, `NON-NEGOTIABLE`, `PREFER` — because
+descriptions were patched defensively after each misroute. There was no
+documented style guide and no contract test, so each new tool inherited
+whichever voice the previous author preferred.
+
+PR #654 (kerneltoast) surfaced the cost of that drift: the single
+hortatory word `"blocked"` in a routing deny reason was misread by
+Opus 4.6 as a safety/network restriction, causing the agent to capitulate
+to training data instead of using the redirected tool.
+
+A full audit (see `TOOL-DESCRIPTIONS-AUDIT.md`) ran 38 A/B trials across
+6 empirical probes on Haiku and Sonnet against the current descriptions
+and proposed rewrites. Findings:
+
+- Heavy forbidding framing degrades tool selection on some tools (mild
+  but reproducible).
+- Heavy framing **improves** parameter fidelity on small models for
+  complex-contract tools (`ctx_purge` Probe 4: 5/5 vs 3/5). The
+  intuition that "softer == safer" is wrong for at least one tool, so
+  rewrites cannot be one-size-fits-all and **must be probe-gated**.
+- PR #654's `"blocked"` → `"redirected"` wording fix is genuinely
+  corrective on Opus 4.6 (6/6 → 0/6 capitulation on the stress probe),
+  invisible on Sonnet (6/6 capitulate either way), and mildly regressive
+  on Haiku without a paired imperative.
+- ✅ / ❌ emoji bullets inside descriptions tokenize inconsistently across
+  Llama / Gemini families and act as negative-example leakage (rubric #4).
+
+## Decision
+
+All `ctx_*` tool descriptions registered via `server.registerTool()`
+**MUST** follow this structure:
+
+```text
+<1-line role definition>
+
+WHEN:
+  - <bulleted positive trigger conditions>
+
+WHEN NOT (optional):
+  - <bulleted positive disambiguation from sibling tools>
+
+RETURNS:
+  <what the agent sees back>
+
+EXAMPLE:
+  <one concrete call with realistic params>
+```
+
+The legacy alias `WHEN TO USE:` is accepted as a transitional form (see
+`ctx_index`) but new tools MUST use `WHEN:`.
+
+### Forbidden tokens
+
+Descriptions MUST NOT contain:
+
+| Token | Rationale |
+|---|---|
+| `MANDATORY:` (as opener) | Developer-policy phrasing, not a selection cue. |
+| `BLOCKED` | Reserved for ADR-0003 CASE B (real policy restriction). |
+| `PREFER X OVER Y` | Frames the choice as a tradeoff; use positive `WHEN:` instead. |
+| `Do NOT use/read/pull` | Affirmative beats negative (rubric #2). |
+| `Never use` | Same — express as `WHEN NOT:`. |
+| `SESSION STATE` clause | Skill/role persistence is a routing-block.mjs concern. |
+| `✅` / `❌` emoji bullets | Tokenizer inconsistency across LLM families + negative-example leakage. |
+
+### Allowed imperative hierarchy (RFC 2119)
+
+The MUST / SHOULD / MAY hierarchy is preserved ONLY for **post-call
+obligations** on the agent — never for tool-selection cues.
+
+- **MUST**: post-call obligation. Example (allowed): `ctx_upgrade` says
+  "you MUST run the returned shell command and display the output as a
+  checklist." This is a post-call contract, not a selection nudge.
+- **SHOULD**: strong preference with allowed exceptions.
+- **MAY**: optional capability.
+
+Selection cues use the `WHEN:` / `WHEN NOT:` structure instead.
+
+### Length
+
+Descriptions SHOULD be ≤ 1,000 characters. Hard cap 1,500.
+
+### Exemptions
+
+- `ctx_stats`, `ctx_doctor`, `ctx_insight` — minimal one-line descriptions
+  by design (diagnostic / GUI affordances, not routing targets).
+- `ctx_upgrade` — `MUST` is permitted per the post-call obligation rule
+  above.
+- `ctx_purge` — rewrite deferred per Probe 4 empirical evidence (see
+  Consequences). A naïve rewrite would regress parameter fidelity on
+  Haiku (5/5 → 3/5). The follow-up rewrite PR must run a tri-LLM probe
+  (Haiku / Sonnet / Opus) and gate merge on that probe.
+
+## Consequences
+
+- PR #683 rewrites the six tools where the audit showed clear voice
+  drift: `ctx_execute`, `ctx_execute_file`, `ctx_batch_execute`,
+  `ctx_search`, `ctx_index`, `ctx_fetch_and_index`.
+- A new contract test in `tests/core/server.test.ts` (`tool description
+  style contract (#683 ADR-0002)`) parses every `server.registerTool()`
+  block and enforces the forbidden-token list + WHEN: requirement on
+  every commit. Cheap (no LLM call), runs on every commit, catches
+  drift before merge.
+- Voice-of-trainer text (`THINK IN CODE`, `MANDATORY routing rules`)
+  lives in `hooks/routing-block.mjs` and `CLAUDE.md`, not in tool
+  descriptions. That layer is correct because it runs as system-prompt
+  injection, where exhortations belong.
+- `ctx_purge` rewrite is a separate PR with a tri-LLM probe gate.
+  Documented inline in `EXEMPT_FROM_FORBIDDEN_TOKENS` so future authors
+  see the empirical rationale, not just a quiet skip.
+- New `ctx_*` tools added in future PRs MUST cite this ADR in the PR
+  description and pass the contract test.
+
+## Alternatives considered
+
+- **Status quo (no style policy).** Rejected — PR #654 evidence shows
+  organic drift directly causes user-visible bugs (Opus 4.6 capitulation).
+- **Single hortatory voice across all descriptions.** Rejected — Probe 4
+  evidence: heavy framing helps `ctx_purge` and hurts `ctx_execute`.
+  One-size-fits-all is empirically wrong.
+- **Per-tool author discretion.** Rejected — that's what we already had,
+  and it produced the bug.
+- **Rewrite all 11 in one PR.** Rejected — large diff, hard to revert,
+  blocks on style debates, and would regress `ctx_purge` per Probe 4.
+  PR #683 explicitly defers `ctx_purge`.
+
+## References
+
+- `TOOL-DESCRIPTIONS-AUDIT.md` (§3 audit table, §5 probe evidence, §6
+  verbatim rewrites)
+- `GRILL-Q1-VERDICT.md` (SESSION STATE drop rationale)
+- ADR-0003 — Routing deny reasons MUST distinguish redirect from
+  restriction (sibling decision, also from PR #683)

--- a/docs/adr/0003-routing-deny-reasons.md
+++ b/docs/adr/0003-routing-deny-reasons.md
@@ -1,0 +1,103 @@
+# ADR-0003 — Routing deny reasons: redirect ≠ restriction
+
+- **Status**: Accepted
+- **Date**: 2026-05-24
+- **PR**: #683 (substitutes #654)
+- **Motivating bug**: kerneltoast / @noctivoro / Mert reproduced on Opus 4.6
+- **Reviewers**: owner Mert
+
+## Context
+
+`hooks/core/routing.mjs` returns deny reasons for intercepted Bash, Read,
+Grep, and WebFetch calls. These reasons are displayed to the agent at
+runtime and shape the agent's next-action decision. PR #654
+(`kerneltoast`) reproduced that the bare word `"blocked"` in WebFetch's
+deny reason (`"WebFetch blocked"`) was misread by Opus 4.6 as a
+network / security restriction, causing the agent to capitulate to
+training data instead of using the redirected tool.
+
+The intent of the routing layer is to **redirect** the agent to a
+context-efficient alternative (`ctx_fetch_and_index` for WebFetch,
+`ctx_execute` for large-output Bash). It is NOT a security gate, and
+its denial text MUST NOT read like one.
+
+There is a real, separate set of denials in `routing.mjs` that ARE
+security restrictions: the deny-pattern check (curl to private IPs,
+sensitive-path reads, etc.). Those denials are correct to read like
+restrictions — they are restrictions.
+
+The bug PR #654 caught was that a single deny-reason string in CASE A
+was using the vocabulary of CASE B. The fix is to formalize the
+distinction so any future hook author cannot make the same mistake.
+
+## Decision
+
+Routing deny reasons MUST distinguish two cases:
+
+### CASE A — Routing redirect
+
+The action is supported, via a different tool, for context-window or
+efficiency reasons.
+
+- **Opening verb**: "redirected"
+- **MUST state**: "this is NOT a network / security restriction"
+- **MUST specify**: the alternative tool to use
+- **MUST end with**: an imperative next-action — e.g. "retry if it fails
+  with a transient error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)"
+
+The word `BLOCKED` MUST NOT appear bare in CASE A. It is reserved for
+true policy denial (CASE B) where the agent's correct response IS to
+stop and inform the user.
+
+### CASE B — True security / policy restriction
+
+The action is denied per deny pattern, security gate, or unsupported
+sandbox capability.
+
+- **Opening verb**: "denied" or "blocked by security policy"
+- **MUST cite**: the pattern or rule violated
+- **MAY suggest**: a safe alternative
+
+## Consequences
+
+- PR #654's wording fix (`"blocked"` → `"redirected"`) becomes formal
+  policy.
+- PR #683 already lands the wording change at
+  `hooks/core/routing.mjs:804` and adds the `EAI_AGAIN | ETIMEDOUT |
+  ETIMEOUT | ENETUNREACH | EPERM` transient-DNS retry hint to both
+  `routing.mjs` (WebFetch denial) and `src/server.ts:2783-2795`
+  (`ctx_fetch_and_index` subprocess fetch failure) so the two surfaces
+  speak with one voice.
+- Existing `routing.mjs` deny reasons audited for CASE A / CASE B
+  classification:
+  - L707 (curl / wget redirect) — CASE A
+  - L738 (inline HTTP redirect) — CASE A
+  - L803 (WebFetch redirect) — CASE A
+  - L652, L844, L862, L873, L894 (security deny patterns) — CASE B
+- Test substring expectations in `tests/hooks/*` updated where they
+  asserted the literal word `"blocked"` for CASE A paths.
+- A future contract test on `routing.mjs` deny reasons (similar to PR
+  #683's `tool description style contract`) is out of scope here but
+  recommended as a follow-up — the rule is already mechanically
+  checkable.
+
+## Alternatives considered
+
+- **Keep "blocked" everywhere; document the convention.** Rejected —
+  documentation doesn't change LLM behaviour, the wording does. PR
+  #654's empirical reproduction is the disqualifying evidence.
+- **Remove the denial path entirely; just silently invoke the
+  alternative tool.** Rejected — the agent needs to know its tool call
+  was rerouted (for telemetry, for the user-visible audit trail, and so
+  it can adjust its plan).
+- **Use the same wording in both cases, distinguish by exit code.**
+  Rejected — the agent reads the prose, not the exit code, when
+  deciding whether to retry or capitulate.
+
+## References
+
+- PR #654 (kerneltoast) — original bug report and reproduction
+- PR #683 — implementation + ADR
+- ADR-0002 — Tool description voice and structure (companion ADR,
+  same PR)
+- `TOOL-DESCRIPTIONS-AUDIT.md` §2 — PR #654 verdict and probe evidence

--- a/docs/adr/0003-routing-deny-reasons.md
+++ b/docs/adr/0003-routing-deny-reasons.md
@@ -40,11 +40,14 @@ Routing deny reasons MUST distinguish two cases:
 The action is supported, via a different tool, for context-window or
 efficiency reasons.
 
-- **Opening verb**: "redirected to <ctx_tool> for context-window
-  efficiency" — affirmative routing intent, no negation.
-- **MUST affirm capability**: "<ctx_tool> has full network access"
+- **Opening verb**: `"redirected to <ctx_tool>"` — affirmative routing
+  intent, no negation, no org-rationale (the agent's job is to act on the
+  redirect, not to audit policy).
+- **MUST affirm capability**: `"<ctx_tool> has full network access"`
   (positive frame of the same signal the old `NOT a network restriction`
-  parenthetical tried to deliver).
+  parenthetical tried to deliver — and the same signal the
+  `for context-window efficiency` rationale prescription also tried to
+  deliver before the 2026-05-24 second amendment).
 - **MUST specify**: the alternative tool to use, by name, as an
   imperative call (e.g. `Call ctx_fetch_and_index(url, source) now`).
 - **MUST end with**: a positive imperative retry hint —
@@ -53,6 +56,10 @@ efficiency reasons.
 - **MUST NOT contain**: bare-NOT negations (`NOT a network restriction`,
   `Do NOT retry with curl`, etc.). See §Amendment below for the
   empirical rationale.
+- **MUST NOT contain**: org-rationale prefaces (`for context-window
+  efficiency`, `for performance`, etc.). The redirect verb + the
+  capability affirmation already carry the full action signal; rationale
+  is metadata, not action input. See §Second amendment below.
 
 The word `BLOCKED` MUST NOT appear bare in CASE A. It is reserved for
 true policy denial (CASE B) where the agent's correct response IS to
@@ -82,22 +89,43 @@ sibling negation in the very next clause. PR #683 follow-up
 (this amendment) eradicates the negation construct entirely:
 
 - Replace `"(context-window optimization, NOT a network restriction)"`
-  with affirmative `"to <ctx_tool> for context-window efficiency"` +
-  separate affirmative sentence `"<ctx_tool> has full network
-  access."`.
+  with the affirmative sentence `"<ctx_tool> has full network access."`
+  (originally also prescribed a `"for context-window efficiency"` opening
+  preface — see §Second amendment below for why that prescription was
+  dropped).
 - Replace `"Do NOT retry with curl/wget"` with positive
   `"Retry the same call on a transient DNS error (...)"` — the
   affirmative retry hint IS the next-action signal; the prohibition was
   redundant once the routing is correct.
 
+## Second amendment (PR #683 mid-review, 2026-05-24)
+
+Mert flagged on review of the first amendment: the prescribed opening
+`"redirected to <ctx_tool> for context-window efficiency"` itself
+carries org-rationale that the agent does not need to act. The agent's
+job is to (a) understand a redirect happened, (b) make the correct next
+call, (c) know it has the capability to do so, (d) know when to retry.
+"For X reason" is post-hoc justification — pure prompt overhead.
+
+Compare to HTTP 301 `Moved Permanently` — the response carries `Location:
+<new-url>` and the client uses it. The server never appends
+`"for SEO efficiency"` or `"for caching strategy"`. The redirect verb
++ the new target are the entire action signal.
+
+The capability affirmation (`"<ctx_tool> has full network access"`)
+already delivers the substantive content the rationale was trying to
+carry — that this is a routing optimization, not a capability denial.
+The rationale preface was double-encoding that signal.
+
 The four CASE A sites in `hooks/core/routing.mjs` (L707 curl/wget,
 L738 inline HTTP, L751 build tool, L804 WebFetch) all conform to the
-amended rubric after this PR. A contract test in
+second-amended rubric after this PR. A contract test in
 `tests/core/server.test.ts` (`ADR-0003 CASE A: routing.mjs redirect
 deny reasons`) locks the rule: every CASE A string MUST open with
 "redirected", MUST NOT contain bare uppercase `BLOCKED`, MUST name at
 least one `ctx_*` alternative, MUST NOT contain `"NOT a network"`,
-MUST NOT contain `"Do NOT retry"`.
+MUST NOT contain `"Do NOT retry"`, MUST NOT contain
+`"for context-window efficiency"` (or sibling org-rationale prefaces).
 
 ## Consequences
 

--- a/docs/adr/0003-routing-deny-reasons.md
+++ b/docs/adr/0003-routing-deny-reasons.md
@@ -1,6 +1,7 @@
 # ADR-0003 — Routing deny reasons: redirect ≠ restriction
 
-- **Status**: Accepted
+- **Status**: Accepted — amended 2026-05-24 (PR #683 follow-up) to drop the
+  `"NOT a network restriction"` negation prescription; see §Amendment.
 - **Date**: 2026-05-24
 - **PR**: #683 (substitutes #654)
 - **Motivating bug**: kerneltoast / @noctivoro / Mert reproduced on Opus 4.6
@@ -39,11 +40,19 @@ Routing deny reasons MUST distinguish two cases:
 The action is supported, via a different tool, for context-window or
 efficiency reasons.
 
-- **Opening verb**: "redirected"
-- **MUST state**: "this is NOT a network / security restriction"
-- **MUST specify**: the alternative tool to use
-- **MUST end with**: an imperative next-action — e.g. "retry if it fails
-  with a transient error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)"
+- **Opening verb**: "redirected to <ctx_tool> for context-window
+  efficiency" — affirmative routing intent, no negation.
+- **MUST affirm capability**: "<ctx_tool> has full network access"
+  (positive frame of the same signal the old `NOT a network restriction`
+  parenthetical tried to deliver).
+- **MUST specify**: the alternative tool to use, by name, as an
+  imperative call (e.g. `Call ctx_fetch_and_index(url, source) now`).
+- **MUST end with**: a positive imperative retry hint —
+  `"Retry the same call on a transient DNS error (EAI_AGAIN,
+  ETIMEDOUT, ENETUNREACH)"`.
+- **MUST NOT contain**: bare-NOT negations (`NOT a network restriction`,
+  `Do NOT retry with curl`, etc.). See §Amendment below for the
+  empirical rationale.
 
 The word `BLOCKED` MUST NOT appear bare in CASE A. It is reserved for
 true policy denial (CASE B) where the agent's correct response IS to
@@ -57,6 +66,38 @@ sandbox capability.
 - **Opening verb**: "denied" or "blocked by security policy"
 - **MUST cite**: the pattern or rule violated
 - **MAY suggest**: a safe alternative
+
+## Amendment (PR #683 follow-up, 2026-05-24)
+
+The original CASE A rubric required the parenthetical `"this is NOT a
+network / security restriction"`. Mert flagged on review that this
+prescription itself violates ADR-0002 rubric #2 (affirmative beats
+negation): the bare-NOT construct primes the very frame it tries to
+deny (ironic process theory). `TOOL-DESCRIPTIONS-AUDIT.md §2 Probe 3`
+already documented this — the NOT-parenthetical regressed Haiku
+capitulation rate from 0/6 → 2/6 vs the original "blocked" wording.
+
+PR #654 fixed the headline word (`blocked` → `redirected`) but kept the
+sibling negation in the very next clause. PR #683 follow-up
+(this amendment) eradicates the negation construct entirely:
+
+- Replace `"(context-window optimization, NOT a network restriction)"`
+  with affirmative `"to <ctx_tool> for context-window efficiency"` +
+  separate affirmative sentence `"<ctx_tool> has full network
+  access."`.
+- Replace `"Do NOT retry with curl/wget"` with positive
+  `"Retry the same call on a transient DNS error (...)"` — the
+  affirmative retry hint IS the next-action signal; the prohibition was
+  redundant once the routing is correct.
+
+The four CASE A sites in `hooks/core/routing.mjs` (L707 curl/wget,
+L738 inline HTTP, L751 build tool, L804 WebFetch) all conform to the
+amended rubric after this PR. A contract test in
+`tests/core/server.test.ts` (`ADR-0003 CASE A: routing.mjs redirect
+deny reasons`) locks the rule: every CASE A string MUST open with
+"redirected", MUST NOT contain bare uppercase `BLOCKED`, MUST name at
+least one `ctx_*` alternative, MUST NOT contain `"NOT a network"`,
+MUST NOT contain `"Do NOT retry"`.
 
 ## Consequences
 

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -704,7 +704,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         return mcpRedirect({
           action: "modify",
           updatedInput: {
-            command: `echo "context-mode: curl/wget redirected to ${t("ctx_execute")}. ${t("ctx_execute")} and ${t("ctx_fetch_and_index")} have full network access. Call ${t("ctx_execute")}(language, code) now to fetch, process, and print only the answer. Or call ${t("ctx_fetch_and_index")}(url, source) to fetch and index. Write pure JS with try/catch, no npm deps. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
+            command: `echo "context-mode: curl/wget redirected. Call ${t("ctx_execute")}(language, code) to fetch the URL, derive your answer in code, and print only the result — the raw HTTP body stays in the sandbox instead of entering your conversation. Or call ${t("ctx_fetch_and_index")}(url, source) when you want to query the response later via ${t("ctx_search")}. Both have full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
           },
           // D2 PRD Phase 3.1: marker payload for PostToolUse byte accounting.
           redirectMeta: {
@@ -735,7 +735,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
       return mcpRedirect({
         action: "modify",
         updatedInput: {
-          command: `echo "context-mode: Inline HTTP redirected to ${t("ctx_execute")}. ${t("ctx_execute")} has full network access. Call ${t("ctx_execute")}(language, code) now to fetch, process, and console.log() only the result. Write robust pure JS with try/catch, no npm deps. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
+          command: `echo "context-mode: Inline HTTP redirected. Call ${t("ctx_execute")}(language, code) to fetch, derive your answer in code, and console.log() only the result — the raw response body stays in the sandbox instead of entering your conversation. Full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
         },
       });
     }
@@ -748,7 +748,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
       return mcpRedirect({
         action: "modify",
         updatedInput: {
-          command: `echo "context-mode: Build tool redirected to ${t("ctx_execute")}. Call ${t("ctx_execute")}(language: \\"shell\\", code: \\"${safeCmd} 2>&1 | tail -30\\") to run and print only errors/summary. The sandbox keeps the verbose build log out of context."`,
+          command: `echo "context-mode: Build tool redirected. Call ${t("ctx_execute")}(language: \\"shell\\", code: \\"${safeCmd} 2>&1 | tail -30\\") to run the build and print only the tail — the verbose build log stays in the sandbox instead of entering your conversation. For more targeted output, replace \\"tail -30\\" with \\"grep -E '(error|warning|FAIL|✗|×)'\\" or similar, so only the lines that matter come back."`,
         },
       });
     }
@@ -801,7 +801,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
     const url = toolInput.url ?? "";
     return mcpRedirect({
       action: "deny",
-      reason: `context-mode: WebFetch redirected to ${t("ctx_fetch_and_index")}. ${t("ctx_fetch_and_index")} and ${t("ctx_execute")} have full network access. Call ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") now, then ${t("ctx_search")}(queries: [...]) to query the indexed content. Or call ${t("ctx_execute")}(language, code) to fetch, process, and console.log() only what you need (pure JS, no npm deps). Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH).`,
+      reason: `context-mode: WebFetch redirected. Call ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") to fetch + index the page, then ${t("ctx_search")}(queries: [...]) to query the indexed content — the raw page bytes stay in storage instead of entering your conversation. Or call ${t("ctx_execute")}(language, code) when you want to derive your answer in one round trip (parse, extract, count) without persisting the response. Both have full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH).`,
       // D2 PRD Phase 4.1: marker payload for PostToolUse byte accounting.
       redirectMeta: {
         tool: "WebFetch",

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -704,7 +704,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         return mcpRedirect({
           action: "modify",
           updatedInput: {
-            command: `echo "context-mode: curl/wget redirected (context-window optimization, NOT a network restriction). ${t("ctx_execute")} and ${t("ctx_fetch_and_index")} have full network access — retry if it fails with a transient DNS error. Think in Code — call ${t("ctx_execute")}(language, code) now to fetch, process, and print only the answer. Or ${t("ctx_fetch_and_index")}(url, source) to fetch and index. Write pure JS with try/catch, no npm deps. Do NOT retry with curl/wget."`,
+            command: `echo "context-mode: curl/wget redirected to ${t("ctx_execute")} for context-window efficiency. ${t("ctx_execute")} and ${t("ctx_fetch_and_index")} have full network access. Call ${t("ctx_execute")}(language, code) now to fetch, process, and print only the answer. Or call ${t("ctx_fetch_and_index")}(url, source) to fetch and index. Write pure JS with try/catch, no npm deps. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
           },
           // D2 PRD Phase 3.1: marker payload for PostToolUse byte accounting.
           redirectMeta: {
@@ -735,7 +735,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
       return mcpRedirect({
         action: "modify",
         updatedInput: {
-          command: `echo "context-mode: Inline HTTP redirected (context-window optimization, NOT a network restriction). ${t("ctx_execute")} has full network access — retry if it fails with a transient DNS error. Think in Code — call ${t("ctx_execute")}(language, code) now to fetch, process, and console.log() only the result. Write robust pure JS with try/catch, no npm deps. Do NOT retry with Bash."`,
+          command: `echo "context-mode: Inline HTTP redirected to ${t("ctx_execute")} for context-window efficiency. ${t("ctx_execute")} has full network access. Call ${t("ctx_execute")}(language, code) now to fetch, process, and console.log() only the result. Write robust pure JS with try/catch, no npm deps. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
         },
       });
     }
@@ -748,7 +748,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
       return mcpRedirect({
         action: "modify",
         updatedInput: {
-          command: `echo "context-mode: Build tool redirected. Think in Code — use ${t("ctx_execute")}(language: \\"shell\\", code: \\"${safeCmd} 2>&1 | tail -30\\") to run and print only errors/summary. Do NOT retry with Bash."`,
+          command: `echo "context-mode: Build tool redirected to ${t("ctx_execute")} for context-window efficiency. Call ${t("ctx_execute")}(language: \\"shell\\", code: \\"${safeCmd} 2>&1 | tail -30\\") to run and print only errors/summary. Use the sandbox so the verbose build log stays out of context."`,
         },
       });
     }
@@ -801,7 +801,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
     const url = toolInput.url ?? "";
     return mcpRedirect({
       action: "deny",
-      reason: `context-mode: WebFetch redirected to ${t("ctx_fetch_and_index")} (context-window optimization, NOT a network restriction). ${t("ctx_fetch_and_index")} has full network access — retry if it fails with a transient DNS error. Call ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") now, then ${t("ctx_search")}(queries: [...]) to query. Or ${t("ctx_execute")}(language, code) to fetch, process, and console.log() only what you need. Write pure JS, no npm deps. Do NOT retry with WebFetch, curl, or wget.`,
+      reason: `context-mode: WebFetch redirected to ${t("ctx_fetch_and_index")} for context-window efficiency. ${t("ctx_fetch_and_index")} and ${t("ctx_execute")} have full network access. Call ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") now, then ${t("ctx_search")}(queries: [...]) to query the indexed content. Or call ${t("ctx_execute")}(language, code) to fetch, process, and console.log() only what you need (pure JS, no npm deps). Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH).`,
       // D2 PRD Phase 4.1: marker payload for PostToolUse byte accounting.
       redirectMeta: {
         tool: "WebFetch",

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -704,7 +704,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         return mcpRedirect({
           action: "modify",
           updatedInput: {
-            command: `echo "context-mode: curl/wget blocked. Think in Code — use ${t("ctx_execute")}(language, code) to write code that fetches, processes, and prints only the answer. Or use ${t("ctx_fetch_and_index")}(url, source) to fetch and index. Write pure JS with try/catch, no npm deps. Do NOT retry with curl/wget."`,
+            command: `echo "context-mode: curl/wget redirected (context-window optimization, NOT a network restriction). ${t("ctx_execute")} and ${t("ctx_fetch_and_index")} have full network access — retry if it fails with a transient DNS error. Think in Code — call ${t("ctx_execute")}(language, code) now to fetch, process, and print only the answer. Or ${t("ctx_fetch_and_index")}(url, source) to fetch and index. Write pure JS with try/catch, no npm deps. Do NOT retry with curl/wget."`,
           },
           // D2 PRD Phase 3.1: marker payload for PostToolUse byte accounting.
           redirectMeta: {
@@ -735,7 +735,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
       return mcpRedirect({
         action: "modify",
         updatedInput: {
-          command: `echo "context-mode: Inline HTTP blocked. Think in Code — use ${t("ctx_execute")}(language, code) to write code that fetches, processes, and console.log() only the result. Write robust pure JS with try/catch, no npm deps. Do NOT retry with Bash."`,
+          command: `echo "context-mode: Inline HTTP redirected (context-window optimization, NOT a network restriction). ${t("ctx_execute")} has full network access — retry if it fails with a transient DNS error. Think in Code — call ${t("ctx_execute")}(language, code) now to fetch, process, and console.log() only the result. Write robust pure JS with try/catch, no npm deps. Do NOT retry with Bash."`,
         },
       });
     }
@@ -801,7 +801,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
     const url = toolInput.url ?? "";
     return mcpRedirect({
       action: "deny",
-      reason: `context-mode: WebFetch blocked. Think in Code — use ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") to fetch and index, then ${t("ctx_search")}(queries: [...]) to query. Or use ${t("ctx_execute")}(language, code) to fetch, process, and console.log() only what you need. Write pure JS, no npm deps. Do NOT use curl, wget, or WebFetch.`,
+      reason: `context-mode: WebFetch redirected to ${t("ctx_fetch_and_index")} (context-window optimization, NOT a network restriction). ${t("ctx_fetch_and_index")} has full network access — retry if it fails with a transient DNS error. Call ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") now, then ${t("ctx_search")}(queries: [...]) to query. Or ${t("ctx_execute")}(language, code) to fetch, process, and console.log() only what you need. Write pure JS, no npm deps. Do NOT retry with WebFetch, curl, or wget.`,
       // D2 PRD Phase 4.1: marker payload for PostToolUse byte accounting.
       redirectMeta: {
         tool: "WebFetch",

--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -704,7 +704,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         return mcpRedirect({
           action: "modify",
           updatedInput: {
-            command: `echo "context-mode: curl/wget redirected to ${t("ctx_execute")} for context-window efficiency. ${t("ctx_execute")} and ${t("ctx_fetch_and_index")} have full network access. Call ${t("ctx_execute")}(language, code) now to fetch, process, and print only the answer. Or call ${t("ctx_fetch_and_index")}(url, source) to fetch and index. Write pure JS with try/catch, no npm deps. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
+            command: `echo "context-mode: curl/wget redirected to ${t("ctx_execute")}. ${t("ctx_execute")} and ${t("ctx_fetch_and_index")} have full network access. Call ${t("ctx_execute")}(language, code) now to fetch, process, and print only the answer. Or call ${t("ctx_fetch_and_index")}(url, source) to fetch and index. Write pure JS with try/catch, no npm deps. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
           },
           // D2 PRD Phase 3.1: marker payload for PostToolUse byte accounting.
           redirectMeta: {
@@ -735,7 +735,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
       return mcpRedirect({
         action: "modify",
         updatedInput: {
-          command: `echo "context-mode: Inline HTTP redirected to ${t("ctx_execute")} for context-window efficiency. ${t("ctx_execute")} has full network access. Call ${t("ctx_execute")}(language, code) now to fetch, process, and console.log() only the result. Write robust pure JS with try/catch, no npm deps. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
+          command: `echo "context-mode: Inline HTTP redirected to ${t("ctx_execute")}. ${t("ctx_execute")} has full network access. Call ${t("ctx_execute")}(language, code) now to fetch, process, and console.log() only the result. Write robust pure JS with try/catch, no npm deps. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
         },
       });
     }
@@ -748,7 +748,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
       return mcpRedirect({
         action: "modify",
         updatedInput: {
-          command: `echo "context-mode: Build tool redirected to ${t("ctx_execute")} for context-window efficiency. Call ${t("ctx_execute")}(language: \\"shell\\", code: \\"${safeCmd} 2>&1 | tail -30\\") to run and print only errors/summary. Use the sandbox so the verbose build log stays out of context."`,
+          command: `echo "context-mode: Build tool redirected to ${t("ctx_execute")}. Call ${t("ctx_execute")}(language: \\"shell\\", code: \\"${safeCmd} 2>&1 | tail -30\\") to run and print only errors/summary. The sandbox keeps the verbose build log out of context."`,
         },
       });
     }
@@ -801,7 +801,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
     const url = toolInput.url ?? "";
     return mcpRedirect({
       action: "deny",
-      reason: `context-mode: WebFetch redirected to ${t("ctx_fetch_and_index")} for context-window efficiency. ${t("ctx_fetch_and_index")} and ${t("ctx_execute")} have full network access. Call ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") now, then ${t("ctx_search")}(queries: [...]) to query the indexed content. Or call ${t("ctx_execute")}(language, code) to fetch, process, and console.log() only what you need (pure JS, no npm deps). Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH).`,
+      reason: `context-mode: WebFetch redirected to ${t("ctx_fetch_and_index")}. ${t("ctx_fetch_and_index")} and ${t("ctx_execute")} have full network access. Call ${t("ctx_fetch_and_index")}(url: "${url}", source: "...") now, then ${t("ctx_search")}(queries: [...]) to query the indexed content. Or call ${t("ctx_execute")}(language, code) to fetch, process, and console.log() only what you need (pure JS, no npm deps). Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH).`,
       // D2 PRD Phase 4.1: marker payload for PostToolUse byte accounting.
       redirectMeta: {
         tool: "WebFetch",

--- a/hooks/routing-block.mjs
+++ b/hooks/routing-block.mjs
@@ -18,41 +18,37 @@ export function createRoutingBlock(t, options = {}) {
   return `
 <context_window_protection>
   <priority_instructions>
-    Raw tool output floods context window. MUST use context-mode MCP tools. Keep raw data in sandbox.
+    Raw tool output floods the context window. Use context-mode MCP tools to keep raw data in the sandbox; only your printed summary enters context.
   </priority_instructions>
 
   <tool_selection_hierarchy>
     0. MEMORY: ${t("ctx_search")}(sort: "timeline")
-       - After resume, check prior context before asking user.
+       - After resume, check prior context before asking the user.
     1. GATHER: ${t("ctx_batch_execute")}(commands, queries)
        - Primary research tool. Runs commands, auto-indexes, searches. ONE call replaces many steps.
        - Each command: {label: "section header", command: "shell command"}
-       - label becomes FTS5 chunk title — descriptive labels improve search.
+       - label becomes the FTS5 chunk title — descriptive labels improve search.
     2. FOLLOW-UP: ${t("ctx_search")}(queries: ["q1", "q2", ...])
        - All follow-up questions. ONE call, many queries (default relevance mode).
     3. PROCESSING: ${t("ctx_execute")}(language, code) | ${t("ctx_execute_file")}(path, language, code)
        - API calls, log analysis, data processing.
   </tool_selection_hierarchy>
 
-  <forbidden_actions>
-    - NO Bash for commands producing >20 lines output.
-    - NO Read for analysis — use ${t("ctx_execute_file")}. Read IS correct for files you intend to Edit.
-    - NO WebFetch — use ${t("ctx_fetch_and_index")}.
-    - Bash ONLY for git/mkdir/rm/mv/navigation.
-    - NO ${t("ctx_execute")} or ${t("ctx_execute_file")} for file creation/modification.
-      ${t("ctx_execute")} is for analysis, processing, computation only.
-  </forbidden_actions>
+  <when_not_to_use>
+    - Bash with output >20 lines → use ${t("ctx_batch_execute")} or ${t("ctx_execute")}; Bash stays correct for git, mkdir, rm, mv, navigation, and other short-output commands.
+    - Read for analysis → use ${t("ctx_execute_file")}; Read stays correct for files you intend to Edit (Edit needs the content in context).
+    - WebFetch → use ${t("ctx_fetch_and_index")}; full network access, results indexed for ${t("ctx_search")}.
+    - ${t("ctx_execute")} and ${t("ctx_execute_file")} for file writes → these run code in a subprocess and discard the sandbox FS; they are for analysis, processing, and computation only.
+  </when_not_to_use>
 
   <file_writing_policy>
-    ALWAYS use native Write/Edit tools for file creation/modification.
-    NEVER use ${t("ctx_execute")}, ${t("ctx_execute_file")}, or Bash to write files.
+    File writes use the native Write or Edit tool — ${t("ctx_execute")}, ${t("ctx_execute_file")}, and Bash subprocesses do not persist edits to the host filesystem.
     Applies to all file types: code, configs, plans, specs, YAML, JSON, markdown.
   </file_writing_policy>
 
   <output_constraints>
     <artifact_policy>
-      Write artifacts (code, configs, PRDs) to FILES. NEVER inline.
-      Return only: file path + 1-line description.
+      Write artifacts (code, configs, PRDs) to files. Return only: file path + 1-line description.
     </artifact_policy>
   </output_constraints>
   <session_continuity>

--- a/hooks/routing-block.mjs
+++ b/hooks/routing-block.mjs
@@ -18,26 +18,25 @@ export function createRoutingBlock(t, options = {}) {
   return `
 <context_window_protection>
   <priority_instructions>
-    Raw tool output floods the context window. Use context-mode MCP tools to keep raw data in the sandbox; only your printed summary enters context.
+    Every byte a tool returns enters your conversation memory and costs reasoning capacity for the rest of the session. The context-mode tools let you do the work in a sandbox and surface only the derived answer — the raw bytes stay out. Think-in-Code: program the analysis, do not compute it by reading raw data into your conversation.
   </priority_instructions>
 
   <tool_selection_hierarchy>
     0. MEMORY: ${t("ctx_search")}(sort: "timeline")
-       - After resume, check prior context before asking the user.
+       - On resume or compaction, query prior decisions, errors, plans, user prompts before asking the user — auto-captured session memory is searchable.
     1. GATHER: ${t("ctx_batch_execute")}(commands, queries)
-       - Primary research tool. Runs commands, auto-indexes, searches. ONE call replaces many steps.
-       - Each command: {label: "section header", command: "shell command"}
-       - label becomes the FTS5 chunk title — descriptive labels improve search.
+       - Primary research tool. Runs commands in parallel, auto-indexes each output, and (when queries are passed) returns matching sections in the same round trip — no follow-up search call.
+       - Each command: {label: "section header", command: "shell command"}; the label becomes the FTS5 chunk title — descriptive labels improve search.
     2. FOLLOW-UP: ${t("ctx_search")}(queries: ["q1", "q2", ...])
-       - All follow-up questions. ONE call, many queries (default relevance mode).
+       - Multiple related questions about anything already indexed (your captures + session memory). Batch every question in one array; the ranking pipeline runs per-query and the round-trip cost is paid once.
     3. PROCESSING: ${t("ctx_execute")}(language, code) | ${t("ctx_execute_file")}(path, language, code)
-       - API calls, log analysis, data processing.
+       - Derive answers FROM data: filter, count, aggregate, parse, transform. Only what you console.log() enters your conversation; the raw bytes stay in the sandbox.
   </tool_selection_hierarchy>
 
   <when_not_to_use>
-    - Bash with output >20 lines → use ${t("ctx_batch_execute")} or ${t("ctx_execute")}; Bash stays correct for git, mkdir, rm, mv, navigation, and other short-output commands.
-    - Read for analysis → use ${t("ctx_execute_file")}; Read stays correct for files you intend to Edit (Edit needs the content in context).
-    - WebFetch → use ${t("ctx_fetch_and_index")}; full network access, results indexed for ${t("ctx_search")}.
+    - You intend to PROCESS the output (filter, count, parse, aggregate) → use ${t("ctx_batch_execute")} or ${t("ctx_execute")}. Bash stays correct when you intend to OBSERVE a short fixed output (git status on a clean tree, whoami, pwd) or when you are mutating state (git, mkdir, rm, mv, navigation).
+    - You want to analyze, summarize, or extract from a file → use ${t("ctx_execute_file")}. Read stays correct when you intend to Edit the file (Edit needs the exact bytes in your conversation to match against).
+    - WebFetch → use ${t("ctx_fetch_and_index")}; full network access, results indexed for ${t("ctx_search")}, raw page bytes never enter your conversation.
     - ${t("ctx_execute")} and ${t("ctx_execute_file")} for file writes → these run code in a subprocess and discard the sandbox FS; they are for analysis, processing, and computation only.
   </when_not_to_use>
 
@@ -76,19 +75,19 @@ ${includeCommands ? `
 }
 
 export function createReadGuidance(t) {
-  return '<context_guidance>\n  <tip>\n    Reading to Edit? Read is correct — Edit needs content in context.\n    Reading to analyze/explore? Use ' + t("ctx_execute_file") + '(path, language, code) — only printed summary enters context.\n  </tip>\n</context_guidance>';
+  return '<context_guidance>\n  <tip>\n    Reading to Edit the file? Read is correct — Edit needs the exact bytes in your conversation to match against.\n    Reading to analyze, summarize, or extract from the file? Use ' + t("ctx_execute_file") + '(path, language, code) — the bytes stay in the sandbox and only what your code prints enters your conversation.\n  </tip>\n</context_guidance>';
 }
 
 export function createGrepGuidance(t) {
-  return '<context_guidance>\n  <tip>\n    May flood context. Use ' + t("ctx_execute") + '(language: "shell", code: "...") to run searches in sandbox. Only printed summary enters context.\n  </tip>\n</context_guidance>';
+  return '<context_guidance>\n  <tip>\n    Grep results may be larger than you expect. When you intend to count, filter, or aggregate matches (not just spot-check one), run the search through ' + t("ctx_execute") + '(language: "shell", code: "...") — the raw match list stays in the sandbox and only your derived answer enters your conversation.\n  </tip>\n</context_guidance>';
 }
 
 export function createBashGuidance(t) {
-  return '<context_guidance>\n  <tip>\n    May produce large output. Use ' + t("ctx_batch_execute") + '(commands, queries) for multiple commands, ' + t("ctx_execute") + '(language: "shell", code: "...") for single. Only printed summary enters context. Bash only for: git, mkdir, rm, mv, navigation.\n  </tip>\n</context_guidance>';
+  return '<context_guidance>\n  <tip>\n    When you intend to PROCESS the output (filter, count, parse, aggregate), use ' + t("ctx_batch_execute") + '(commands, queries) for multiple commands or ' + t("ctx_execute") + '(language: "shell", code: "...") for one — the raw output stays in the sandbox and only what you print enters your conversation. Bash stays the right surface when you intend to OBSERVE a short fixed output or when you are mutating state (git, mkdir, rm, mv, navigation).\n  </tip>\n</context_guidance>';
 }
 
 export function createExternalMcpGuidance(t) {
-  return '<context_guidance>\n  <tip>\n    External MCP tools may return large payloads (channel history, file content, search results) that flood context. After this call, if the result is large or you need to filter/aggregate it, pipe the data through ' + t("ctx_execute") + '(language, code) — only your printed summary enters context. For docs-style fetches, prefer ' + t("ctx_fetch_and_index") + '(url, source) then ' + t("ctx_search") + '(queries).\n  </tip>\n</context_guidance>';
+  return '<context_guidance>\n  <tip>\n    External MCP tools commonly return large payloads (channel history, file content, search results) that enter your conversation in full. When you intend to filter, count, or aggregate that data, pipe it through ' + t("ctx_execute") + '(language, code) — the raw payload stays in the sandbox and only the derived answer enters your conversation. For docs-style fetches you will want to query later, prefer ' + t("ctx_fetch_and_index") + '(url, source) then ' + t("ctx_search") + '(queries).\n  </tip>\n</context_guidance>';
 }
 
 // ── Backward compat: static exports defaulting to claude-code ──

--- a/src/server.ts
+++ b/src/server.ts
@@ -2107,15 +2107,17 @@ WHEN:
   - You already indexed content via ctx_batch_execute, ctx_index, or ctx_fetch_and_index
   - You have multiple related questions about that content - batch them in one call
   - You want to scope to one labelled source (pass \`source\`)
+  - You want to query auto-captured session memory: decisions, errors, blockers, plans, user prompts, rejected approaches, post-compact session guides
 
 WHEN NOT:
-  - Nothing has been indexed yet - run ctx_batch_execute, ctx_index, or ctx_fetch_and_index first
+  - Nothing has been indexed yet AND no session memory has accumulated - run ctx_batch_execute, ctx_index, or ctx_fetch_and_index first
   - You only have a single one-off question on un-indexed data - ctx_execute is simpler
 
 RETURNS:
-  Top matches per query with section headers and content previews. Use 2-4 specific terms per query and pass every question in the queries array.
+  Top matches per query with section headers and content previews. Use 2-4 specific terms per query and pass every question in the queries array. Common session-memory sources: \`decision\`, \`error\`, \`error-resolution\`, \`blocker\`, \`plan\`, \`user-prompt\`, \`rejected-approach\`, \`compaction\`. Pass \`sort: "timeline"\` for chronological retrieval; see ctx_stats for live category counts.
 
-EXAMPLE: ctx_search(queries: ["root cause", "proposed fix", "test coverage"], source: "issue-#683")`,
+EXAMPLE: ctx_search(queries: ["root cause", "proposed fix", "test coverage"], source: "issue-#683")
+EXAMPLE: ctx_search(queries: ["what did we decide"], source: "decision", sort: "timeline")`,
     inputSchema: z.object({
       queries: z.preprocess(coerceJsonArray, z
         .array(z.string())
@@ -3744,8 +3746,8 @@ WHEN NOT:
   - User wants to free memory or improve performance -> recommend ctx_stats first, do not purge
 
 SCOPES (pass exactly one):
-  - Per-session: ctx_purge(confirm: true, sessionId: "<uuid>") deletes that session's events and per-session FTS5 chunks; sibling sessions and stats file are preserved.
-  - Per-project: ctx_purge(confirm: true, scope: "project") wipes FTS5 knowledge base, every session DB row, events markdown, and resets the stats file.
+  - Per-session: ctx_purge(confirm: true, sessionId: "<uuid>") deletes that session's events (auto-captured decisions, errors, plans, user prompts, rejected approaches, etc.) and per-session FTS5 chunks; sibling sessions and stats file are preserved.
+  - Per-project: ctx_purge(confirm: true, scope: "project") wipes FTS5 knowledge base, every session DB row, events markdown, and resets the stats file. Use ctx_stats first to preview category counts before purging.
 
 CONTRACT:
   - confirm:true is required; confirm:false returns 'purge cancelled'.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1416,7 +1416,20 @@ server.registerTool(
   "ctx_execute",
   {
     title: "Execute Code",
-    description: `Run code in a sandboxed subprocess. Only what you console.log() enters the agent's context; the raw stdout stays in the sandbox.${bunNote} Languages: ${langList}.\n\nWHEN:\n  - Command output is large (>= 20 lines) or unbounded\n  - You want to filter, count, summarize, or aggregate before printing\n  - API calls (gh, curl, aws), test runners (npm test, pytest), git queries (git log, git diff)\n\nWHEN NOT:\n  - File mutations, simple navigation, single short commands -> use Bash\n\nRETURNS: only your printed output. Wrap risky calls in try/catch.\n\nEXAMPLE: ctx_execute(language: "shell", code: "npm test 2>&1 | tail -40")\nEXAMPLE: ctx_execute(language: "javascript", code: "const r = await fetch('...'); console.log(r.status)")`,
+    description: `Run code in a sandboxed subprocess. Only what you console.log() enters the agent's context; the raw stdout stays in the sandbox.${bunNote} Languages: ${langList}.
+
+WHEN:
+  - Command output is large (>= 20 lines) or unbounded
+  - You want to filter, count, summarize, or aggregate before printing
+  - API calls (gh, curl, aws), test runners (npm test, pytest), git queries (git log, git diff)
+
+WHEN NOT:
+  - File mutations, simple navigation, single short commands -> use Bash
+
+RETURNS: only your printed output. Wrap risky calls in try/catch.
+
+EXAMPLE: ctx_execute(language: "shell", code: "npm test 2>&1 | tail -40")
+EXAMPLE: ctx_execute(language: "javascript", code: "const r = await fetch('...'); console.log(r.status)")`,
     inputSchema: z.object({
       language: z
         .enum([
@@ -1751,20 +1764,23 @@ server.registerTool(
   "ctx_execute_file",
   {
     title: "Execute File Processing",
-    description:
-      "Read a file into a sandboxed FILE_CONTENT variable and run code over it. Only what you console.log() enters the agent's context.\n\n" +
-      "WHEN:\n" +
-      "  - Large logs, CSVs, JSON dumps, or source files you want to analyze, filter, or summarize\n" +
-      "  - The raw contents would flood context\n\n" +
-      "WHEN NOT:\n" +
-      "  - You want to edit the file -> use Read so Edit can match the exact text\n" +
-      "  - You only need one specific line -> Read with offset/limit is simpler\n\n" +
-      "RETURNS: only your printed summary.\n\n" +
-      "EXAMPLE: ctx_execute_file(\n" +
-      "  path: \"huge.log\",\n" +
-      "  language: \"javascript\",\n" +
-      "  code: \"console.log(FILE_CONTENT.split('\\\\n').filter(l => l.includes('ERROR')).slice(0, 20).join('\\\\n'))\"\n" +
-      ")",
+    description: `Read a file into a sandboxed FILE_CONTENT variable and run code over it. Only what you console.log() enters the agent's context.
+
+WHEN:
+  - Large logs, CSVs, JSON dumps, or source files you want to analyze, filter, or summarize
+  - The raw contents would flood context
+
+WHEN NOT:
+  - You want to edit the file -> use Read so Edit can match the exact text
+  - You only need one specific line -> Read with offset/limit is simpler
+
+RETURNS: only your printed summary.
+
+EXAMPLE: ctx_execute_file(
+  path: "huge.log",
+  language: "javascript",
+  code: "console.log(FILE_CONTENT.split('\\\\n').filter(l => l.includes('ERROR')).slice(0, 20).join('\\\\n'))"
+)`,
     inputSchema: z.object({
       path: z
         .string()
@@ -1909,20 +1925,23 @@ server.registerTool(
   "ctx_index",
   {
     title: "Index Content",
-    description:
-      "Index documentation or knowledge content into a searchable BM25 knowledge base. Chunks markdown by headings (keeping code blocks intact) and stores in an FTS5 database. Only a brief summary is returned - the full content stays in the store.\n\n" +
-      "WHEN:\n" +
-      "  - Documentation from Context7, Skills, or MCP tools (API docs, framework guides, code examples)\n" +
-      "  - API references (endpoint details, parameter specs, response schemas)\n" +
-      "  - MCP tools/list output (exact tool signatures and descriptions)\n" +
-      "  - Skill prompts and instructions that are too large for context\n" +
-      "  - README files, migration guides, changelog entries\n" +
-      "  - Any content with code examples you may need to reference precisely\n\n" +
-      "WHEN NOT:\n" +
-      "  - Log files, test output, CSV, or build output -> use ctx_execute_file (it processes in-sandbox)\n\n" +
-      "RETURNS:\n" +
-      "  A brief indexing summary. Retrieve sections on-demand via ctx_search. When `path` is provided, a content hash is stored for automatic stale detection in search results.\n\n" +
-      "EXAMPLE: ctx_index(content: \"# React useEffect\\n\\nThe Effect Hook lets you ...\", source: \"react-useeffect-docs\")",
+    description: `Index documentation or knowledge content into a searchable BM25 knowledge base. Chunks markdown by headings (keeping code blocks intact) and stores in an FTS5 database. Only a brief summary is returned - the full content stays in the store.
+
+WHEN:
+  - Documentation from Context7, Skills, or MCP tools (API docs, framework guides, code examples)
+  - API references (endpoint details, parameter specs, response schemas)
+  - MCP tools/list output (exact tool signatures and descriptions)
+  - Skill prompts and instructions that are too large for context
+  - README files, migration guides, changelog entries
+  - Any content with code examples you may need to reference precisely
+
+WHEN NOT:
+  - Log files, test output, CSV, or build output -> use ctx_execute_file (it processes in-sandbox)
+
+RETURNS:
+  A brief indexing summary. Retrieve sections on-demand via ctx_search. When \`path\` is provided, a content hash is stored for automatic stale detection in search results.
+
+EXAMPLE: ctx_index(content: "# React useEffect\\n\\nThe Effect Hook lets you ...", source: "react-useeffect-docs")`,
     inputSchema: z.object({
       content: z
         .string()
@@ -2080,18 +2099,21 @@ server.registerTool(
   "ctx_search",
   {
     title: "Search Indexed Content",
-    description:
-      "Search indexed content (BM25 over an FTS5 store). File-backed sources auto-refresh when the source file changes.\n\n" +
-      "WHEN:\n" +
-      "  - You already indexed content via ctx_batch_execute, ctx_index, or ctx_fetch_and_index\n" +
-      "  - You have multiple related questions about that content - batch them in one call\n" +
-      "  - You want to scope to one labelled source (pass `source`)\n\n" +
-      "WHEN NOT:\n" +
-      "  - Nothing has been indexed yet - run ctx_batch_execute, ctx_index, or ctx_fetch_and_index first\n" +
-      "  - You only have a single one-off question on un-indexed data - ctx_execute is simpler\n\n" +
-      "RETURNS:\n" +
-      "  Top matches per query with section headers and content previews. Use 2-4 specific terms per query and pass every question in the queries array.\n\n" +
-      "EXAMPLE: ctx_search(queries: [\"root cause\", \"proposed fix\", \"test coverage\"], source: \"issue-#683\")",
+    description: `Search indexed content (BM25 over an FTS5 store). File-backed sources auto-refresh when the source file changes.
+
+WHEN:
+  - You already indexed content via ctx_batch_execute, ctx_index, or ctx_fetch_and_index
+  - You have multiple related questions about that content - batch them in one call
+  - You want to scope to one labelled source (pass \`source\`)
+
+WHEN NOT:
+  - Nothing has been indexed yet - run ctx_batch_execute, ctx_index, or ctx_fetch_and_index first
+  - You only have a single one-off question on un-indexed data - ctx_execute is simpler
+
+RETURNS:
+  Top matches per query with section headers and content previews. Use 2-4 specific terms per query and pass every question in the queries array.
+
+EXAMPLE: ctx_search(queries: ["root cause", "proposed fix", "test coverage"], source: "issue-#683")`,
     inputSchema: z.object({
       queries: z.preprocess(coerceJsonArray, z
         .array(z.string())
@@ -2879,21 +2901,24 @@ server.registerTool(
   "ctx_fetch_and_index",
   {
     title: "Fetch & Index URL(s)",
-    description:
-      "Fetches URL content, converts HTML to markdown, indexes into a searchable knowledge base, and returns a ~3KB preview. Full content stays in the store - use ctx_search() for deeper lookups. Content-type aware: HTML becomes markdown, JSON is chunked by key paths, plain text is indexed directly.\n\n" +
-      "WHEN:\n" +
-      "  - You need web content (docs, changelogs, API references) without raw HTML entering context\n" +
-      "  - Multi-URL research: library evaluation, migration scans, doc comparisons (pass `requests` with concurrency 4-8)\n" +
-      "  - The preview is enough to plan follow-up ctx_search calls\n\n" +
-      "WHEN NOT:\n" +
-      "  - You already have the content locally - ctx_index handles raw text or files\n" +
-      "  - You need to execute JavaScript in the page (SPA-rendered content) - this is a plain fetch, no headless browser\n\n" +
-      "RETURNS:\n" +
-      "  A ~3KB preview per fetched source plus an indexing summary. Retrieve sections on demand via ctx_search(source: \"<label>\"). Fetches parallelize up to `concurrency`; FTS5 indexing then serializes writes (SQLite single-writer rule).\n\n" +
-      "EXAMPLE: ctx_fetch_and_index(\n" +
-      "  requests: [{url: \"https://react.dev/...\", source: \"react\"}, {url: \"https://vuejs.org/...\", source: \"vue\"}],\n" +
-      "  concurrency: 5\n" +
-      ")",
+    description: `Fetches URL content, converts HTML to markdown, indexes into a searchable knowledge base, and returns a ~3KB preview. Full content stays in the store - use ctx_search() for deeper lookups. Content-type aware: HTML becomes markdown, JSON is chunked by key paths, plain text is indexed directly.
+
+WHEN:
+  - You need web content (docs, changelogs, API references) without raw HTML entering context
+  - Multi-URL research: library evaluation, migration scans, doc comparisons (pass \`requests\` with concurrency 4-8)
+  - The preview is enough to plan follow-up ctx_search calls
+
+WHEN NOT:
+  - You already have the content locally - ctx_index handles raw text or files
+  - You need to execute JavaScript in the page (SPA-rendered content) - this is a plain fetch, no headless browser
+
+RETURNS:
+  A ~3KB preview per fetched source plus an indexing summary. Retrieve sections on demand via ctx_search(source: "<label>"). Fetches parallelize up to \`concurrency\`; FTS5 indexing then serializes writes (SQLite single-writer rule).
+
+EXAMPLE: ctx_fetch_and_index(
+  requests: [{url: "https://react.dev/...", source: "react"}, {url: "https://vuejs.org/...", source: "vue"}],
+  concurrency: 5
+)`,
     inputSchema: z.object({
       url: z.string().optional().describe("Single URL to fetch and index (legacy single-shape)"),
       source: z
@@ -3128,22 +3153,25 @@ server.registerTool(
   "ctx_batch_execute",
   {
     title: "Batch Execute & Search",
-    description:
-      "Run multiple commands in ONE call. Output is auto-indexed. Optional queries return matching sections - no follow-up ctx_search needed.\n\n" +
-      "WHEN:\n" +
-      "  - You have 3+ related commands (gh issue view x N, git log + git diff, multi-file reads)\n" +
-      "  - You want to gather + search in one round trip\n" +
-      "  - You want to parallelize I/O-bound calls (pass concurrency 4-8 for gh, curl, multi-region cloud queries, multi-repo git reads)\n\n" +
-      "WHEN NOT:\n" +
-      "  - One command, no follow-up search -> ctx_execute is simpler\n" +
-      "  - CPU-bound or stateful commands -> keep concurrency at 1 (npm test, build, lint, ports, lock files)\n\n" +
-      "RETURNS:\n" +
-      "  Section list plus top matches per query. Add a processing command that console.log()s only the answer when you need to filter or aggregate.\n\n" +
-      "EXAMPLE: ctx_batch_execute(\n" +
-      "  commands: [{label:\"issue 1\", command:\"gh issue view 1\"}, {label:\"issue 2\", command:\"gh issue view 2\"}],\n" +
-      "  queries: [\"root cause\", \"proposed fix\"],\n" +
-      "  concurrency: 4\n" +
-      ")",
+    description: `Run multiple commands in ONE call. Output is auto-indexed. Optional queries return matching sections - no follow-up ctx_search needed.
+
+WHEN:
+  - You have 3+ related commands (gh issue view x N, git log + git diff, multi-file reads)
+  - You want to gather + search in one round trip
+  - You want to parallelize I/O-bound calls (pass concurrency 4-8 for gh, curl, multi-region cloud queries, multi-repo git reads)
+
+WHEN NOT:
+  - One command, no follow-up search -> ctx_execute is simpler
+  - CPU-bound or stateful commands -> keep concurrency at 1 (npm test, build, lint, ports, lock files)
+
+RETURNS:
+  Section list plus top matches per query. Add a processing command that console.log()s only the answer when you need to filter or aggregate.
+
+EXAMPLE: ctx_batch_execute(
+  commands: [{label:"issue 1", command:"gh issue view 1"}, {label:"issue 2", command:"gh issue view 2"}],
+  queries: ["root cause", "proposed fix"],
+  concurrency: 4
+)`,
     inputSchema: z.object({
       commands: z.preprocess(coerceCommandsArray, z
         .array(
@@ -3703,25 +3731,30 @@ server.registerTool(
   "ctx_purge",
   {
     title: "Purge Knowledge Base",
-    description:
-      "DESTRUCTIVE: permanently delete indexed content. Cannot be undone. Requires confirm:true and exactly one scope.\n\n" +
-      "WHEN:\n" +
-      "  - User explicitly asks to clear a specific session ('purge this session', 'wipe this conversation')\n" +
-      "  - User explicitly asks to reset the whole project ('reset everything', 'wipe the knowledge base')\n\n" +
-      "WHEN NOT:\n" +
-      "  - User says 'reset', 'clear', or 'wipe' without naming a scope -> ask which scope before calling\n" +
-      "  - User wants to free memory or improve performance -> recommend ctx_stats first, do not purge\n\n" +
-      "SCOPES (pass exactly one):\n" +
-      "  - Per-session: ctx_purge(confirm: true, sessionId: \"<uuid>\") deletes that session's events and per-session FTS5 chunks; sibling sessions and stats file are preserved.\n" +
-      "  - Per-project: ctx_purge(confirm: true, scope: \"project\") wipes FTS5 knowledge base, every session DB row, events markdown, and resets the stats file.\n\n" +
-      "CONTRACT:\n" +
-      "  - confirm:true is required; confirm:false returns 'purge cancelled'.\n" +
-      "  - sessionId and scope:'project' together return 'ambiguous - pick one'.\n" +
-      "  - scope:'session' without sessionId throws (sessionId required).\n" +
-      "  - Bare {confirm:true} is deprecated: maps to scope:'project' with a stderr warning; will hard-error in a future major.\n\n" +
-      "RETURNS: a summary of removed rows + the resolved scope.\n\n" +
-      "EXAMPLE: ctx_purge(confirm: true, sessionId: \"7c8a-1234-5678-9abc-def012345678\")\n" +
-      "EXAMPLE: ctx_purge(confirm: true, scope: \"project\")",
+    description: `DESTRUCTIVE: permanently delete indexed content. Cannot be undone. Requires confirm:true and exactly one scope.
+
+WHEN:
+  - User explicitly asks to clear a specific session ('purge this session', 'wipe this conversation')
+  - User explicitly asks to reset the whole project ('reset everything', 'wipe the knowledge base')
+
+WHEN NOT:
+  - User says 'reset', 'clear', or 'wipe' without naming a scope -> ask which scope before calling
+  - User wants to free memory or improve performance -> recommend ctx_stats first, do not purge
+
+SCOPES (pass exactly one):
+  - Per-session: ctx_purge(confirm: true, sessionId: "<uuid>") deletes that session's events and per-session FTS5 chunks; sibling sessions and stats file are preserved.
+  - Per-project: ctx_purge(confirm: true, scope: "project") wipes FTS5 knowledge base, every session DB row, events markdown, and resets the stats file.
+
+CONTRACT:
+  - confirm:true is required; confirm:false returns 'purge cancelled'.
+  - sessionId and scope:'project' together return 'ambiguous - pick one'.
+  - scope:'session' without sessionId throws (sessionId required).
+  - Bare {confirm:true} is deprecated: maps to scope:'project' with a stderr warning; will hard-error in a future major.
+
+RETURNS: a summary of removed rows + the resolved scope.
+
+EXAMPLE: ctx_purge(confirm: true, sessionId: "7c8a-1234-5678-9abc-def012345678")
+EXAMPLE: ctx_purge(confirm: true, scope: "project")`,
     // NOTE: schema MUST be a plain z.object — no .refine()/.transform()/
     // .superRefine() wrapper. See block comment above & issue #563. The
     // cross-field ambiguity check lives in the handler body below.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1416,21 +1416,36 @@ server.registerTool(
   "ctx_execute",
   {
     title: "Execute Code",
-    description: `Run code in a sandboxed subprocess. Only what you console.log() enters the agent's context; the raw stdout stays in the sandbox.${bunNote} Languages: ${langList}.
+    description: `Run code in a sandboxed subprocess.${bunNote} Languages: ${langList}.
+
+Think-in-Code — the core philosophy: the bytes your code processes never enter your conversation memory; only what you console.log() does. Reading a 700 KB log directly means 700 KB of your remaining reasoning capacity gets spent on raw bytes. Running code over that same log in this sandbox and printing a 3 KB summary leaves you with 697 KB of capacity for the actual work.
+
+Concrete shape — analyze 47 source files without reading any of them:
+  ctx_execute(language: "javascript", code: \`
+    const fs = require('fs');
+    const files = fs.readdirSync('src').filter(f => f.endsWith('.ts'));
+    files.forEach(f => {
+      const lines = fs.readFileSync('src/'+f,'utf8').split('\\\\n').length;
+      console.log(f + ': ' + lines + ' lines');
+    });
+  \`)
+  // 47 files analyzed, 15,314 LoC summarized — output ~3.6 KB instead of 47 Read() calls = ~700 KB.
 
 WHEN:
-  - Command output is large (>= 20 lines) or unbounded
-  - You want to filter, count, summarize, or aggregate before printing
-  - API calls (gh, curl, aws), test runners (npm test, pytest), git queries (git log, git diff)
+  - You intend to derive an answer FROM data (filter, count, aggregate, parse, compare, transform) — do the derivation in code and print only the answer
+  - Output shape or size cannot be predicted before execution (recursive finds, repo-wide greps, list endpoints, query results, log scans)
+  - You would otherwise read raw output and then mentally compute — that compute belongs here, in code, where its inputs stay out of your conversation
 
 WHEN NOT:
-  - File mutations, simple navigation, single short commands -> use Bash
+  - Single observational command whose entire short output you intend to consume verbatim (whoami, pwd, git status on a clean tree) — Bash is simpler
+  - File mutations (Edit/Write) or navigation (cd/ls) — Bash is the right surface
+  - You already know the output is one short fixed line and you want to read it as-is
 
 RETURNS:
-  Only your printed output. Wrap risky calls in try/catch.
+  Only what your code prints. Wrap risky calls in try/catch — uncaught errors go to stderr and may leak more than intended.
 
-EXAMPLE: ctx_execute(language: "shell", code: "npm test 2>&1 | tail -40")
-EXAMPLE: ctx_execute(language: "javascript", code: "const r = await fetch('...'); console.log(r.status)")`,
+EXAMPLE: ctx_execute(language: "shell", code: "npm test 2>&1 | grep -E '(FAIL|✗|×|Error:|Tests +.*(failed|passed))' | head -60")
+EXAMPLE: ctx_execute(language: "javascript", code: "const out = require('child_process').execSync('gh issue list --json number,title --limit 100', {encoding:'utf8'}); const hooks = JSON.parse(out).filter(i => /hook|routing/i.test(i.title)); console.log(\`\${hooks.length} hook-related issues\`)")`,
     inputSchema: z.object({
       language: z
         .enum([
@@ -1765,24 +1780,25 @@ server.registerTool(
   "ctx_execute_file",
   {
     title: "Execute File Processing",
-    description: `Read a file into a sandboxed FILE_CONTENT variable and run code over it. Only what you console.log() enters the agent's context.
+    description: `Read a file into a sandboxed FILE_CONTENT variable and run code over it. Only what you console.log() enters your conversation — the file bytes stay in the sandbox.
+
+Think-in-Code applied to file-level analysis: Reading the whole file means every byte enters your conversation memory and costs reasoning capacity for the rest of the session. Running code over it here lets you keep the raw bytes out and only the derived answer in. Same principle as ctx_execute, scoped to one named file via the FILE_CONTENT variable.
 
 WHEN:
-  - Large logs, CSVs, JSON dumps, or source files you want to analyze, filter, or summarize
-  - The raw contents would flood context
+  - You want to KNOW SOMETHING ABOUT a file (line count, matches of a pattern, parsed structure, statistical aggregate) without needing to SEE all of it
+  - The file is structured (CSV, JSON, log, code) and a code-level derivation is cheaper than reading verbatim
+  - The file is large enough that reading the full content would burn meaningful conversation memory you need for the actual work
 
 WHEN NOT:
-  - You want to edit the file -> use Read so Edit can match the exact text
-  - You only need one specific line -> Read with offset/limit is simpler
+  - You intend to EDIT the file — use Read so the subsequent Edit can match the exact text
+  - You only need one specific line and you know its offset — Read with offset/limit is the simplest path
+  - The file is small AND you will consume all of it for understanding/editing — Read directly
 
 RETURNS:
-  Only your printed summary.
+  Only what your code prints. The FILE_CONTENT variable holds the raw bytes inside the sandbox; nothing else leaves.
 
-EXAMPLE: ctx_execute_file(
-  path: "huge.log",
-  language: "javascript",
-  code: "console.log(FILE_CONTENT.split('\\\\n').filter(l => l.includes('ERROR')).slice(0, 20).join('\\\\n'))"
-)`,
+EXAMPLE: ctx_execute_file(path: "huge.log", language: "javascript", code: "const errs = FILE_CONTENT.split('\\\\n').filter(l => /ERROR|FATAL/.test(l)); console.log(\`\${errs.length} error lines\`); console.log(errs.slice(-5).join('\\\\n'))")
+EXAMPLE: ctx_execute_file(path: "data.csv", language: "javascript", code: "const rows = FILE_CONTENT.split('\\\\n'); console.log(\`rows: \${rows.length - 1}, header: \${rows[0]}\`)")`,
     inputSchema: z.object({
       path: z
         .string()
@@ -1927,23 +1943,25 @@ server.registerTool(
   "ctx_index",
   {
     title: "Index Content",
-    description: `Index documentation or knowledge content into a searchable BM25 knowledge base. Chunks markdown by headings (keeping code blocks intact) and stores in an FTS5 database. Only a brief summary is returned - the full content stays in the store.
+    description: `Store content in a searchable knowledge base (BM25 over FTS5). Splits markdown by headings, keeps code blocks intact, and persists the raw chunks. The full content stays in storage — retrieve any section on-demand via ctx_search; nothing is summarized or truncated.
 
 WHEN:
   - Documentation from Context7, Skills, or MCP tools (API docs, framework guides, code examples)
   - API references (endpoint details, parameter specs, response schemas)
   - MCP tools/list output (exact tool signatures and descriptions)
-  - Skill prompts and instructions that are too large for context
+  - Skill prompts and instructions that are too large to keep verbatim in conversation
   - README files, migration guides, changelog entries
-  - Any content with code examples you may need to reference precisely
+  - Any content with code examples you may need to reference precisely later
 
 WHEN NOT:
-  - Log files, test output, CSV, or build output -> use ctx_execute_file (it processes in-sandbox)
+  - Log files, test output, CSV, or build output — use ctx_execute_file, which processes in-sandbox without persisting bytes
+  - Single-use ephemeral content you will not query later — keep it inline if it fits, or ctx_execute_file it
 
 RETURNS:
-  A brief indexing summary. Retrieve sections on-demand via ctx_search. When \`path\` is provided, a content hash is stored for automatic stale detection in search results.
+  Indexing metadata: chunk counts (total, code-bearing), source label, and the exact ctx_search call shape to query the indexed content. Raw content is NOT echoed back — it lives in storage, retrievable via ctx_search(source: "<label>"). When \`path\` is provided, a content hash is stored so ctx_search results auto-flag staleness on future calls.
 
-EXAMPLE: ctx_index(content: "# React useEffect\\n\\nThe Effect Hook lets you ...", source: "react-useeffect-docs")`,
+EXAMPLE: ctx_index(content: "# React useEffect\\n\\nThe Effect Hook lets you ...", source: "react-useeffect-docs")
+EXAMPLE: ctx_index(path: "/path/to/large-spec.md", source: "openapi-v2-spec")`,
     inputSchema: z.object({
       content: z
         .string()
@@ -2905,19 +2923,19 @@ server.registerTool(
   "ctx_fetch_and_index",
   {
     title: "Fetch & Index URL(s)",
-    description: `Fetches URL content, converts HTML to markdown, indexes into a searchable knowledge base, and returns a ~3KB preview. Full content stays in the store - use ctx_search() for deeper lookups. Content-type aware: HTML becomes markdown, JSON is chunked by key paths, plain text is indexed directly.
+    description: `Fetches URL content, converts HTML to markdown, indexes into a searchable knowledge base (BM25 over FTS5), and returns a ~3KB preview per source. Raw HTML never enters your conversation — the full content stays in storage, retrievable on-demand via ctx_search. Content-type aware: HTML becomes markdown, JSON is chunked by key paths, plain text is indexed directly.
 
 WHEN:
-  - You need web content (docs, changelogs, API references) without raw HTML entering context
-  - Multi-URL research: library evaluation, migration scans, doc comparisons (pass \`requests\` with concurrency 4-8)
+  - You need web content (docs, changelogs, API references) and the raw page bytes should NOT enter your conversation memory
+  - Multi-URL research: library evaluation, migration scans, doc comparisons — pass \`requests\` array with concurrency 4-8 for parallel I/O
   - The preview is enough to plan follow-up ctx_search calls
 
 WHEN NOT:
-  - You already have the content locally - ctx_index handles raw text or files
-  - You need to execute JavaScript in the page (SPA-rendered content) - this is a plain fetch, no headless browser
+  - You already have the content locally — ctx_index handles raw text or files
+  - The page is SPA-rendered (JavaScript-required) — this is a plain HTTP fetch, no headless browser
 
 RETURNS:
-  A ~3KB preview per fetched source plus an indexing summary. Retrieve sections on demand via ctx_search(source: "<label>"). Fetches parallelize up to \`concurrency\`; FTS5 indexing then serializes writes (SQLite single-writer rule).
+  A ~3KB preview per fetched source plus indexing metadata (chunk counts, source labels). Raw content is NOT echoed back — retrieve any section on-demand via ctx_search(source: "<label>"). Fetches parallelize up to \`concurrency\`; FTS5 indexing then serializes writes (SQLite single-writer rule).
 
 EXAMPLE: ctx_fetch_and_index(
   requests: [{url: "https://react.dev/...", source: "react"}, {url: "https://vuejs.org/...", source: "vue"}],

--- a/src/server.ts
+++ b/src/server.ts
@@ -1416,7 +1416,7 @@ server.registerTool(
   "ctx_execute",
   {
     title: "Execute Code",
-    description: `MANDATORY: Use for any command where output exceeds 20 lines. Execute code in a sandboxed subprocess. Only stdout enters context — raw data stays in the subprocess.${bunNote} Available: ${langList}.\n\nPREFER THIS OVER BASH for: API calls (gh, curl, aws), test runners (npm test, pytest), git queries (git log, git diff), data processing, and ANY CLI command that may produce large output. Bash should only be used for file mutations, git writes, and navigation.\n\nTHINK IN CODE: When you need to analyze, count, filter, compare, or process data — write code that does the work and console.log() only the answer. Do NOT read raw data into context to process mentally. Program the analysis, don't compute it in your reasoning. Write robust, pure JavaScript (no npm dependencies). Use only Node.js built-ins (fs, path, child_process). Always wrap in try/catch. Handle null/undefined. Works on both Node.js and Bun.`,
+    description: `Run code in a sandboxed subprocess. Only what you console.log() enters the agent's context; the raw stdout stays in the sandbox.${bunNote} Languages: ${langList}.\n\nWHEN:\n  - Command output is large (>= 20 lines) or unbounded\n  - You want to filter, count, summarize, or aggregate before printing\n  - API calls (gh, curl, aws), test runners (npm test, pytest), git queries (git log, git diff)\n\nWHEN NOT:\n  - File mutations, simple navigation, single short commands -> use Bash\n\nRETURNS: only your printed output. Wrap risky calls in try/catch.\n\nEXAMPLE: ctx_execute(language: "shell", code: "npm test 2>&1 | tail -40")\nEXAMPLE: ctx_execute(language: "javascript", code: "const r = await fetch('...'); console.log(r.status)")`,
     inputSchema: z.object({
       language: z
         .enum([
@@ -1752,7 +1752,19 @@ server.registerTool(
   {
     title: "Execute File Processing",
     description:
-      "Read a file and process it without loading contents into context. The file is read into a FILE_CONTENT variable inside the sandbox. Only your printed summary enters context.\n\nPREFER THIS OVER Read/cat for: log files, data files (CSV, JSON, XML), large source files for analysis, and any file where you need to extract specific information rather than read the entire content.\n\nTHINK IN CODE: Write code that processes FILE_CONTENT and console.log() only the answer. Don't read files into context to analyze mentally. Write robust, pure JavaScript — no npm deps, try/catch, null-safe. Node.js + Bun compatible.",
+      "Read a file into a sandboxed FILE_CONTENT variable and run code over it. Only what you console.log() enters the agent's context.\n\n" +
+      "WHEN:\n" +
+      "  - Large logs, CSVs, JSON dumps, or source files you want to analyze, filter, or summarize\n" +
+      "  - The raw contents would flood context\n\n" +
+      "WHEN NOT:\n" +
+      "  - You want to edit the file -> use Read so Edit can match the exact text\n" +
+      "  - You only need one specific line -> Read with offset/limit is simpler\n\n" +
+      "RETURNS: only your printed summary.\n\n" +
+      "EXAMPLE: ctx_execute_file(\n" +
+      "  path: \"huge.log\",\n" +
+      "  language: \"javascript\",\n" +
+      "  code: \"console.log(FILE_CONTENT.split('\\\\n').filter(l => l.includes('ERROR')).slice(0, 20).join('\\\\n'))\"\n" +
+      ")",
     inputSchema: z.object({
       path: z
         .string()
@@ -1899,18 +1911,19 @@ server.registerTool(
     title: "Index Content",
     description:
       "Index documentation or knowledge content into a searchable BM25 knowledge base. " +
-      "Chunks markdown by headings (keeping code blocks intact) and stores in ephemeral FTS5 database. " +
-      "The full content does NOT stay in context — only a brief summary is returned.\n\n" +
-      "WHEN TO USE:\n" +
-      "- Documentation from Context7, Skills, or MCP tools (API docs, framework guides, code examples)\n" +
-      "- API references (endpoint details, parameter specs, response schemas)\n" +
-      "- MCP tools/list output (exact tool signatures and descriptions)\n" +
-      "- Skill prompts and instructions that are too large for context\n" +
-      "- README files, migration guides, changelog entries\n" +
-      "- Any content with code examples you may need to reference precisely\n\n" +
-      "After indexing, use 'ctx_search' to retrieve specific sections on-demand.\n" +
-      "When `path` is provided, a content hash is stored for automatic stale detection in search results.\n" +
-      "Do NOT use for: log files, test output, CSV, build output — use 'ctx_execute_file' for those.",
+      "Chunks markdown by headings (keeping code blocks intact) and stores in an FTS5 database. " +
+      "Only a brief summary is returned — the full content stays in the store.\n\n" +
+      "WHEN:\n" +
+      "  - Documentation from Context7, Skills, or MCP tools (API docs, framework guides, code examples)\n" +
+      "  - API references (endpoint details, parameter specs, response schemas)\n" +
+      "  - MCP tools/list output (exact tool signatures and descriptions)\n" +
+      "  - Skill prompts and instructions that are too large for context\n" +
+      "  - README files, migration guides, changelog entries\n" +
+      "  - Any content with code examples you may need to reference precisely\n\n" +
+      "WHEN NOT:\n" +
+      "  - Log files, test output, CSV, or build output -> use ctx_execute_file (it processes in-sandbox)\n\n" +
+      "RETURNS: a brief indexing summary. Retrieve sections on-demand via ctx_search.\n\n" +
+      "When `path` is provided, a content hash is stored for automatic stale detection in search results.",
     inputSchema: z.object({
       content: z
         .string()
@@ -2069,11 +2082,14 @@ server.registerTool(
   {
     title: "Search Indexed Content",
     description:
-      "Search indexed content. Requires prior indexing via ctx_batch_execute, ctx_index, or ctx_fetch_and_index. " +
-      "Pass ALL search questions as queries array in ONE call. " +
-      "File-backed sources are auto-refreshed when the source file changes.\n\n" +
-      "TIPS: 2-4 specific terms per query. Use 'source' to scope results.\n\n" +
-      "SESSION STATE: If skills, roles, or decisions were set earlier in this conversation, they are still active. Do not discard or contradict them.",
+      "Search indexed content (BM25 over an FTS5 store). File-backed sources auto-refresh when the source file changes.\n\n" +
+      "WHEN:\n" +
+      "  - You already indexed content via ctx_batch_execute, ctx_index, or ctx_fetch_and_index\n" +
+      "  - You have multiple related questions about that content — batch them in one call\n" +
+      "  - You want to scope to one labelled source (pass `source`)\n\n" +
+      "RETURNS: top matches per query with section headers and content previews.\n\n" +
+      "TIPS: 2-4 specific terms per query. Pass ALL questions in the queries array — one call, many queries.\n\n" +
+      "EXAMPLE: ctx_search(queries: [\"root cause\", \"proposed fix\", \"test coverage\"], source: \"issue-#683\")",
     inputSchema: z.object({
       queries: z.preprocess(coerceJsonArray, z
         .array(z.string())
@@ -2862,15 +2878,22 @@ server.registerTool(
   {
     title: "Fetch & Index URL(s)",
     description:
-      "Fetches URL content, converts HTML to markdown, indexes into searchable knowledge base, " +
-      "and returns a ~3KB preview. Full content stays in sandbox — use ctx_search() for deeper lookups.\n\n" +
-      "Better than WebFetch: preview is immediate, full content is searchable, raw HTML never enters context.\n\n" +
+      "Fetches URL content, converts HTML to markdown, indexes into a searchable knowledge base, " +
+      "and returns a ~3KB preview. Full content stays in the store — use ctx_search() for deeper lookups.\n\n" +
+      "WHEN:\n" +
+      "  - You need web content (docs, changelogs, API references) without raw HTML entering context\n" +
+      "  - Multi-URL research: library evaluation, migration scans, doc comparisons\n" +
+      "  - The preview is enough to plan follow-up ctx_search calls\n\n" +
       "Content-type aware: HTML is converted to markdown, JSON is chunked by key paths, plain text is indexed directly.\n\n" +
-      "PARALLELIZE I/O: For multi-URL research (library evaluation, migration scans, doc comparisons), pass `requests: [{url, source}, ...]` with `concurrency: 4-8` — speeds up by 3-5x on real workloads.\n" +
-      "  ✅ Use concurrency: 4-8 for: library docs sweep, multi-changelog scan, competitive pricing pages, multi-region docs, GitHub raw file pulls.\n" +
-      "  ❌ Single URL → use the legacy {url, source} shape (concurrency irrelevant).\n" +
-      "  Example: requests: [{url: 'https://react.dev/...', source: 'react'}, {url: 'https://vuejs.org/...', source: 'vue'}], concurrency: 5.\n" +
-      "  Fetches parallelize up to your concurrency setting; FTS5 indexing serializes the writes after (SQLite single-writer rule).",
+      "CONCURRENCY:\n" +
+      "  - Use concurrency 4-8 for I/O-bound batches: library docs sweep, multi-changelog scan, competitive pricing pages, multi-region docs, GitHub raw file pulls.\n" +
+      "  - Keep concurrency 1 (default) for a single URL — pass `url` + `source` directly.\n" +
+      "  - Fetches parallelize up to your concurrency setting; FTS5 indexing serializes the writes after (SQLite single-writer rule).\n\n" +
+      "RETURNS: a ~3KB preview per fetched source + an indexing summary. Call ctx_search(source: \"<label>\") to retrieve specific sections.\n\n" +
+      "EXAMPLE: ctx_fetch_and_index(\n" +
+      "  requests: [{url: \"https://react.dev/...\", source: \"react\"}, {url: \"https://vuejs.org/...\", source: \"vue\"}],\n" +
+      "  concurrency: 5\n" +
+      ")",
     inputSchema: z.object({
       url: z.string().optional().describe("Single URL to fetch and index (legacy single-shape)"),
       source: z
@@ -3106,17 +3129,22 @@ server.registerTool(
   {
     title: "Batch Execute & Search",
     description:
-      "Execute multiple commands in ONE call, auto-index all output, and search with multiple queries. " +
-      "Returns search results directly — no follow-up calls needed.\n\n" +
-      "THIS IS THE PRIMARY TOOL. Use this instead of multiple ctx_execute() calls.\n\n" +
-      "One ctx_batch_execute call replaces 30+ ctx_execute calls + 10+ ctx_search calls.\n" +
-      "Provide all commands to run and all queries to search — everything happens in one round trip.\n\n" +
-      "PARALLELIZE I/O: For I/O-bound batches (network calls, slow API queries, multi-URL fetches), ALWAYS pass concurrency: 4-8 — speeds up by 3-5x on real workloads.\n" +
-      "  ✅ Use concurrency: 4-8 for: gh API calls, curl/web fetches, multi-region cloud queries, multi-repo git reads, dig/DNS, docker inspect.\n" +
-      "  ❌ Keep concurrency: 1 for: npm test, build, lint, image processing (CPU-bound), or commands sharing state (ports, lock files, same-repo writes).\n" +
-      "  Example: [gh issue view 1, gh issue view 2, gh issue view 3] → concurrency: 3.\n" +
-      "  Speedup depends on workload — applies to I/O wait, not CPU work.\n\n" +
-      "THINK IN CODE — NON-NEGOTIABLE: When commands produce data you need to analyze, count, filter, compare, or transform — add a processing command that runs JavaScript and console.log() ONLY the answer. NEVER pull raw output into context to reason over. Concurrency parallelizes the FETCH; THINK IN CODE owns the PROCESSING. One programmed analysis replaces ten read-and-reason rounds. Pure JavaScript, Node.js built-ins (fs, path, child_process), try/catch, null-safe.",
+      "Run multiple commands in ONE call. Output is auto-indexed. Optional queries return matching sections — no follow-up ctx_search needed.\n\n" +
+      "WHEN:\n" +
+      "  - You have 3+ related commands (gh issue view x N, git log + git diff, multi-file reads)\n" +
+      "  - You want to gather + search in one round trip\n" +
+      "  - You want to parallelize I/O-bound calls\n\n" +
+      "WHEN NOT:\n" +
+      "  - One command, no follow-up search -> ctx_execute is simpler\n\n" +
+      "CONCURRENCY:\n" +
+      "  - 4-8 for I/O-bound: gh, curl, multi-region cloud queries, multi-repo git reads.\n" +
+      "  - 1 for CPU-bound or stateful: npm test, build, lint, ports, lock files.\n\n" +
+      "RETURNS: section list + top matches per query. Add a processing command that console.log()s only the answer when you need to filter or aggregate.\n\n" +
+      "EXAMPLE: ctx_batch_execute(\n" +
+      "  commands: [{label:\"issue 1\", command:\"gh issue view 1\"}, {label:\"issue 2\", command:\"gh issue view 2\"}],\n" +
+      "  queries: [\"root cause\", \"proposed fix\"],\n" +
+      "  concurrency: 4\n" +
+      ")",
     inputSchema: z.object({
       commands: z.preprocess(coerceCommandsArray, z
         .array(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1426,7 +1426,8 @@ WHEN:
 WHEN NOT:
   - File mutations, simple navigation, single short commands -> use Bash
 
-RETURNS: only your printed output. Wrap risky calls in try/catch.
+RETURNS:
+  Only your printed output. Wrap risky calls in try/catch.
 
 EXAMPLE: ctx_execute(language: "shell", code: "npm test 2>&1 | tail -40")
 EXAMPLE: ctx_execute(language: "javascript", code: "const r = await fetch('...'); console.log(r.status)")`,
@@ -1774,7 +1775,8 @@ WHEN NOT:
   - You want to edit the file -> use Read so Edit can match the exact text
   - You only need one specific line -> Read with offset/limit is simpler
 
-RETURNS: only your printed summary.
+RETURNS:
+  Only your printed summary.
 
 EXAMPLE: ctx_execute_file(
   path: "huge.log",
@@ -3751,7 +3753,8 @@ CONTRACT:
   - scope:'session' without sessionId throws (sessionId required).
   - Bare {confirm:true} is deprecated: maps to scope:'project' with a stderr warning; will hard-error in a future major.
 
-RETURNS: a summary of removed rows + the resolved scope.
+RETURNS:
+  A summary of removed rows + the resolved scope.
 
 EXAMPLE: ctx_purge(confirm: true, sessionId: "7c8a-1234-5678-9abc-def012345678")
 EXAMPLE: ctx_purge(confirm: true, scope: "project")`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1910,9 +1910,7 @@ server.registerTool(
   {
     title: "Index Content",
     description:
-      "Index documentation or knowledge content into a searchable BM25 knowledge base. " +
-      "Chunks markdown by headings (keeping code blocks intact) and stores in an FTS5 database. " +
-      "Only a brief summary is returned — the full content stays in the store.\n\n" +
+      "Index documentation or knowledge content into a searchable BM25 knowledge base. Chunks markdown by headings (keeping code blocks intact) and stores in an FTS5 database. Only a brief summary is returned - the full content stays in the store.\n\n" +
       "WHEN:\n" +
       "  - Documentation from Context7, Skills, or MCP tools (API docs, framework guides, code examples)\n" +
       "  - API references (endpoint details, parameter specs, response schemas)\n" +
@@ -1922,8 +1920,9 @@ server.registerTool(
       "  - Any content with code examples you may need to reference precisely\n\n" +
       "WHEN NOT:\n" +
       "  - Log files, test output, CSV, or build output -> use ctx_execute_file (it processes in-sandbox)\n\n" +
-      "RETURNS: a brief indexing summary. Retrieve sections on-demand via ctx_search.\n\n" +
-      "When `path` is provided, a content hash is stored for automatic stale detection in search results.",
+      "RETURNS:\n" +
+      "  A brief indexing summary. Retrieve sections on-demand via ctx_search. When `path` is provided, a content hash is stored for automatic stale detection in search results.\n\n" +
+      "EXAMPLE: ctx_index(content: \"# React useEffect\\n\\nThe Effect Hook lets you ...\", source: \"react-useeffect-docs\")",
     inputSchema: z.object({
       content: z
         .string()
@@ -2085,10 +2084,13 @@ server.registerTool(
       "Search indexed content (BM25 over an FTS5 store). File-backed sources auto-refresh when the source file changes.\n\n" +
       "WHEN:\n" +
       "  - You already indexed content via ctx_batch_execute, ctx_index, or ctx_fetch_and_index\n" +
-      "  - You have multiple related questions about that content — batch them in one call\n" +
+      "  - You have multiple related questions about that content - batch them in one call\n" +
       "  - You want to scope to one labelled source (pass `source`)\n\n" +
-      "RETURNS: top matches per query with section headers and content previews.\n\n" +
-      "TIPS: 2-4 specific terms per query. Pass ALL questions in the queries array — one call, many queries.\n\n" +
+      "WHEN NOT:\n" +
+      "  - Nothing has been indexed yet - run ctx_batch_execute, ctx_index, or ctx_fetch_and_index first\n" +
+      "  - You only have a single one-off question on un-indexed data - ctx_execute is simpler\n\n" +
+      "RETURNS:\n" +
+      "  Top matches per query with section headers and content previews. Use 2-4 specific terms per query and pass every question in the queries array.\n\n" +
       "EXAMPLE: ctx_search(queries: [\"root cause\", \"proposed fix\", \"test coverage\"], source: \"issue-#683\")",
     inputSchema: z.object({
       queries: z.preprocess(coerceJsonArray, z
@@ -2878,18 +2880,16 @@ server.registerTool(
   {
     title: "Fetch & Index URL(s)",
     description:
-      "Fetches URL content, converts HTML to markdown, indexes into a searchable knowledge base, " +
-      "and returns a ~3KB preview. Full content stays in the store — use ctx_search() for deeper lookups.\n\n" +
+      "Fetches URL content, converts HTML to markdown, indexes into a searchable knowledge base, and returns a ~3KB preview. Full content stays in the store - use ctx_search() for deeper lookups. Content-type aware: HTML becomes markdown, JSON is chunked by key paths, plain text is indexed directly.\n\n" +
       "WHEN:\n" +
       "  - You need web content (docs, changelogs, API references) without raw HTML entering context\n" +
-      "  - Multi-URL research: library evaluation, migration scans, doc comparisons\n" +
+      "  - Multi-URL research: library evaluation, migration scans, doc comparisons (pass `requests` with concurrency 4-8)\n" +
       "  - The preview is enough to plan follow-up ctx_search calls\n\n" +
-      "Content-type aware: HTML is converted to markdown, JSON is chunked by key paths, plain text is indexed directly.\n\n" +
-      "CONCURRENCY:\n" +
-      "  - Use concurrency 4-8 for I/O-bound batches: library docs sweep, multi-changelog scan, competitive pricing pages, multi-region docs, GitHub raw file pulls.\n" +
-      "  - Keep concurrency 1 (default) for a single URL — pass `url` + `source` directly.\n" +
-      "  - Fetches parallelize up to your concurrency setting; FTS5 indexing serializes the writes after (SQLite single-writer rule).\n\n" +
-      "RETURNS: a ~3KB preview per fetched source + an indexing summary. Call ctx_search(source: \"<label>\") to retrieve specific sections.\n\n" +
+      "WHEN NOT:\n" +
+      "  - You already have the content locally - ctx_index handles raw text or files\n" +
+      "  - You need to execute JavaScript in the page (SPA-rendered content) - this is a plain fetch, no headless browser\n\n" +
+      "RETURNS:\n" +
+      "  A ~3KB preview per fetched source plus an indexing summary. Retrieve sections on demand via ctx_search(source: \"<label>\"). Fetches parallelize up to `concurrency`; FTS5 indexing then serializes writes (SQLite single-writer rule).\n\n" +
       "EXAMPLE: ctx_fetch_and_index(\n" +
       "  requests: [{url: \"https://react.dev/...\", source: \"react\"}, {url: \"https://vuejs.org/...\", source: \"vue\"}],\n" +
       "  concurrency: 5\n" +
@@ -3129,17 +3129,16 @@ server.registerTool(
   {
     title: "Batch Execute & Search",
     description:
-      "Run multiple commands in ONE call. Output is auto-indexed. Optional queries return matching sections — no follow-up ctx_search needed.\n\n" +
+      "Run multiple commands in ONE call. Output is auto-indexed. Optional queries return matching sections - no follow-up ctx_search needed.\n\n" +
       "WHEN:\n" +
       "  - You have 3+ related commands (gh issue view x N, git log + git diff, multi-file reads)\n" +
       "  - You want to gather + search in one round trip\n" +
-      "  - You want to parallelize I/O-bound calls\n\n" +
+      "  - You want to parallelize I/O-bound calls (pass concurrency 4-8 for gh, curl, multi-region cloud queries, multi-repo git reads)\n\n" +
       "WHEN NOT:\n" +
-      "  - One command, no follow-up search -> ctx_execute is simpler\n\n" +
-      "CONCURRENCY:\n" +
-      "  - 4-8 for I/O-bound: gh, curl, multi-region cloud queries, multi-repo git reads.\n" +
-      "  - 1 for CPU-bound or stateful: npm test, build, lint, ports, lock files.\n\n" +
-      "RETURNS: section list + top matches per query. Add a processing command that console.log()s only the answer when you need to filter or aggregate.\n\n" +
+      "  - One command, no follow-up search -> ctx_execute is simpler\n" +
+      "  - CPU-bound or stateful commands -> keep concurrency at 1 (npm test, build, lint, ports, lock files)\n\n" +
+      "RETURNS:\n" +
+      "  Section list plus top matches per query. Add a processing command that console.log()s only the answer when you need to filter or aggregate.\n\n" +
       "EXAMPLE: ctx_batch_execute(\n" +
       "  commands: [{label:\"issue 1\", command:\"gh issue view 1\"}, {label:\"issue 2\", command:\"gh issue view 2\"}],\n" +
       "  queries: [\"root cause\", \"proposed fix\"],\n" +
@@ -3705,24 +3704,24 @@ server.registerTool(
   {
     title: "Purge Knowledge Base",
     description:
-      "DESTRUCTIVE — permanently delete indexed content. CANNOT be undone.\n\n" +
-      "You MUST specify exactly ONE scope:\n\n" +
-      "  • { confirm: true, sessionId: \"<uuid>\" }\n" +
-      "      Deletes ONLY that session's events + per-session FTS5 chunks.\n" +
-      "      Preserves stats file and ALL other sessions.\n\n" +
-      "  • { confirm: true, scope: \"project\" }\n" +
-      "      Wipes the ENTIRE project: FTS5 knowledge base, every session DB row,\n" +
-      "      events markdown, AND resets the stats file.\n\n" +
-      "REFUSAL RULES (tool returns an error):\n" +
-      "  • confirm: false                              → 'purge cancelled'\n" +
-      "  • Both sessionId AND scope:'project' provided → 'ambiguous — pick one'\n" +
-      "  • scope:'session' without sessionId           → throws (sessionId required)\n" +
-      "  • Neither sessionId NOR scope provided        → DEPRECATED: maps to\n" +
-      "    scope:'project' with a deprecation warning to stderr. Will be a hard\n" +
-      "    error in a future major.\n\n" +
-      "Use sessionId when the user asks to clear a specific conversation's data.\n" +
-      "Use scope:'project' ONLY when the user explicitly asks to reset everything.\n" +
-      "NEVER call with bare {confirm:true} — always specify the scope.",
+      "DESTRUCTIVE: permanently delete indexed content. Cannot be undone. Requires confirm:true and exactly one scope.\n\n" +
+      "WHEN:\n" +
+      "  - User explicitly asks to clear a specific session ('purge this session', 'wipe this conversation')\n" +
+      "  - User explicitly asks to reset the whole project ('reset everything', 'wipe the knowledge base')\n\n" +
+      "WHEN NOT:\n" +
+      "  - User says 'reset', 'clear', or 'wipe' without naming a scope -> ask which scope before calling\n" +
+      "  - User wants to free memory or improve performance -> recommend ctx_stats first, do not purge\n\n" +
+      "SCOPES (pass exactly one):\n" +
+      "  - Per-session: ctx_purge(confirm: true, sessionId: \"<uuid>\") deletes that session's events and per-session FTS5 chunks; sibling sessions and stats file are preserved.\n" +
+      "  - Per-project: ctx_purge(confirm: true, scope: \"project\") wipes FTS5 knowledge base, every session DB row, events markdown, and resets the stats file.\n\n" +
+      "CONTRACT:\n" +
+      "  - confirm:true is required; confirm:false returns 'purge cancelled'.\n" +
+      "  - sessionId and scope:'project' together return 'ambiguous - pick one'.\n" +
+      "  - scope:'session' without sessionId throws (sessionId required).\n" +
+      "  - Bare {confirm:true} is deprecated: maps to scope:'project' with a stderr warning; will hard-error in a future major.\n\n" +
+      "RETURNS: a summary of removed rows + the resolved scope.\n\n" +
+      "EXAMPLE: ctx_purge(confirm: true, sessionId: \"7c8a-1234-5678-9abc-def012345678\")\n" +
+      "EXAMPLE: ctx_purge(confirm: true, scope: \"project\")",
     // NOTE: schema MUST be a plain z.object — no .refine()/.transform()/
     // .superRefine() wrapper. See block comment above & issue #563. The
     // cross-field ambiguity check lives in the handler body below.

--- a/src/server.ts
+++ b/src/server.ts
@@ -2667,10 +2667,23 @@ async function ssrfGuard(rawUrl: string): Promise<FetchOneResult | null> {
       }
     }
   } catch (err) {
+    // libuv DNS error codes that typically indicate the resolver itself can't
+    // reach a nameserver — common when the MCP host process is running under
+    // a sandbox that blocks outbound network, OR a transient upstream DNS
+    // hiccup. Append an imperative retry hint so the agent does not capitulate
+    // to training data on the FIRST transient failure (PR #654 substitute —
+    // sibling-tool consistency with hooks/core/routing.mjs WebFetch wording).
+    const errCode = (err as NodeJS.ErrnoException | undefined)?.code ?? "";
+    const isTransientDns = errCode === "ETIMEOUT" || errCode === "ETIMEDOUT" ||
+      errCode === "EAI_AGAIN" || errCode === "ENETUNREACH" || errCode === "EPERM";
+    const baseMsg = err instanceof Error ? err.message : String(err);
+    const hint = isTransientDns
+      ? " — transient DNS error; retry once before falling back. If it keeps failing, the MCP host may be running under a network sandbox; restart the host with network access enabled."
+      : "";
     return {
       kind: "fetch_error",
       url: rawUrl,
-      error: `DNS lookup failed for "${parsed.hostname}": ${err instanceof Error ? err.message : String(err)}`,
+      error: `DNS lookup failed for "${parsed.hostname}": ${baseMsg}${hint}`,
       reason: "exit",
     };
   }
@@ -2768,7 +2781,18 @@ async function fetchOneUrl(url: string, source: string | undefined, force: boole
       timeout: 30_000,
     });
     if (result.exitCode !== 0) {
-      return { kind: "fetch_error", url, error: result.stderr || result.stdout || "unknown error", reason: "exit" };
+      // Subprocess fetch failure — undici / fetch can surface EAI_AGAIN /
+      // ETIMEDOUT / ENETUNREACH in stderr when the resolver is overloaded
+      // or the network is briefly unavailable. Append the same retry hint
+      // ssrfGuard's pre-flight DNS path emits so the agent doesn't capitulate
+      // to training data on the first transient failure (PR #654 substitute —
+      // sibling-tool consistency with hooks/core/routing.mjs WebFetch wording).
+      const raw = result.stderr || result.stdout || "unknown error";
+      const isTransientDns = /\b(EAI_AGAIN|ETIMEDOUT|ETIMEOUT|ENETUNREACH|EPERM|getaddrinfo)\b/.test(raw);
+      const hint = isTransientDns
+        ? " — transient DNS error; retry once before falling back. If it keeps failing, the MCP host may be running under a network sandbox; restart the host with network access enabled."
+        : "";
+      return { kind: "fetch_error", url, error: `${raw}${hint}`, reason: "exit" };
     }
     const header = (result.stdout || "").trim();
     let markdown: string;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1435,6 +1435,8 @@ WHEN:
   - You intend to derive an answer FROM data (filter, count, aggregate, parse, compare, transform) — do the derivation in code and print only the answer
   - Output shape or size cannot be predicted before execution (recursive finds, repo-wide greps, list endpoints, query results, log scans)
   - You would otherwise read raw output and then mentally compute — that compute belongs here, in code, where its inputs stay out of your conversation
+  - You need to keep a long-running process alive (dev server, watcher, daemon) — pass \`background: true\` to detach on timeout instead of killing the process
+  - The output may legitimately be large but you only want recall-by-topic later — pass an \`intent\` string; outputs over ~5KB are auto-indexed into the knowledge base and only the section titles + previews come back, retrievable via ctx_search
 
 WHEN NOT:
   - Single observational command whose entire short output you intend to consume verbatim (whoami, pwd, git status on a clean tree) — Bash is simpler
@@ -1442,7 +1444,7 @@ WHEN NOT:
   - You already know the output is one short fixed line and you want to read it as-is
 
 RETURNS:
-  Only what your code prints. Wrap risky calls in try/catch — uncaught errors go to stderr and may leak more than intended.
+  Only what your code prints. Wrap risky calls in try/catch — uncaught errors go to stderr and may leak more than intended. When \`intent\` is set and output exceeds the auto-index threshold, the response carries searchable section titles + previews instead of the raw stdout; use ctx_search(queries: [...]) to drill into specific sections.
 
 EXAMPLE: ctx_execute(language: "shell", code: "npm test 2>&1 | grep -E '(FAIL|✗|×|Error:|Tests +.*(failed|passed))' | head -60")
 EXAMPLE: ctx_execute(language: "javascript", code: "const out = require('child_process').execSync('gh issue list --json number,title --limit 100', {encoding:'utf8'}); const hooks = JSON.parse(out).filter(i => /hook|routing/i.test(i.title)); console.log(\`\${hooks.length} hook-related issues\`)")`,
@@ -1788,6 +1790,7 @@ WHEN:
   - You want to KNOW SOMETHING ABOUT a file (line count, matches of a pattern, parsed structure, statistical aggregate) without needing to SEE all of it
   - The file is structured (CSV, JSON, log, code) and a code-level derivation is cheaper than reading verbatim
   - The file is large enough that reading the full content would burn meaningful conversation memory you need for the actual work
+  - The derivation may itself produce a large output you want recall-by-topic on later — pass an \`intent\` string; outputs over ~5KB are auto-indexed and only matching sections come back, retrievable via ctx_search
 
 WHEN NOT:
   - You intend to EDIT the file — use Read so the subsequent Edit can match the exact text
@@ -1795,7 +1798,7 @@ WHEN NOT:
   - The file is small AND you will consume all of it for understanding/editing — Read directly
 
 RETURNS:
-  Only what your code prints. The FILE_CONTENT variable holds the raw bytes inside the sandbox; nothing else leaves.
+  Only what your code prints. The FILE_CONTENT variable holds the raw bytes inside the sandbox; nothing else leaves. When \`intent\` is set and output exceeds the auto-index threshold, the response carries searchable section titles + previews instead of the raw stdout.
 
 EXAMPLE: ctx_execute_file(path: "huge.log", language: "javascript", code: "const errs = FILE_CONTENT.split('\\\\n').filter(l => /ERROR|FATAL/.test(l)); console.log(\`\${errs.length} error lines\`); console.log(errs.slice(-5).join('\\\\n'))")
 EXAMPLE: ctx_execute_file(path: "data.csv", language: "javascript", code: "const rows = FILE_CONTENT.split('\\\\n'); console.log(\`rows: \${rows.length - 1}, header: \${rows[0]}\`)")`,
@@ -2119,23 +2122,28 @@ server.registerTool(
   "ctx_search",
   {
     title: "Search Indexed Content",
-    description: `Search indexed content (BM25 over an FTS5 store). File-backed sources auto-refresh when the source file changes.
+    description: `Search a unified knowledge base with a multi-strategy ranking pipeline. Two parallel matchers run on every query: a Porter-stemming matcher ("caching" finds "cached", "caches", "cach") and a trigram-substring matcher ("useEff" finds "useEffect"). Their ranked lists are merged via Reciprocal Rank Fusion, so a document that ranks well in both surfaces above one that wins only on a single strategy. Multi-term queries get an additional proximity-rerank pass that boosts passages where the query terms appear close together. Typos are corrected via Levenshtein distance and re-searched. Result snippets are window-extracted around the matched terms, not blindly truncated.
+
+The knowledge base is unified: queries reach indexed content you stored (ctx_index, ctx_fetch_and_index, ctx_batch_execute output) AND auto-captured session memory written by hooks (decisions, errors, blockers, plans, user prompts, rejected approaches, tool failures, compaction guides — 26 event categories). File-backed sources carry a content hash and auto-flag staleness when the source file changes.
 
 WHEN:
-  - You already indexed content via ctx_batch_execute, ctx_index, or ctx_fetch_and_index
-  - You have multiple related questions about that content - batch them in one call
-  - You want to scope to one labelled source (pass \`source\`)
-  - You want to query auto-captured session memory: decisions, errors, blockers, plans, user prompts, rejected approaches, post-compact session guides
+  - You want to recall something that exists in storage (recently indexed content, prior session events, auto-memory) instead of re-reading raw sources
+  - You have multiple related questions about the same body of knowledge — batch every question into one call (the ranking pipeline runs per-query but the round-trip cost is paid once)
+  - You want to scope the query to one labelled source (pass \`source\` — partial match is fine)
+  - You want a chronological view across current session + prior sessions + persistent auto-memory (pass \`sort: "timeline"\` — the default \`relevance\` mode only ranks within the current session)
+  - You want to filter ranked results by content shape (pass \`contentType: "code"\` to surface implementation snippets or \`contentType: "prose"\` to surface explanations)
 
 WHEN NOT:
-  - Nothing has been indexed yet AND no session memory has accumulated - run ctx_batch_execute, ctx_index, or ctx_fetch_and_index first
-  - You only have a single one-off question on un-indexed data - ctx_execute is simpler
+  - The data you want to query has never been stored in the knowledge base AND no session memory has accumulated around it — capture first (run a gather-and-index call), then come back here to query
+  - You have one ad-hoc question against data that is not in the knowledge base — answer it inline by running code in the sandbox tool; one round-trip instead of capture-then-query
 
 RETURNS:
-  Top matches per query with section headers and content previews. Use 2-4 specific terms per query and pass every question in the queries array. Common session-memory sources: \`decision\`, \`error\`, \`error-resolution\`, \`blocker\`, \`plan\`, \`user-prompt\`, \`rejected-approach\`, \`compaction\`. Pass \`sort: "timeline"\` for chronological retrieval; see ctx_stats for live category counts.
+  Per-query ranked sections with window-extracted snippets. Use 2-4 specific technical terms per query. Common session-memory source labels: \`decision\` (user corrections / preferences), \`error\` and \`error-resolution\` (past failures + their fixes), \`blocker\`, \`plan\`, \`user-prompt\`, \`rejected-approach\`, \`compaction\` (post-compact session guide). See ctx_stats for live category counts.
 
 EXAMPLE: ctx_search(queries: ["root cause", "proposed fix", "test coverage"], source: "issue-#683")
-EXAMPLE: ctx_search(queries: ["what did we decide"], source: "decision", sort: "timeline")`,
+EXAMPLE: ctx_search(queries: ["what did we decide about caching"], source: "decision", sort: "timeline")
+EXAMPLE: ctx_search(queries: ["useEffect cleanup pattern"], source: "react-docs", contentType: "code", limit: 5)
+EXAMPLE: ctx_search(queries: ["last user prompt", "active skills", "open blockers"], sort: "timeline")`,
     inputSchema: z.object({
       queries: z.preprocess(coerceJsonArray, z
         .array(z.string())
@@ -2923,19 +2931,22 @@ server.registerTool(
   "ctx_fetch_and_index",
   {
     title: "Fetch & Index URL(s)",
-    description: `Fetches URL content, converts HTML to markdown, indexes into a searchable knowledge base (BM25 over FTS5), and returns a ~3KB preview per source. Raw HTML never enters your conversation — the full content stays in storage, retrievable on-demand via ctx_search. Content-type aware: HTML becomes markdown, JSON is chunked by key paths, plain text is indexed directly.
+    description: `Fetches URL content, converts HTML to markdown (JSON is chunked by key paths, plain text indexed directly), persists it in a searchable knowledge base, and returns a small preview window per source. The raw page bytes never enter your conversation — they live in storage and you retrieve any section on-demand via ctx_search.
+
+Caching: every fetch is cached on disk and reused for repeat calls within the TTL window. The default TTL is 24 hours; override per-call with the \`ttl\` parameter (milliseconds, \`ttl: 0\` bypasses cache like \`force: true\`). Stored content older than 14 days is cleaned up on startup.
 
 WHEN:
-  - You need web content (docs, changelogs, API references) and the raw page bytes should NOT enter your conversation memory
-  - Multi-URL research: library evaluation, migration scans, doc comparisons — pass \`requests\` array with concurrency 4-8 for parallel I/O
-  - The preview is enough to plan follow-up ctx_search calls
+  - You need web content (docs, changelogs, API references, spec pages) and the raw page bytes should NOT enter your conversation
+  - Multi-URL research (library evaluation, migration scans, doc comparisons): pass the \`requests\` array and a \`concurrency\` value 2-8 for parallel I/O
+  - You want repeat lookups against the same URL to be cheap (TTL cache hits return only a hint, no re-fetch)
+  - You want a long-lived cache window (override \`ttl\` upward for stable specs) or a guaranteed-fresh fetch (\`ttl: 0\` or \`force: true\`)
 
 WHEN NOT:
-  - You already have the content locally — ctx_index handles raw text or files
-  - The page is SPA-rendered (JavaScript-required) — this is a plain HTTP fetch, no headless browser
+  - You already have the content locally — store it via the inline index tool
+  - The page is SPA-rendered (JavaScript-required to materialize content) — this is a plain HTTP fetch, no headless browser
 
 RETURNS:
-  A ~3KB preview per fetched source plus indexing metadata (chunk counts, source labels). Raw content is NOT echoed back — retrieve any section on-demand via ctx_search(source: "<label>"). Fetches parallelize up to \`concurrency\`; FTS5 indexing then serializes writes (SQLite single-writer rule).
+  Per-source preview windows extracted around indexable headings plus indexing metadata (chunk counts, source labels, cache state). Raw content is NOT echoed back — retrieve any section on-demand via ctx_search(source: "<label>"). Concurrency parallelizes the fetch phase up to your chosen value (capped by the host's logical CPU count); the FTS5 write phase always runs serially because SQLite is a single-writer store. Net latency = max(fetch latency across the pool) + sum(per-source index write time). Cache hits skip both phases and return a small freshness hint instead of re-fetching. Use 4-8 for stable I/O-bound batches; lower the value when the target host enforces a per-IP rate limit you cannot raise.
 
 EXAMPLE: ctx_fetch_and_index(
   requests: [{url: "https://react.dev/...", source: "react"}, {url: "https://vuejs.org/...", source: "vue"}],
@@ -3175,24 +3186,31 @@ server.registerTool(
   "ctx_batch_execute",
   {
     title: "Batch Execute & Search",
-    description: `Run multiple commands in ONE call. Output is auto-indexed. Optional queries return matching sections - no follow-up ctx_search needed.
+    description: `Run multiple commands in ONE call. Every command's output is auto-indexed into the knowledge base; if you also pass \`queries\`, the matching sections come back in the same round trip so a follow-up search call is not needed.
+
+Concurrency parallelizes the FETCH phase (run-the-commands). The DERIVATION phase — turning raw output into an answer — still belongs in code: add a processing command that consumes the indexed output and prints only the answer, so the raw bytes never enter your conversation (Think-in-Code, same principle as the sandbox tool).
 
 WHEN:
-  - You have 3+ related commands (gh issue view x N, git log + git diff, multi-file reads)
-  - You want to gather + search in one round trip
-  - You want to parallelize I/O-bound calls (pass concurrency 4-8 for gh, curl, multi-region cloud queries, multi-repo git reads)
+  - You have 3+ related commands you would otherwise run sequentially (multi-issue lookups, git log + git diff + git blame, multi-file reads, multi-region cloud queries)
+  - You want to gather AND query in one round trip — pass \`queries\` so the matching sections come back inline
+  - You want to parallelize I/O-bound work — pass \`concurrency\` 2-8 (network calls, gh CLI, cloud APIs, multi-repo git reads)
+  - The combined output is large enough that piping it through ctx_search later would itself be expensive — let auto-index + inline queries do both in one shot
 
 WHEN NOT:
-  - One command, no follow-up search -> ctx_execute is simpler
-  - CPU-bound or stateful commands -> keep concurrency at 1 (npm test, build, lint, ports, lock files)
+  - Single command with no follow-up query — run it in the sandbox tool directly
+  - CPU-bound or stateful commands — keep concurrency at 1 (npm test, build, lint, port-binding servers, lock-file holders, anything that races on the same resource)
 
 RETURNS:
-  Section list plus top matches per query. Add a processing command that console.log()s only the answer when you need to filter or aggregate.
+  Auto-indexed section list per command label, plus top matches per query (when \`queries\` is passed). Raw output is NOT echoed in full — only the matched windows. Concurrency>1 switches each command to its own per-command timeout (no shared budget); concurrency=1 preserves the legacy shared-budget cascading-skip-on-timeout path. Use 4-8 for I/O-bound batches; keep at 1 for CPU work or shared-state commands; lower the value when target hosts enforce per-IP rate limits.
 
 EXAMPLE: ctx_batch_execute(
-  commands: [{label:"issue 1", command:"gh issue view 1"}, {label:"issue 2", command:"gh issue view 2"}],
+  commands: [
+    {label: "issue 1", command: "gh issue view 1"},
+    {label: "issue 2", command: "gh issue view 2"},
+    {label: "summarize", command: "echo done"}
+  ],
   queries: ["root cause", "proposed fix"],
-  concurrency: 4
+  concurrency: 2
 )`,
     inputSchema: z.object({
       commands: z.preprocess(coerceCommandsArray, z
@@ -4114,7 +4132,11 @@ server.registerTool(
       "Opens the context-mode Insight dashboard in the browser. " +
       "Shows personal analytics: session activity, tool usage, error rate, " +
       "parallel work patterns, project focus, and actionable insights. " +
-      "First run installs dependencies (~30s). Subsequent runs open instantly.",
+      "First run installs dependencies (~30s). Subsequent runs open instantly. " +
+      "Defaults to port 4747; pass `port` to override. " +
+      "`sessionDir` and `contentDir` override the session/content storage roots " +
+      "(env aliases INSIGHT_SESSION_DIR / INSIGHT_CONTENT_DIR) for diagnosing " +
+      "multi-install setups or pointing at a sibling project's data.",
     inputSchema: z.object({
       port: z.coerce.number().int().min(1).max(65535).optional().describe("Port to serve on (default: 4747)"),
       sessionDir: z.string().optional().describe("Override INSIGHT_SESSION_DIR: directory containing context-mode session .db files"),

--- a/src/session/extract.ts
+++ b/src/session/extract.ts
@@ -62,6 +62,24 @@ function safeStringAny(value: unknown): string {
 
 function isToolError(input: HookInput): boolean {
   const response = String(input.tool_response ?? "");
+  // PreToolUse rewrites curl/wget/inline-HTTP/WebFetch commands into
+  //   echo "context-mode: <guidance text including 'retry', 'fails', 'error'>"
+  // The user-facing copy legitimately mentions failure modes ("retry if it
+  // fails with a transient DNS error"), but those words must NOT classify
+  // our OWN guidance message as a tool error or it gets captured into
+  // session_resume and surfaces as a fake error in the next chat.
+  // We check BOTH sides because:
+  //   - real shell run → response starts with `context-mode:` (echo stdout)
+  //   - test/captured-output path → response is the raw command itself
+  //     (`echo "context-mode: …"`), so we also match the command shape
+  const command = String(input.tool_input?.command ?? "");
+  if (
+    response.startsWith("context-mode:") ||
+    command.startsWith('echo "context-mode:') ||
+    command.startsWith("echo 'context-mode:")
+  ) {
+    return false;
+  }
   const isErrorFlag = input.tool_output?.isError === true || input.tool_output?.is_error === true;
   const isBashError =
     input.tool_name === "Bash" &&

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -2080,9 +2080,14 @@ describe("Hook Injection", () => {
       prompt.includes("<tool_selection_hierarchy>"),
       "Should inject tool_selection_hierarchy",
     );
+    // PR #683 follow-up (ADR-0002 + ADR-0003 hook prompt-surface contract):
+    // <forbidden_actions> renamed to <when_not_to_use> to drop the
+    // Constitutional-AI-trigger container name (rubric #9). Semantic intent
+    // — "Bash, Read, WebFetch, ctx_execute have wrong-tool selection cues
+    // injected into every session" — is preserved and asserted here.
     assert.ok(
-      prompt.includes("<forbidden_actions>"),
-      "Should inject forbidden_actions",
+      prompt.includes("<when_not_to_use>"),
+      "Should inject when_not_to_use (the affirmative successor to <forbidden_actions>, ADR-0002)",
     );
   });
 
@@ -5426,4 +5431,195 @@ describe("tool description style contract (#683 ADR-0002)", () => {
       }
     });
   }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Hook routing prompt-surface contract (#683 ADR-0002 + ADR-0003 extension)
+//
+// `src/server.ts` carries the MCP tool-description surface (read by host
+// LLMs at tool-selection time). The hook routing layer carries TWO MORE
+// agent-facing prompt surfaces that share the same cross-LLM safety bias
+// concerns (rubric #9):
+//
+//   1. `hooks/routing-block.mjs` — system-prompt injection text shipped on
+//      every SessionStart and every routing redirect. Lives in 100% of
+//      sessions; higher blast radius than any single tool description.
+//   2. `hooks/core/routing.mjs` — runtime deny-reason strings shown to the
+//      agent when a Bash / Read / Grep / WebFetch call is intercepted.
+//      ADR-0003 distinguishes:
+//        - CASE A (routing redirect — alternative tool exists for
+//          context-window or efficiency reasons) → MUST use "redirected"
+//          opener, MUST NOT use bare "BLOCKED".
+//        - CASE B (true security / policy restriction) → "blocked by
+//          security policy" + matched pattern is correct and expected.
+//
+// This block extends the ADR-0002 forbidden-token contract above to both
+// surfaces, plus enforces ADR-0003 CASE A wording requirements on every
+// `action: "deny"` / redirect-emitting branch in `routing.mjs`.
+//
+// One contract test, three prompt surfaces. Single regression guard.
+// ──────────────────────────────────────────────────────────────────────────
+describe("hook routing prompt-surface contract (#683 ADR-0002 + ADR-0003)", () => {
+  const routingMjsPath = resolve(__dirname, "../../hooks/core/routing.mjs");
+  const routingBlockMjsPath = resolve(__dirname, "../../hooks/routing-block.mjs");
+  const routingMjs = readFileSync(routingMjsPath, "utf-8");
+  const routingBlockMjs = readFileSync(routingBlockMjsPath, "utf-8");
+
+  // Forbidden tokens that apply to BOTH hook prompt surfaces. These are
+  // a strict superset of the ADR-0002 ctx_* description rules above
+  // because routing.mjs deny reasons and routing-block.mjs guidance run
+  // as system-prompt injection — exactly the layer where Constitutional AI
+  // safety priors fire most aggressively (rubric #9).
+  //
+  // Each pattern is documented inline so a future contributor reading a
+  // failure understands the rationale, not just the regex.
+  type SurfaceRule = { name: string; pattern: RegExp; rationale: string };
+  const SURFACE_FORBIDDEN: SurfaceRule[] = [
+    {
+      name: "<forbidden_actions> XML container",
+      // Rubric #9: the container name itself is a Constitutional AI
+      // trigger. Anthropic-tier models are RLHF'd to handle anything
+      // tagged "forbidden" with extra caution, which inverts the intent
+      // (the agent should follow the directive, not refuse it).
+      // Reframe positively as <when_not_to_use> or fold into the
+      // affirmative hierarchy.
+      pattern: /<forbidden_actions>/,
+      rationale: "Rename to <when_not_to_use> or fold into positive hierarchy (rubric #2 + #9).",
+    },
+    {
+      name: "NEVER (uppercase imperative)",
+      // Rubric #2 + #7: smaller / cross-family models fixate on the
+      // forbidden token (ironic process theory). Use ALWAYS / WHEN NOT
+      // structure instead.
+      pattern: /\bNEVER\b/,
+      rationale: "Rewrite uppercase NEVER as ALWAYS / WHEN NOT / positive directive.",
+    },
+    {
+      name: "FORBIDDEN (capital banner)",
+      // Same rubric. Pure negative banner with no positive counterpart
+      // is the highest-risk framing under Constitutional AI priors.
+      pattern: /\bFORBIDDEN\b/,
+      rationale: "Avoid 'FORBIDDEN' banner; express as positive WHEN: cues.",
+    },
+    {
+      name: "NO X for Y bullet",
+      // Rubric #2: bullet-list negatives anchor the agent's attention
+      // on the prohibited action. Convert each bullet to "Use Y for X"
+      // (affirmative redirect).
+      pattern: /^\s*-\s*NO\s+(Bash|Read|Grep|WebFetch|ctx_)/m,
+      rationale: "Convert 'NO X for Y' bullets to positive 'Use Y for X' redirects.",
+    },
+  ];
+
+  test("hooks/routing-block.mjs MUST NOT contain forbidden tokens", () => {
+    const failures: string[] = [];
+    for (const rule of SURFACE_FORBIDDEN) {
+      const m = routingBlockMjs.match(rule.pattern);
+      if (m) {
+        const lineNo = routingBlockMjs.slice(0, m.index ?? 0).split("\n").length;
+        failures.push(
+          `hooks/routing-block.mjs:${lineNo} contains forbidden token '${m[0]}' ` +
+            `(rule: ${rule.name}). ${rule.rationale}`,
+        );
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  test("hooks/core/routing.mjs MUST NOT contain forbidden tokens", () => {
+    const failures: string[] = [];
+    for (const rule of SURFACE_FORBIDDEN) {
+      const m = routingMjs.match(rule.pattern);
+      if (m) {
+        const lineNo = routingMjs.slice(0, m.index ?? 0).split("\n").length;
+        failures.push(
+          `hooks/core/routing.mjs:${lineNo} contains forbidden token '${m[0]}' ` +
+            `(rule: ${rule.name}). ${rule.rationale}`,
+        );
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  // ── ADR-0003 enforcement on routing.mjs deny / redirect strings ──
+  //
+  // Mechanically: any string literal that the agent sees as a redirect
+  // explanation (curl/wget, inline HTTP, build tools, WebFetch) is CASE A.
+  // ADR-0003 CASE A REQUIRES:
+  //   - Opens with the verb "redirected"
+  //   - MUST NOT contain the bare uppercase token "BLOCKED" (reserved for
+  //     CASE B — see `Blocked by security policy: …` form)
+  //   - MUST name the alternative ctx_* tool the agent should use
+  //
+  // CASE B (security policy) strings live in the same file and use the
+  // form `Blocked by security policy: matches deny pattern <pat>`. Those
+  // are correct AS-IS — the test only enforces CASE A on CASE A strings.
+  //
+  // Detection heuristic: a string-literal segment that contains "redirected"
+  // is CASE A. A string segment that contains "Blocked by security policy"
+  // is CASE B (exempt). String segments are extracted naively from the
+  // source by walking forward from each return statement and capturing the
+  // template-literal payload up to the closing backtick — sufficient for
+  // the four current call sites (L707, L738, L751, L804) and any future
+  // ones a contributor adds.
+  describe("ADR-0003 CASE A: routing.mjs redirect deny reasons", () => {
+    type CaseAString = { lineNo: number; payload: string };
+
+    function extractCaseAStrings(src: string): CaseAString[] {
+      const lines = src.split("\n");
+      const out: CaseAString[] = [];
+      for (let i = 0; i < lines.length; i++) {
+        const ln = lines[i];
+        // Skip comments — both single-line // and JSDoc * lines that mention
+        // 'redirected' as documentation of the routing case, not as a deny
+        // payload. The real CASE A payloads live inside template literals
+        // assigned to `command:` or `reason:` object keys.
+        const trimmed = ln.replace(/^\s+/, "");
+        if (trimmed.startsWith("//") || trimmed.startsWith("*")) continue;
+        // Require BOTH "redirected" AND a template-literal backtick
+        // (current shape for L707/738/751/804). CASE B strings use the
+        // `Blocked by security policy: …` form and are excluded.
+        if (
+          /redirected/i.test(ln) &&
+          /`/.test(ln) &&
+          !/Blocked by security policy/.test(ln)
+        ) {
+          out.push({ lineNo: i + 1, payload: ln });
+        }
+      }
+      return out;
+    }
+
+    const caseAs = extractCaseAStrings(routingMjs);
+
+    test("at least 4 CASE A redirect strings present (sanity check on extractor)", () => {
+      // Current corpus: L707 curl/wget, L738 inline HTTP, L751 build tools,
+      // L804 WebFetch. If a contributor removes one, the count drops and
+      // this sanity check forces the test author to revisit the extractor.
+      expect(caseAs.length).toBeGreaterThanOrEqual(4);
+    });
+
+    for (const cs of caseAs) {
+      describe(`hooks/core/routing.mjs:${cs.lineNo}`, () => {
+        test("MUST open with the verb 'redirected' (CASE A wording — ADR-0003)", () => {
+          expect(cs.payload).toMatch(/redirected/i);
+        });
+
+        test("MUST NOT contain bare uppercase BLOCKED (reserved for CASE B)", () => {
+          // ADR-0003: CASE A strings MUST NOT borrow CASE B vocabulary.
+          // Lowercase `block` (e.g. `blockchain`) is fine; uppercase BLOCKED
+          // is the Constitutional AI trigger.
+          expect(cs.payload).not.toMatch(/\bBLOCKED\b/);
+        });
+
+        test("MUST name at least one ctx_* alternative tool", () => {
+          // ADR-0003 §CASE A: "MUST specify the alternative tool to use."
+          // The current four sites all name ctx_execute and/or
+          // ctx_fetch_and_index — we just enforce that SOMETHING ctx_*
+          // is mentioned so the agent has a concrete next call.
+          expect(cs.payload).toMatch(/ctx_(execute|fetch_and_index|search|batch_execute)/);
+        });
+      });
+    }
+  });
 });

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -5562,6 +5562,42 @@ describe("tool description style contract (#683 ADR-0002)", () => {
             `Use markdown '- ' bullets only (ADR-0002 §Canonical structure).`,
           ).toEqual([]);
         });
+
+        // ── PR #683 second amendment (Mert flag): RETURNS form uniformity ──
+        //
+        // ADR-0002 L56-57 specifies RETURNS as a header on its own line with
+        // the body on the next line indented (matching WHEN: / WHEN NOT:
+        // shape). Three tools (ctx_execute, ctx_execute_file, ctx_purge)
+        // historically used inline form ("RETURNS: only your printed output.")
+        // while four tools (ctx_index, ctx_search, ctx_fetch_and_index,
+        // ctx_batch_execute) used the canonical header+body form. Mert flagged
+        // the visual inconsistency on review. This guard locks the canonical
+        // form so the regression can't slip back.
+        //
+        // EXAMPLE: stays inline per ADR-0002 L59 ("EXAMPLE: <one canonical
+        // call>"). The asymmetry is intentional — RETURNS prose is multi-line
+        // capable, EXAMPLE values are one-call-per-line.
+        test("RETURNS: header MUST be on its own line, body indented below (ADR-0002 L56-57)", () => {
+          // Match RETURNS: followed by anything other than \n on the same
+          // line (treating \\n source escape as the same boundary as a real
+          // newline). Inline form like "RETURNS: only your printed output."
+          // fails; header+body form like "RETURNS:\n  Only your printed
+          // output." passes.
+          //
+          // Source descriptions live either as template literals with real
+          // newlines OR as `+ "...\n"` concat strings with escape sequences.
+          // Match both shapes via a non-newline-non-backslash assertion.
+          const inlineRe = /RETURNS:[ \t]+[^\n\\]/;
+          const m = tool.description.match(inlineRe);
+          expect(
+            m,
+            m
+              ? `${tool.name} (src/server.ts:${tool.lineNo}) uses inline RETURNS form: '${m[0]}…'. ` +
+                `ADR-0002 L56-57 requires header on its own line with body indented below. ` +
+                `Rewrite as 'RETURNS:\\n  <body>'.`
+              : "RETURNS: header on own line.",
+          ).toBeNull();
+        });
       }
     });
   }
@@ -5779,6 +5815,24 @@ describe("hook routing prompt-surface contract (#683 ADR-0002 + ADR-0003)", () =
           // the disallowed action. Express as the positive next step — the
           // ctx_execute / ctx_fetch_and_index call IS the next step.
           expect(cs.payload).not.toMatch(/\bDo\s+NOT\s+retry\b/i);
+        });
+
+        // ── PR #683 second amendment (Mert flag): no org-rationale preface ──
+        //
+        // The first amendment replaced the bare-NOT parenthetical
+        // "(context-window optimization, NOT a network restriction)" with the
+        // affirmative-voice opening "redirected to <ctx_tool> for context-window
+        // efficiency". Mert's second-pass flag: the "for X reason" preface is
+        // org-rationale, not action input. The agent's job is to (a) make the
+        // correct next call, (b) know it has the capability, (c) know when to
+        // retry — not to audit policy. The capability affirmation
+        // "<ctx_tool> has full network access" already carries the substantive
+        // signal the rationale was double-encoding. ADR-0003 §Second amendment.
+        //
+        // Compare HTTP 301: the response carries "Location: <new-url>" and the
+        // client uses it. The server never appends "for SEO efficiency".
+        test("MUST NOT contain 'for context-window efficiency' org-rationale (PR #683 second amendment)", () => {
+          expect(cs.payload).not.toMatch(/\bfor\s+context-window\s+(efficiency|optimization)\b/i);
         });
       });
     }

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3112,12 +3112,18 @@ describe("batch_execute FS read tracking", () => {
   });
 
   test("tool description documents the concurrency field with positive guidance", () => {
-    // PR #683 / ADR-0002: emoji bullets replaced with prose. The guidance
-    // still names the I/O-bound vs CPU-bound split and the speedup window,
-    // but uses positive WHEN: structure instead of ✅/❌ rows.
-    expect(serverSrc).toContain("4-8 for I/O-bound");
-    expect(serverSrc).toContain("1 for CPU-bound");
-    expect(serverSrc).toContain("CONCURRENCY");
+    // PR #683 / ADR-0002: emoji bullets replaced with prose. The standalone
+    // CONCURRENCY: section was folded into WHEN: / WHEN NOT: prose by the
+    // PR #683 WS3 canonical-structure pass so descriptions only carry the
+    // four canonical sections (WHEN / WHEN NOT / RETURNS / EXAMPLE) plus
+    // approved per-tool carve-outs (e.g. ctx_purge SCOPES / CONTRACT).
+    // The I/O-bound vs CPU-bound split and the 4-8 speedup window are still
+    // named — just inline in the WHEN clauses now, not under a separate
+    // UPPERCASE banner.
+    expect(serverSrc).toContain("parallelize I/O-bound calls");
+    expect(serverSrc).toContain("concurrency 4-8");
+    expect(serverSrc).toContain("CPU-bound or stateful");
+    expect(serverSrc).toContain("keep concurrency at 1");
   });
 });
 
@@ -3658,14 +3664,17 @@ describe("ctx_fetch_and_index batch refactor", () => {
   });
 
   test("PARALLELIZE I/O guidance + locked requests:[] schema in description", () => {
-    // PR #683 / ADR-0002: emoji bullets replaced with prose, "PARALLELIZE
-    // I/O" banner replaced with a positive CONCURRENCY: section. The
-    // requests:[{url, source}] schema callout stays (it's a contract cue),
-    // and the I/O-bound vs single-URL split is still named — just in prose.
-    expect(fetchHandlerSrc).toContain("CONCURRENCY");
+    // PR #683 / ADR-0002: emoji bullets replaced with prose. PR #683 WS3
+    // (canonical structure) folded the dedicated CONCURRENCY: section into
+    // the WHEN: / RETURNS: prose so the description carries only the
+    // canonical four sections (WHEN / WHEN NOT / RETURNS / EXAMPLE).
+    // The requests:[{url, source}] schema callout stays (contract cue), and
+    // the I/O-bound multi-URL guidance + the FTS5 serial-write contract
+    // remain explicit in the description — just inline now, not under a
+    // separate UPPERCASE banner.
     expect(fetchHandlerSrc).toContain("requests: [{url");
-    expect(fetchHandlerSrc).toContain("concurrency 4-8 for I/O-bound");
-    expect(fetchHandlerSrc).toContain("concurrency 1");
+    expect(fetchHandlerSrc).toContain("concurrency 4-8");
+    expect(fetchHandlerSrc).toContain("FTS5 indexing then serializes writes");
   });
 
   test("serial-write contract: index drain is a for-loop calling indexFetched serially", () => {
@@ -5302,17 +5311,17 @@ describe("tool description style contract (#683 ADR-0002)", () => {
     "ctx_doctor",
     "ctx_insight",
     "ctx_upgrade",
-    "ctx_purge", // deferred entirely (see EXEMPT_FROM_FORBIDDEN_TOKENS below)
   ]);
 
-  // ctx_purge is exempt from the forbidden-word scan because its rewrite is
-  // deferred to a separate PR per Probe 4 empirical evidence in
-  // TOOL-DESCRIPTIONS-AUDIT.md §6.1: heavy negative framing OUTPERFORMS the
-  // softer rewrite (5/5 vs 3/5 on parameter fidelity on Haiku). A naive
-  // wording fix here would REGRESS the tool. The follow-up PR must run a
-  // tri-LLM probe (Haiku / Sonnet / Opus) and gate merge on that probe.
-  // Documented in PR #683 body and ADR-0002.
-  const EXEMPT_FROM_FORBIDDEN_TOKENS = new Set(["ctx_purge"]);
+  // ctx_purge carve-out — the rewrite (PR #683 WS2) preserves the
+  // user-facing DESTRUCTIVE signal because Probe 4 empirically showed that
+  // soft framing regresses parameter fidelity on Haiku (5/5 → 3/5). The
+  // word "DESTRUCTIVE" is therefore an accurate-signaling carve-out,
+  // distinct from cross-LLM-bias negative framing the rubric forbids.
+  // ADR-0002 §Exemptions documents this; the WHEN/WHEN NOT/SCOPES/
+  // CONTRACT/RETURNS/EXAMPLE structure of the rewritten description still
+  // meets the canonical contract enforced below.
+  const EXEMPT_FROM_FORBIDDEN_TOKENS = new Set<string>([]);
 
   test("at least 11 ctx_* tools are registered", () => {
     // Sanity check that the extractor found the corpus.
@@ -5385,10 +5394,70 @@ describe("tool description style contract (#683 ADR-0002)", () => {
     },
   ];
 
+  // ── Canonical structure (ADR-0002 amendment, PR #683 WS3) ────────────
+  //
+  // Every non-exempt ctx_* tool description MUST follow the canonical
+  // structure documented in ADR-0002:
+  //
+  //   <1-line headline>
+  //   WHEN:        (mandatory — positive selection cues, bulleted with `- `)
+  //   WHEN NOT:    (optional — sibling-tool disambiguation, bulleted)
+  //   RETURNS:     (mandatory — what the agent gets back)
+  //   EXAMPLE:     (mandatory — one canonical call)
+  //
+  // Rules:
+  //   1. Section order MUST be WHEN -> WHEN NOT -> RETURNS -> EXAMPLE
+  //      (positive cues precede negative disambiguation, per audit rubric #2).
+  //   2. Bullets MUST use markdown `- ` only. `1.`, `1-`, `* `, and `•` are
+  //      rejected because they tokenize inconsistently across LLM families
+  //      and break the audit's bullet-uniformity contract.
+  //   3. Section headers MUST be UPPERCASE + colon at the start of a line
+  //      (after the `\n` escape in source form).
+  //   4. ctx_purge has an audit-approved carve-out for DESTRUCTIVE / SCOPES /
+  //      CONTRACT headers (accurate-signaling and parameter-fidelity
+  //      requirements that Probe 4 empirically validated). All four headers
+  //      coexist with the canonical WHEN/WHEN NOT/RETURNS/EXAMPLE.
+  //
+  // Helper: flatten the source-form description into the literal text the
+  // LLM eventually sees (collapse `\n` escapes, join `"..." + "..."` concat,
+  // strip template-literal backticks). This is the same shape the host LLM
+  // receives at tool-selection time.
+  function flattenDescription(d: string): string {
+    return d
+      .replace(/^\s*description:\s*/, "")
+      .replace(/\\n/g, "\n")
+      .replace(/\\"/g, '"')
+      .replace(/"\s*\+\s*\n\s*"/g, "")
+      .replace(/"\s*\+\s*"/g, "")
+      .replace(/^"|"$/gm, "")
+      .replace(/`/g, "");
+  }
+
+  // Per-tool carve-outs that allow non-canonical UPPERCASE: section headers.
+  // Each entry is justified inline so a future contributor reading a failure
+  // understands why the carve-out exists.
+  const ALLOWED_EXTRA_SECTIONS: Record<string, string[]> = {
+    // ctx_purge: heavy framing is empirically validated by Probe 4. The
+    // DESTRUCTIVE prefix preserves accurate user-facing signaling and
+    // SCOPES/CONTRACT preserve parameter-fidelity discipline on Haiku.
+    ctx_purge: ["DESTRUCTIVE", "SCOPES", "CONTRACT"],
+  };
+
+  // Canonical mandatory + optional sections.
+  const CANONICAL_ORDER = ["WHEN", "WHEN NOT", "RETURNS", "EXAMPLE"] as const;
+  const MANDATORY = ["WHEN", "RETURNS", "EXAMPLE"] as const;
+
+  // Bullet patterns the contract rejects in routing-target descriptions.
+  const BAD_BULLETS = [
+    { name: "numeric-dot bullet (e.g. '1.')", pattern: /^\s*\d+\.\s/m },
+    { name: "numeric-dash bullet (e.g. '1-')", pattern: /^\s*\d+-\s/m },
+    { name: "asterisk bullet (e.g. '* foo')", pattern: /^\s*\*\s/m },
+    { name: "unicode bullet (e.g. '• foo')", pattern: /^\s*•\s/m },
+  ];
+
   for (const tool of tools) {
-    // Tools exempt from BOTH groups (only ctx_purge today) have no assertions
-    // to make — emit a placeholder test so vitest doesn't error on empty
-    // describe blocks. The placeholder documents the deferral inline.
+    // Tools exempt from BOTH groups have no assertions to make — emit a
+    // placeholder test so vitest doesn't error on empty describe blocks.
     const isFullyExempt =
       EXEMPT_FROM_FORBIDDEN_TOKENS.has(tool.name) && EXEMPT_FROM_WHEN.has(tool.name);
     describe(tool.name, () => {
@@ -5427,6 +5496,71 @@ describe("tool description style contract (#683 ADR-0002)", () => {
           // template-literal and string-concat description shapes pass.
           const hasWhen = /(?:\\n|^|\s|")WHEN(?:\s+TO\s+USE)?:/.test(tool.description);
           expect(hasWhen, `${tool.name} description (src/server.ts:${tool.lineNo}) must contain a WHEN: section`).toBe(true);
+        });
+
+        // ── Canonical structure assertions (PR #683 WS3) ─────────────
+        const flat = flattenDescription(tool.description);
+
+        test("MUST contain RETURNS: and EXAMPLE: sections (canonical structure)", () => {
+          for (const section of MANDATORY) {
+            expect(
+              flat.includes(section + ":"),
+              `${tool.name} (src/server.ts:${tool.lineNo}) missing mandatory section '${section}:' per ADR-0002 canonical structure.`,
+            ).toBe(true);
+          }
+        });
+
+        test("section order MUST be WHEN -> WHEN NOT -> RETURNS -> EXAMPLE", () => {
+          // For each canonical section present, its position in the flattened
+          // description must be strictly greater than the previous canonical
+          // section's position. Carve-out headers (DESTRUCTIVE, SCOPES,
+          // CONTRACT for ctx_purge) are allowed between canonical sections
+          // — only the relative order of the canonical four is enforced.
+          let lastPos = -1;
+          for (const section of CANONICAL_ORDER) {
+            const pos = flat.indexOf(section + ":");
+            if (pos < 0) continue;
+            expect(
+              pos,
+              `${tool.name} (src/server.ts:${tool.lineNo}) section '${section}:' appears before a sibling that should follow it (positions: ${CANONICAL_ORDER.map(s => `${s}=${flat.indexOf(s + ":")}`).join(", ")}). Canonical order: WHEN -> WHEN NOT -> RETURNS -> EXAMPLE.`,
+            ).toBeGreaterThan(lastPos);
+            lastPos = pos;
+          }
+        });
+
+        test("section headers MUST be UPPERCASE + colon (no off-spec UPPERCASE sections)", () => {
+          // Extract every UPPERCASE-header occurrence (two or more uppercase
+          // chars, optional space, then colon at line start). Reject any
+          // that aren't in the canonical set or the per-tool carve-out.
+          const headerMatches = [...flat.matchAll(/^([A-Z][A-Z _]+):/gm)].map(m => m[1]);
+          const allowed = new Set<string>([...CANONICAL_ORDER, ...(ALLOWED_EXTRA_SECTIONS[tool.name] ?? [])]);
+          const offSpec = [...new Set(headerMatches.filter(h => !allowed.has(h)))];
+          expect(
+            offSpec,
+            `${tool.name} (src/server.ts:${tool.lineNo}) uses off-spec UPPERCASE sections [${offSpec.join(", ")}]. ` +
+            `Allowed: [${[...allowed].join(", ")}]. Fold operational sub-guidance (CONCURRENCY, TIPS, ...) into WHEN: / RETURNS: prose.`,
+          ).toEqual([]);
+        });
+
+        test("bullets MUST use '- ' markdown only (no '1.', '1-', '* ', or '•')", () => {
+          // Scan the flattened description. The rubric requires uniform
+          // markdown bullets so the host LLM tokenizes them consistently
+          // across Claude / GPT / Gemini / Llama. Numbered ordering inside
+          // a routing-target description is also discouraged because each
+          // bullet should be independently true, not sequenced.
+          const failures: string[] = [];
+          for (const rule of BAD_BULLETS) {
+            const m = flat.match(rule.pattern);
+            if (m) {
+              const lineNo = flat.slice(0, flat.indexOf(m[0])).split("\n").length;
+              failures.push(`${rule.name} at description-line ${lineNo}: '${m[0].trim()}'`);
+            }
+          }
+          expect(
+            failures,
+            `${tool.name} (src/server.ts:${tool.lineNo}) bullet uniformity violation: ${failures.join("; ")}. ` +
+            `Use markdown '- ' bullets only (ADR-0002 §Canonical structure).`,
+          ).toEqual([]);
         });
       }
     });

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3107,11 +3107,12 @@ describe("batch_execute FS read tracking", () => {
   });
 
   test("tool description documents the concurrency field with positive guidance", () => {
-    // Hardened guidance per PRD-concurrency-architectural.md Section 4
-    expect(serverSrc).toContain("concurrency: 4-8");
-    expect(serverSrc).toContain("3-5x");
-    expect(serverSrc).toContain("✅");
-    expect(serverSrc).toContain("❌");
+    // PR #683 / ADR-0002: emoji bullets replaced with prose. The guidance
+    // still names the I/O-bound vs CPU-bound split and the speedup window,
+    // but uses positive WHEN: structure instead of ✅/❌ rows.
+    expect(serverSrc).toContain("4-8 for I/O-bound");
+    expect(serverSrc).toContain("1 for CPU-bound");
+    expect(serverSrc).toContain("CONCURRENCY");
   });
 });
 
@@ -3652,11 +3653,14 @@ describe("ctx_fetch_and_index batch refactor", () => {
   });
 
   test("PARALLELIZE I/O guidance + locked requests:[] schema in description", () => {
-    expect(fetchHandlerSrc).toContain("PARALLELIZE I/O");
-    expect(fetchHandlerSrc).toContain("requests: [{url, source}");
-    expect(fetchHandlerSrc).toContain("3-5x");
-    expect(fetchHandlerSrc).toContain("✅");
-    expect(fetchHandlerSrc).toContain("❌");
+    // PR #683 / ADR-0002: emoji bullets replaced with prose, "PARALLELIZE
+    // I/O" banner replaced with a positive CONCURRENCY: section. The
+    // requests:[{url, source}] schema callout stays (it's a contract cue),
+    // and the I/O-bound vs single-URL split is still named — just in prose.
+    expect(fetchHandlerSrc).toContain("CONCURRENCY");
+    expect(fetchHandlerSrc).toContain("requests: [{url");
+    expect(fetchHandlerSrc).toContain("concurrency 4-8 for I/O-bound");
+    expect(fetchHandlerSrc).toContain("concurrency 1");
   });
 
   test("serial-write contract: index drain is a for-loop calling indexFetched serially", () => {
@@ -5215,3 +5219,211 @@ test("registerEmptyToolsListHandler responds with {tools:[]} so operators don't 
     })(),
   ]);
 }, 15_000);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tool description style contract (#683 ADR-0002)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Static contract test that scans every server.registerTool() block in
+// src/server.ts and asserts the tool description meets the style policy
+// codified in docs/adr/0002-tool-description-style.md.
+//
+// Motivation: PR #654 surfaced that a single hortatory word ("blocked") in a
+// routing deny reason was misread by Opus 4.6 as a network restriction,
+// causing capitulation to training data instead of routing. The same drift
+// has accumulated organically in tool descriptions (MANDATORY:, PREFER X
+// OVER Y, NEVER, Do NOT, ✅/❌). This test is the regression guard.
+//
+// Per CONTRIBUTING.md "Test file organization", we fold the contract into
+// tests/core/server.test.ts rather than creating tests/server/*.test.ts.
+//
+// Exemptions: ctx_stats, ctx_doctor, ctx_insight have minimal one-line
+// descriptions by design — they are GUI/diagnostic affordances, not routing
+// targets, so the WHEN: structural requirement does not apply.
+describe("tool description style contract (#683 ADR-0002)", () => {
+  const serverTsPath = resolve(__dirname, "../../src/server.ts");
+  const serverTs = readFileSync(serverTsPath, "utf-8");
+
+  // Extract every registered tool with its description string.
+  // Description is a template literal or "+"-concatenated string literal
+  // sitting on the `description:` key inside the registerTool config object.
+  function extractToolDescriptions(): Array<{ name: string; description: string; lineNo: number }> {
+    const out: Array<{ name: string; description: string; lineNo: number }> = [];
+    const lines = serverTs.split("\n");
+    const RE_REGISTER = /server\.registerTool\(\s*$/;
+    const RE_NAME = /^\s*"(ctx_[a-z_]+)"\s*,\s*$/;
+    for (let i = 0; i < lines.length; i++) {
+      if (!RE_REGISTER.test(lines[i])) continue;
+      const nameMatch = lines[i + 1]?.match(RE_NAME);
+      if (!nameMatch) continue;
+      const name = nameMatch[1];
+      // Description block starts at first `description:` after the name.
+      // Capture until the next `inputSchema:` line at the same indentation.
+      let descStart = -1;
+      let descEnd = -1;
+      for (let j = i + 2; j < Math.min(i + 80, lines.length); j++) {
+        if (descStart < 0 && /^\s*description:/.test(lines[j])) {
+          descStart = j;
+        } else if (descStart >= 0 && /^\s*(inputSchema|outputSchema|annotations):/.test(lines[j])) {
+          descEnd = j;
+          break;
+        }
+      }
+      if (descStart < 0 || descEnd < 0) continue;
+      const block = lines.slice(descStart, descEnd).join("\n");
+      // Strip the leading `description: ` and trailing comma.
+      // The literal text the LLM sees is just the string content — for the
+      // contract we work on the source-form block (template-literal/concat
+      // syntax), which is sufficient to detect forbidden tokens like
+      // `MANDATORY:` or `PREFER`. We do NOT execute the template here.
+      out.push({ name, description: block, lineNo: descStart + 1 });
+    }
+    return out;
+  }
+
+  const tools = extractToolDescriptions();
+
+  // Tools exempt from the WHEN: structural requirement, with documented
+  // rationale per the audit (see TOOL-DESCRIPTIONS-AUDIT.md §3 table).
+  //
+  // - ctx_stats / ctx_doctor / ctx_insight: minimal one-line descriptions by
+  //   design — diagnostic/GUI affordances, not routing targets. Audit row:
+  //   "NIT — Clean, minimal, no change."
+  // - ctx_upgrade: MUST is appropriate here (post-call obligation on the
+  //   agent to run the returned shell command). Audit row: "LOW — MUST is
+  //   appropriate here (post-call obligation), good use case. No change."
+  const EXEMPT_FROM_WHEN = new Set([
+    "ctx_stats",
+    "ctx_doctor",
+    "ctx_insight",
+    "ctx_upgrade",
+    "ctx_purge", // deferred entirely (see EXEMPT_FROM_FORBIDDEN_TOKENS below)
+  ]);
+
+  // ctx_purge is exempt from the forbidden-word scan because its rewrite is
+  // deferred to a separate PR per Probe 4 empirical evidence in
+  // TOOL-DESCRIPTIONS-AUDIT.md §6.1: heavy negative framing OUTPERFORMS the
+  // softer rewrite (5/5 vs 3/5 on parameter fidelity on Haiku). A naive
+  // wording fix here would REGRESS the tool. The follow-up PR must run a
+  // tri-LLM probe (Haiku / Sonnet / Opus) and gate merge on that probe.
+  // Documented in PR #683 body and ADR-0002.
+  const EXEMPT_FROM_FORBIDDEN_TOKENS = new Set(["ctx_purge"]);
+
+  test("at least 11 ctx_* tools are registered", () => {
+    // Sanity check that the extractor found the corpus.
+    expect(tools.length).toBeGreaterThanOrEqual(11);
+  });
+
+  // Forbidden tokens per ADR-0002. Each pattern is documented inline so
+  // a future contributor reading a failure understands the rationale, not
+  // just the regex.
+  type ForbiddenRule = { name: string; pattern: RegExp; rationale: string };
+  const FORBIDDEN: ForbiddenRule[] = [
+    {
+      name: "SESSION STATE clause",
+      // Rubric #3 + GRILL-Q1-VERDICT: tool descriptions are selection cues,
+      // not in-context prompts. Skill/role/decision persistence belongs in
+      // routing-block.mjs (which already covers it more thoroughly).
+      pattern: /\bSESSION STATE\b/,
+      rationale: "Move SESSION STATE guidance to routing-block.mjs (it already lives there).",
+    },
+    {
+      name: "BLOCKED",
+      // ADR-0003: 'blocked' is reserved for CASE B (real policy restriction)
+      // in routing.mjs deny reasons. It MUST NOT appear in any ctx_* tool
+      // description, where there is no security restriction to express.
+      pattern: /\bBLOCKED\b/,
+      rationale: "Reserve 'blocked' for routing CASE B (security policy denial) per ADR-0003.",
+    },
+    {
+      name: "MANDATORY: opener",
+      // Rubric #7: MANDATORY in a tool description reads as a developer
+      // policy note rather than a tool-selection cue. Replace with WHEN:.
+      pattern: /\bMANDATORY:/,
+      rationale: "Replace 'MANDATORY:' opener with role definition + WHEN: section.",
+    },
+    {
+      name: "PREFER X OVER Y",
+      // Rubric #7: 'PREFER' is the wrong strength and frames the choice as
+      // a tradeoff. WHEN:/WHEN NOT: sections give the agent positive cues.
+      pattern: /\bPREFER\s+THIS\s+OVER\b/,
+      rationale: "Replace 'PREFER THIS OVER X' with positive WHEN: clauses.",
+    },
+    {
+      name: "Do NOT (descriptive)",
+      // Rubric #2 + #7: affirmative beats negative. 'Do NOT' inside the
+      // description is voice-of-trainer; routing-block.mjs is the right
+      // layer for prohibitions.
+      pattern: /\bDo NOT\s+(?:read|use|pull|call)\b/,
+      rationale: "Rewrite 'Do NOT read/use/pull' as positive WHEN: / WHEN NOT: clauses.",
+    },
+    {
+      name: "Never use (capitalised imperative)",
+      // Rubric #7: 'Never' as a soft imperative inside a description is
+      // a forbidding voice; sibling-tool selection should be expressed
+      // through WHEN NOT: structure instead.
+      pattern: /\bNever\s+use\b/,
+      rationale: "Rewrite 'Never use' as positive WHEN NOT: clause.",
+    },
+    {
+      name: "checkmark emoji ✅",
+      // Rubric #4 + Probe 3 evidence: emoji tokenize inconsistently across
+      // LLM families (Llama, Gemini) and ❌ bullets are precisely the
+      // negative-example leakage pattern.
+      pattern: /✅/,
+      rationale: "Replace ✅ bullets with prose 'USE concurrency 4-8 for ...' (ADR-0002).",
+    },
+    {
+      name: "cross emoji ❌",
+      pattern: /❌/,
+      rationale: "Replace ❌ bullets with prose 'KEEP concurrency 1 for ...' (ADR-0002).",
+    },
+  ];
+
+  for (const tool of tools) {
+    // Tools exempt from BOTH groups (only ctx_purge today) have no assertions
+    // to make — emit a placeholder test so vitest doesn't error on empty
+    // describe blocks. The placeholder documents the deferral inline.
+    const isFullyExempt =
+      EXEMPT_FROM_FORBIDDEN_TOKENS.has(tool.name) && EXEMPT_FROM_WHEN.has(tool.name);
+    describe(tool.name, () => {
+      if (isFullyExempt) {
+        test("deferred to follow-up PR (see EXEMPT_FROM_FORBIDDEN_TOKENS rationale)", () => {
+          expect(EXEMPT_FROM_FORBIDDEN_TOKENS.has(tool.name)).toBe(true);
+        });
+        return;
+      }
+      if (!EXEMPT_FROM_FORBIDDEN_TOKENS.has(tool.name)) {
+        for (const rule of FORBIDDEN) {
+          test(`MUST NOT contain '${rule.name}'`, () => {
+            const match = tool.description.match(rule.pattern);
+            if (match) {
+              throw new Error(
+                `${tool.name} description (src/server.ts:${tool.lineNo}) contains forbidden token '${match[0]}' ` +
+                `(rule: ${rule.name}). ${rule.rationale}`,
+              );
+            }
+          });
+        }
+      }
+
+      if (!EXEMPT_FROM_WHEN.has(tool.name)) {
+        test("MUST contain a WHEN: section (or WHEN TO USE: legacy)", () => {
+          // Per ADR-0002: every routing-target ctx_* tool MUST have a
+          // positive selection cue. The legacy alias `WHEN TO USE:` is
+          // accepted because ctx_index already uses it and rewriting that
+          // header is out of scope for this PR (audit MEDIUM, separate work).
+          //
+          // We can't use `\bWHEN` because in source-form descriptions the
+          // preceding token is often the literal two-char sequence `\n`
+          // (from the JS escape) — `n` is a word character so `\b` fails.
+          // Likewise, for `+ "WHEN:..."` concat style the preceding char is
+          // `"`. Match any of those legitimate prefixes explicitly so both
+          // template-literal and string-concat description shapes pass.
+          const hasWhen = /(?:\\n|^|\s|")WHEN(?:\s+TO\s+USE)?:/.test(tool.description);
+          expect(hasWhen, `${tool.name} description (src/server.ts:${tool.lineNo}) must contain a WHEN: section`).toBe(true);
+        });
+      }
+    });
+  }
+});

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -5753,7 +5753,145 @@ describe("hook routing prompt-surface contract (#683 ADR-0002 + ADR-0003)", () =
           // is mentioned so the agent has a concrete next call.
           expect(cs.payload).toMatch(/ctx_(execute|fetch_and_index|search|batch_execute)/);
         });
+
+        // ── PR #683 follow-up (Mert flag): negation-pattern eradication ──
+        //
+        // The original PR #654 fix replaced the single word "blocked" with
+        // "redirected", which removed the Constitutional-AI safety trigger but
+        // kept a sibling rubric #2 violation in the very next clause:
+        //
+        //   "(context-window optimization, NOT a network restriction)"
+        //
+        // The audit (TOOL-DESCRIPTIONS-AUDIT.md §2 Probe 3) measured this
+        // parenthetical regressing Haiku capitulation from 0/6 → 2/6 — the
+        // bare-NOT construct primes the very frame it tries to deny (ironic
+        // process theory). Per ADR-0002 rubric #2 (affirmative beats negative),
+        // CASE A strings MUST avoid bare-NOT negations entirely. Reframe with
+        // affirmative "X has full network access" + imperative retry hint.
+        test("MUST NOT contain the 'NOT a network' negation (PR #683 follow-up)", () => {
+          // Matches "NOT a network restriction", "NOT a network/security
+          // restriction", "is NOT a network ...", etc. Affirmative-only voice.
+          expect(cs.payload).not.toMatch(/\bNOT\s+a\s+network\b/i);
+        });
+
+        test("MUST NOT contain 'Do NOT retry' negation (PR #683 follow-up)", () => {
+          // Same rubric: "Do NOT retry with curl/wget" anchors attention on
+          // the disallowed action. Express as the positive next step — the
+          // ctx_execute / ctx_fetch_and_index call IS the next step.
+          expect(cs.payload).not.toMatch(/\bDo\s+NOT\s+retry\b/i);
+        });
       });
     }
   });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// PR #683 follow-up (Mert flag, 2026-05-24): tool description source-form
+// uniformity — embedded `\n\n` escapes in template literals
+//
+// ctx_execute was the lone ctx_* tool whose description used a template
+// literal with embedded `\n\n` escape sequences inline (compact but
+// escape-heavy and harder to scan). Every other multi-section ctx_*
+// description used `"..." + "...\n\n"` concat-form. Both render identically
+// to the host LLM — the bytes are the same `\n\n` separators — but the
+// source form was inconsistent.
+//
+// Canonical decision (ADR-0002 follow-up): template literal with REAL
+// newlines. Source mirrors the rendered prompt. Zero escape sequences.
+// Markdown-friendly when read in an editor. The contract test below locks
+// the decision so a future contributor can't slip back to either of the
+// rejected forms (embedded `\n\n` escapes OR multi-line string concat).
+// ──────────────────────────────────────────────────────────────────────────
+describe("tool description source form contract (#683 PR follow-up)", () => {
+  const serverTsPath = resolve(__dirname, "../../src/server.ts");
+  const serverTs = readFileSync(serverTsPath, "utf-8");
+
+  // Locate every `description: ...,` block under a server.registerTool() call
+  // and capture its raw source text. Reuse the same anchor pattern as the
+  // ADR-0002 contract test for consistency.
+  function extractDescriptionBlocks(): Array<{ name: string; raw: string; lineNo: number }> {
+    const out: Array<{ name: string; raw: string; lineNo: number }> = [];
+    const lines = serverTs.split("\n");
+    const RE_REGISTER = /server\.registerTool\(\s*$/;
+    const RE_NAME = /^\s*"(ctx_[a-z_]+)"\s*,\s*$/;
+    for (let i = 0; i < lines.length; i++) {
+      if (!RE_REGISTER.test(lines[i])) continue;
+      const nameMatch = lines[i + 1]?.match(RE_NAME);
+      if (!nameMatch) continue;
+      const name = nameMatch[1];
+      let descStart = -1;
+      let descEnd = -1;
+      for (let j = i + 2; j < Math.min(i + 80, lines.length); j++) {
+        if (descStart < 0 && /^\s*description:/.test(lines[j])) {
+          descStart = j;
+        } else if (descStart >= 0 && /^\s*(inputSchema|outputSchema|annotations):/.test(lines[j])) {
+          descEnd = j;
+          break;
+        }
+      }
+      if (descStart < 0 || descEnd < 0) continue;
+      out.push({ name, raw: lines.slice(descStart, descEnd).join("\n"), lineNo: descStart + 1 });
+    }
+    return out;
+  }
+
+  const blocks = extractDescriptionBlocks();
+
+  // Tools whose descriptions are intentionally one-line concats with no
+  // section structure (diagnostic / GUI affordances per ADR-0002
+  // §Exemptions). They carry no `\n` separators in the source at all, so
+  // the embedded-escape rule is trivially satisfied and the concat-form
+  // exemption applies. Future contributors can promote these to template
+  // literals at will; they just aren't forced to.
+  const SHORT_DESCRIPTION_EXEMPT = new Set([
+    "ctx_stats",
+    "ctx_doctor",
+    "ctx_upgrade",
+    "ctx_insight",
+  ]);
+
+  test("at least 11 ctx_* tools surfaced for source-form contract", () => {
+    expect(blocks.length).toBeGreaterThanOrEqual(11);
+  });
+
+  for (const block of blocks) {
+    if (SHORT_DESCRIPTION_EXEMPT.has(block.name)) continue;
+
+    describe(block.name, () => {
+      test("source-form MUST NOT contain embedded '\\n\\n' escape (use real newlines in template literal)", () => {
+        // The forbidden pattern is the literal four-character source-text
+        // sequence: backslash, n, backslash, n. In source these appear inside
+        // template literals (`...\n\n...`) or quoted strings ("...\n\n").
+        // The canonical form is a template literal with REAL newlines so the
+        // source mirrors the rendered prompt byte-for-byte without escapes.
+        const hasEscapedDoubleNewline = /\\n\\n/.test(block.raw);
+        expect(
+          hasEscapedDoubleNewline,
+          `${block.name} description (src/server.ts:${block.lineNo}) contains embedded '\\n\\n' escapes. ` +
+            `Use a template literal with REAL newlines instead — source should mirror the rendered prompt. ` +
+            `Diff: replace \`...\\n\\n...\` source spans with multi-line template literals.`,
+        ).toBe(false);
+      });
+
+      test("source-form MUST NOT use multi-line string concat with '+' (use template literal)", () => {
+        // Concat-form was the legacy alternative — `"...\n\n" + "WHEN:\n"`.
+        // Once we ban `\n\n`, the only sensible multi-section shape is a
+        // template literal. This second assertion makes that explicit so a
+        // contributor doesn't switch one negative form for another (e.g.
+        // splitting on a newline inside a `+ "\n"` chain).
+        //
+        // Heuristic: a `"\n" +` or `"+ \n"` chain inside the description
+        // block. Single-line concats (e.g. `"a " + "b"`) are too loose to
+        // ban without false positives, so we anchor on the embedded newline
+        // form which is what multi-section descriptions actually used.
+        const hasConcatNewline = /"[^"]*"\s*\+\s*\n\s*"/.test(block.raw) ||
+          /\\n"\s*\+/.test(block.raw);
+        expect(
+          hasConcatNewline,
+          `${block.name} description (src/server.ts:${block.lineNo}) uses multi-line string concat with '+'. ` +
+            `Use a template literal with REAL newlines instead — single canonical source form for all multi-section descriptions.`,
+        ).toBe(false);
+      });
+    });
+  }
 });

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -3118,10 +3118,13 @@ describe("batch_execute FS read tracking", () => {
     // four canonical sections (WHEN / WHEN NOT / RETURNS / EXAMPLE) plus
     // approved per-tool carve-outs (e.g. ctx_purge SCOPES / CONTRACT).
     // The I/O-bound vs CPU-bound split and the 4-8 speedup window are still
-    // named — just inline in the WHEN clauses now, not under a separate
-    // UPPERCASE banner.
-    expect(serverSrc).toContain("parallelize I/O-bound calls");
-    expect(serverSrc).toContain("concurrency 4-8");
+    // named — the PR #683 second amendment then deepened the concurrency
+    // guidance (CPU-bound stays at 1, GitHub API caps at 4 to respect rate
+    // limits, I/O-bound uses 4-8). This test pins the load-bearing concepts
+    // (I/O-bound parallelism, the 4-8 window, the keep-at-1 rule) not the
+    // exact prose so future copy-edits don't break it.
+    expect(serverSrc).toMatch(/parallelize I\/O-bound (work|calls|batches)/);
+    expect(serverSrc).toMatch(/4-8\s+(for I\/O-bound|I\/O-bound batches)/);
     expect(serverSrc).toContain("CPU-bound or stateful");
     expect(serverSrc).toContain("keep concurrency at 1");
   });
@@ -3668,13 +3671,16 @@ describe("ctx_fetch_and_index batch refactor", () => {
     // (canonical structure) folded the dedicated CONCURRENCY: section into
     // the WHEN: / RETURNS: prose so the description carries only the
     // canonical four sections (WHEN / WHEN NOT / RETURNS / EXAMPLE).
-    // The requests:[{url, source}] schema callout stays (contract cue), and
-    // the I/O-bound multi-URL guidance + the FTS5 serial-write contract
-    // remain explicit in the description — just inline now, not under a
-    // separate UPPERCASE banner.
-    expect(fetchHandlerSrc).toContain("requests: [{url");
-    expect(fetchHandlerSrc).toContain("concurrency 4-8");
-    expect(fetchHandlerSrc).toContain("FTS5 indexing then serializes writes");
+    // PR #683 second amendment then deepened the concurrency guidance
+    // (gh API cap 4, single-writer mechanism explanation) and reframed the
+    // FTS5 serialization in more technical terms ("write phase always runs
+    // serially because SQLite is a single-writer store").
+    // This test pins the load-bearing concepts (requests:[] batch shape,
+    // 4-8 I/O window, FTS5 serial-write contract) using semantic regexes
+    // so future copy-edits don't break it.
+    expect(fetchHandlerSrc).toMatch(/requests(:\s*\[|`\s*array)/);
+    expect(fetchHandlerSrc).toMatch(/4-8\s+(for|stable)/);
+    expect(fetchHandlerSrc).toMatch(/FTS5[^.]*(serializes? writes?|write phase[^.]*serial|single-writer)/);
   });
 
   test("serial-write contract: index drain is a for-loop calling indexFetched serially", () => {

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -88,9 +88,10 @@ describe("routePreToolUse", () => {
       expect(result).not.toBeNull();
       expect(result!.action).toBe("modify");
       expect(result!.updatedInput).toBeDefined();
-      expect((result!.updatedInput as Record<string, string>).command).toContain(
-        "curl/wget blocked",
-      );
+      const cmd = (result!.updatedInput as Record<string, string>).command;
+      expect(cmd).toContain("curl/wget redirected");
+      expect(cmd).not.toContain("curl/wget blocked");
+      expect(cmd).toMatch(/retry/i);
     });
 
     it("denies Codex exec_command cmd payloads like Bash command payloads", () => {
@@ -104,7 +105,7 @@ describe("routePreToolUse", () => {
       expect(result).not.toBeNull();
       expect(result!.action).toBe("modify");
       expect((result!.updatedInput as Record<string, string>).command).toContain(
-        "curl/wget blocked",
+        "curl/wget redirected",
       );
     });
 
@@ -115,7 +116,7 @@ describe("routePreToolUse", () => {
       expect(result).not.toBeNull();
       expect(result!.action).toBe("modify");
       expect((result!.updatedInput as Record<string, string>).command).toContain(
-        "curl/wget blocked",
+        "curl/wget redirected",
       );
     });
 
@@ -194,9 +195,10 @@ describe("routePreToolUse", () => {
       });
       expect(result).not.toBeNull();
       expect(result!.action).toBe("modify");
-      expect((result!.updatedInput as Record<string, string>).command).toContain(
-        "Inline HTTP blocked",
-      );
+      const cmd = (result!.updatedInput as Record<string, string>).command;
+      expect(cmd).toContain("Inline HTTP redirected");
+      expect(cmd).not.toContain("Inline HTTP blocked");
+      expect(cmd).toMatch(/retry/i);
     });
 
     it("denies requests.get() with modify action", () => {
@@ -206,7 +208,7 @@ describe("routePreToolUse", () => {
       expect(result).not.toBeNull();
       expect(result!.action).toBe("modify");
       expect((result!.updatedInput as Record<string, string>).command).toContain(
-        "Inline HTTP blocked",
+        "Inline HTTP redirected",
       );
     });
 
@@ -346,8 +348,13 @@ describe("routePreToolUse", () => {
       });
       expect(result).not.toBeNull();
       expect(result!.action).toBe("deny");
-      expect(result!.reason).toContain("WebFetch blocked");
+      // PR #654 substitute: imperative-positive framing, no "blocked" wording,
+      // explicit retry hint to keep Haiku-tier agents from capitulating to
+      // training data on transient DNS errors (audit Probe 3).
+      expect(result!.reason).toContain("WebFetch redirected");
+      expect(result!.reason).not.toContain("WebFetch blocked");
       expect(result!.reason).toContain("fetch_and_index");
+      expect(result!.reason).toMatch(/retry/i);
     });
 
     it("includes the URL in deny reason", () => {
@@ -362,7 +369,7 @@ describe("routePreToolUse", () => {
       const result = routePreToolUse("mcp_web_fetch", { url });
       expect(result).not.toBeNull();
       expect(result!.action).toBe("deny");
-      expect(result!.reason).toContain("WebFetch blocked");
+      expect(result!.reason).toContain("WebFetch redirected");
       expect(result!.reason).toContain("fetch_and_index");
       expect(result!.reason).toContain("ctx_search");
     });
@@ -372,7 +379,7 @@ describe("routePreToolUse", () => {
       const result = routePreToolUse("mcp_fetch_tool", { url });
       expect(result).not.toBeNull();
       expect(result!.action).toBe("deny");
-      expect(result!.reason).toContain("WebFetch blocked");
+      expect(result!.reason).toContain("WebFetch redirected");
       expect(result!.reason).toContain("fetch_and_index");
       expect(result!.reason).toContain("ctx_search");
     });

--- a/tests/hooks/core-routing.test.ts
+++ b/tests/hooks/core-routing.test.ts
@@ -608,26 +608,39 @@ describe("routePreToolUse", () => {
   // ─── Routing block content ──────────────────────────────
 
   describe("routing block content", () => {
-    it("contains file_writing_policy forbidding ctx_execute for file writes", () => {
+    // Wording rewritten per ADR-0002 (PR #683 follow-up): the original tests
+    // asserted negative framings (`NEVER use`, `NO …`, `NEVER inline`) that
+    // failed the cross-LLM safety-bias rubric (#9) and the prompt-surface
+    // forbidden-token contract in tests/core/server.test.ts. The new
+    // assertions cover the same semantic intent expressed positively:
+    //   - file writes go through the native Write/Edit tool
+    //   - ctx_execute / ctx_execute_file / Bash subprocesses do not persist edits
+    //   - artifacts get written to files (path + 1-line description returned)
+    it("file_writing_policy points file writes at native Write/Edit tools", () => {
       expect(ROUTING_BLOCK).toContain("<file_writing_policy>");
-      expect(ROUTING_BLOCK).toContain("NEVER use");
+      expect(ROUTING_BLOCK).toContain("File writes use the native Write or Edit tool");
+      // semantic intent: ctx_execute family must not be used for file writes —
+      // expressed positively as "do not persist edits to the host filesystem"
       expect(ROUTING_BLOCK).toContain("ctx_execute");
-      expect(ROUTING_BLOCK).toContain("native Write/Edit tools");
+      expect(ROUTING_BLOCK).toContain("do not persist edits");
     });
 
-    it("forbidden_actions blocks ctx_execute for file creation", () => {
-      expect(ROUTING_BLOCK).toContain(
-        "NO",
-      );
-      expect(ROUTING_BLOCK).toContain(
-        "for file creation/modification",
-      );
+    it("when_not_to_use redirects ctx_execute away from file creation", () => {
+      // Replaces the old `<forbidden_actions>` container; same semantic intent
+      // (do not pick ctx_execute for file creation) expressed via WHEN NOT.
+      expect(ROUTING_BLOCK).toContain("<when_not_to_use>");
+      expect(ROUTING_BLOCK).toContain("for file writes");
+      expect(ROUTING_BLOCK).toContain("analysis, processing, and computation only");
     });
 
-    it("artifact_policy specifies native Write tool", () => {
+    it("artifact_policy points artifacts at files with file-path return shape", () => {
+      // Replaces the old "Write artifacts ... NEVER inline" wording.
+      // The semantic intent — write artifacts to files, return only the path
+      // plus a 1-line description — is asserted via the positive surface.
       expect(ROUTING_BLOCK).toContain(
-        "Write artifacts (code, configs, PRDs) to FILES. NEVER inline.",
+        "Write artifacts (code, configs, PRDs) to files",
       );
+      expect(ROUTING_BLOCK).toContain("file path + 1-line description");
     });
   });
 

--- a/tests/hooks/cursor-hooks.test.ts
+++ b/tests/hooks/cursor-hooks.test.ts
@@ -118,7 +118,7 @@ describe("Cursor hooks", () => {
       expect(result.exitCode).toBe(0);
       const payload = JSON.parse(result.stdout) as Record<string, unknown>;
       expect(payload.permission).toBe("deny");
-      expect(String(payload.user_message)).toContain("WebFetch blocked");
+      expect(String(payload.user_message)).toContain("WebFetch redirected");
     });
 
     test("blocks mcp_web_fetch with the same sandbox redirect", () => {
@@ -132,7 +132,7 @@ describe("Cursor hooks", () => {
       expect(result.exitCode).toBe(0);
       const payload = JSON.parse(result.stdout) as Record<string, unknown>;
       expect(payload.permission).toBe("deny");
-      expect(String(payload.user_message)).toContain("WebFetch blocked");
+      expect(String(payload.user_message)).toContain("WebFetch redirected");
       expect(String(payload.user_message)).toContain("ctx_fetch_and_index");
       expect(String(payload.user_message)).toContain("ctx_search");
     });
@@ -148,7 +148,7 @@ describe("Cursor hooks", () => {
       expect(result.exitCode).toBe(0);
       const payload = JSON.parse(result.stdout) as Record<string, unknown>;
       expect(payload.permission).toBe("deny");
-      expect(String(payload.user_message)).toContain("WebFetch blocked");
+      expect(String(payload.user_message)).toContain("WebFetch redirected");
       expect(String(payload.user_message)).toContain("ctx_fetch_and_index");
       expect(String(payload.user_message)).toContain("ctx_search");
     });

--- a/tests/hooks/integration.test.ts
+++ b/tests/hooks/integration.test.ts
@@ -241,7 +241,7 @@ describe("WebFetch", () => {
       "Expected original URL in reason",
     );
     assert.ok(
-      parsed.hookSpecificOutput.permissionDecisionReason.includes("Do NOT use curl"),
+      /Do NOT retry with .*curl/.test(parsed.hookSpecificOutput.permissionDecisionReason),
       "Expected curl warning in reason",
     );
   });

--- a/tests/hooks/integration.test.ts
+++ b/tests/hooks/integration.test.ts
@@ -240,9 +240,18 @@ describe("WebFetch", () => {
       parsed.hookSpecificOutput.permissionDecisionReason.includes("https://docs.example.com/api"),
       "Expected original URL in reason",
     );
+    // PR #683 follow-up (ADR-0003 amendment): the deny reason was reframed
+    // affirmatively. The negative "Do NOT retry with curl" hint was replaced
+    // by a positive imperative retry hint scoped to transient DNS errors and
+    // by the ctx_fetch_and_index call instruction. Assert on the affirmative
+    // wording instead of the dropped negation.
     assert.ok(
-      /Do NOT retry with .*curl/.test(parsed.hookSpecificOutput.permissionDecisionReason),
-      "Expected curl warning in reason",
+      /Retry the same call on a transient DNS error/.test(parsed.hookSpecificOutput.permissionDecisionReason),
+      "Expected positive transient-DNS retry hint in reason",
+    );
+    assert.ok(
+      /Call .*ctx_fetch_and_index/.test(parsed.hookSpecificOutput.permissionDecisionReason),
+      "Expected explicit ctx_fetch_and_index call instruction in reason",
     );
   });
 });

--- a/tests/hooks/tool-naming.test.ts
+++ b/tests/hooks/tool-naming.test.ts
@@ -414,7 +414,7 @@ describe("routePreToolUse with platform parameter", () => {
       expect(result).not.toBeNull();
       expect(result!.action).toBe("modify");
       expect((result!.updatedInput as Record<string, string>).command).toContain(
-        "curl/wget blocked",
+        "curl/wget redirected",
       );
     });
 
@@ -427,7 +427,7 @@ describe("routePreToolUse with platform parameter", () => {
       );
       expect(result).not.toBeNull();
       expect(result!.action).toBe("deny");
-      expect(result!.reason).toContain("WebFetch blocked");
+      expect(result!.reason).toContain("WebFetch redirected");
     });
 
     it("read_file routes as Read → context guidance", () => {

--- a/tests/hooks/tool-naming.test.ts
+++ b/tests/hooks/tool-naming.test.ts
@@ -330,7 +330,11 @@ describe("routePreToolUse with platform parameter", () => {
     expect(result).not.toBeNull();
     const cmd = (result!.updatedInput as Record<string, string>).command;
     expect(cmd).toContain("ctx_execute");
-    expect(cmd).toContain("Think in Code");
+    // PR #683 follow-up (ADR-0003 amendment): "Think in Code" voice-of-trainer
+    // marker was folded into the imperative call instruction. The deny reason
+    // now opens with the affirmative redirect frame; assert on the explicit
+    // ctx_execute call instruction that survived the rewrite.
+    expect(cmd).toContain("Call ctx_execute");
     expect(cmd).not.toContain("mcp__");
   });
 

--- a/tests/session/continuity.test.ts
+++ b/tests/session/continuity.test.ts
@@ -76,8 +76,8 @@ describe("SessionStart Hook", () => {
       "Expected <tool_selection_hierarchy> tag",
     );
     assert.ok(
-      ctx.includes("<forbidden_actions>"),
-      "Expected <forbidden_actions> tag",
+      ctx.includes("<when_not_to_use>"),
+      "Expected <when_not_to_use> tag (renamed from <forbidden_actions> in ADR-0002 — affirmative framing, same semantic intent)",
     );
     assert.ok(
       ctx.includes("<output_constraints>"),


### PR DESCRIPTION
Substitutes #654 (kept open and credited — the WebFetch refusal scope
was the trigger for this comprehensive audit).

## Scope

This PR ships PR #1 + PR #3 of the 3-PR sequencing strategy from
`TOOL-DESCRIPTIONS-AUDIT.md` §9: the original WebFetch refusal fix
PLUS the corpus-wide voice consistency pass. PR #2 (`ctx_purge`
rewrite) is explicitly deferred — see "Deferred" below for the
empirical reason.

## Changes

### Routing layer (substitutes #654)

- `hooks/core/routing.mjs:804` — replace `"WebFetch blocked"` with
  `"WebFetch redirected — this is NOT a network/security restriction"`
  + alternative-tool pointer + transient-error retry hint.
- `src/server.ts:2783-2795` — sibling-consistent
  `EAI_AGAIN | ETIMEDOUT | ETIMEOUT | ENETUNREACH | EPERM` retry hint
  on `ctx_fetch_and_index` subprocess fetch failure so the two
  surfaces speak with one voice. Non-transient errors (`ENOTFOUND`)
  stay silent — we do not suggest retry on real "not found".

### Tool descriptions (audit §3, six tools — ADR-0002)

HIGH severity (voice consistency on the ctx_execute family):

- `ctx_execute` (`src/server.ts:1419`): drop `MANDATORY:` opener,
  `PREFER THIS OVER BASH`, `THINK IN CODE` voice-of-trainer paragraph,
  `Do NOT read raw data`. Apply WHEN: / WHEN NOT: / RETURNS: /
  EXAMPLE: template per ADR-0002. ~1,200 → ~700 chars.
- `ctx_execute_file` (`src/server.ts:1755`): same shape; drop
  `PREFER THIS OVER Read/cat` and the `Don't read files into context`
  voice-of-trainer line.
- `ctx_batch_execute` (`src/server.ts:3109`): drop
  `THIS IS THE PRIMARY TOOL`, `THINK IN CODE — NON-NEGOTIABLE`, and
  the emoji-bulleted `PARALLELIZE I/O` block. Replace with
  WHEN: / CONCURRENCY: prose. ~1,700 → ~900 chars.

MEDIUM severity:

- `ctx_search` (`src/server.ts:2072`): drop the SESSION STATE clause
  (it is a `routing-block.mjs` concern; semantic-equivalence proof in
  `GRILL-Q1-VERDICT.md` Round 5). Add explicit WHEN: structure.
- `ctx_index` (`src/server.ts:1900`): rewrite `Do NOT use for: log
  files…` as a positive WHEN NOT: clause pointing at
  `ctx_execute_file`.
- `ctx_fetch_and_index` (`src/server.ts:2865`): replace
  `PARALLELIZE I/O` banner + ✅/❌ emoji bullets with a positive
  CONCURRENCY: prose block. Emoji tokenize inconsistently across
  Llama / Gemini and act as negative-example leakage (rubric #4 +
  Probe 3 evidence).

### Regression guard (audit §10.1)

New `describe` block in `tests/core/server.test.ts`:
`tool description style contract (#683 ADR-0002)`. Folded into the
existing file per `CONTRIBUTING.md` L282 ("Do NOT create new test
files"). Parses every `server.registerTool()` block in `src/server.ts`
and asserts:

- MUST NOT contain forbidden tokens (`MANDATORY:`, `BLOCKED`,
  `PREFER X OVER Y`, `Do NOT read/use/pull`, `Never use`,
  `SESSION STATE`, `✅`, `❌`).
- MUST contain a `WHEN:` section (`WHEN TO USE:` accepted as
  transitional alias).

Exemptions, with inline-documented rationale:

- `ctx_stats` / `ctx_doctor` / `ctx_insight` — minimal one-line
  descriptions by design (audit `NIT — no change`).
- `ctx_upgrade` — `MUST` is appropriate for the post-call obligation
  on the agent to run the returned shell command (audit `LOW — MUST
  is appropriate here, good use case`).
- `ctx_purge` — exempt from BOTH groups; deferred entirely (see
  below).

Two existing tests updated to assert the new wording:
`tool description documents the concurrency field with positive
guidance` and `PARALLELIZE I/O guidance + locked requests:[] schema in
description`. Both now check the prose form.

### ADRs

New under `docs/adr/`:

- `0002-tool-description-style.md` — codifies the WHEN/RETURNS/EXAMPLE
  template, forbidden-token list, MUST/SHOULD/MAY hierarchy (reserved
  for post-call obligations only), and the empirical rationale.
- `0003-routing-deny-reasons.md` — CASE A (redirect) vs CASE B
  (security policy) distinction, with the PR #654 reproduction as the
  motivating example.

## Deferred — `ctx_purge` rewrite

NOT in this PR. Probe 4 in `TOOL-DESCRIPTIONS-AUDIT.md` §6.1 ran 5
trials × 2 variants on Haiku and found the proposed soft rewrite
**regresses** parameter fidelity 5/5 → 3/5. The heavy negative framing
(`DESTRUCTIVE`, `REFUSAL RULES`, `NEVER call with bare {confirm:true}`)
anchors small models to the required scope discipline; the softer
rewrite drops `sessionId` in a portion of trials.

A naïve wording fix on `ctx_purge` would ship a regression. The
follow-up PR must run a tri-LLM probe (Haiku / Sonnet / Opus) and gate
merge on that probe before changing this tool. The deferral is
documented inline in `tests/core/server.test.ts` via
`EXEMPT_FROM_FORBIDDEN_TOKENS` so a future contributor can see the
empirical rationale, not just a quiet skip.

## Tests

- `npx tsc --noEmit`: clean.
- `tests/core/server.test.ts`: 361/364 pass. The 3 remaining failures
  are **pre-existing on the base branch** (`ctx_index` storage-error
  test + 2 `ctx_doctor` storage-roots tests). Verified via
  `git stash` repro — they fail on `next` without this PR's changes
  too. Out of scope for #683.
- `tests/hooks/`: 438/438 pass.
- `tests/adapters/`: 787/787 pass.
- New contract test: 88 assertions (15 forbidden-token checks + 6
  WHEN: checks + 1 corpus-size sanity + 66 per-tool slots), 0
  failures.

No new test files (CONTRIBUTING L282). Bundles untouched — CI rebuilds
on main push per the established workflow.

## Files changed

- `hooks/core/routing.mjs` — WebFetch refusal wording (already on
  branch from b0bbd75)
- `src/server.ts` — 2 EAI_AGAIN hints (b0bbd75) + 6 description
  rewrites (47c8e16)
- `tests/core/server.test.ts` — contract test + 2 stale-test updates
  (47c8e16)
- `docs/adr/0002-tool-description-style.md` — new (72c93d6)
- `docs/adr/0003-routing-deny-reasons.md` — new (72c93d6)

## Commits on branch

- `b0bbd75` — fix(server): replace "blocked" wording in WebFetch
  refusal with imperative retry hint
- `72c93d6` — docs(adr): tool description style (ADR-0002) + routing
  deny reasons (ADR-0003)
- `47c8e16` — fix(server): apply ADR-0002 voice to 6 ctx_* tool
  descriptions + contract test

## Empirical references

- `TOOL-DESCRIPTIONS-AUDIT.md` (38 A/B trials × 6 probes, Haiku +
  Sonnet)
- `GRILL-Q1-VERDICT.md` (SESSION STATE drop, Round 5
  semantic-equivalence proof)
