### PR TITLE
fix(codex): report standalone doctor status accurately

### DIFF
--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -14,6 +14,7 @@
  * Track: https://github.com/openai/codex/issues/18491
  */
 
+import { execFileSync } from "node:child_process";
 import {
   readFileSync,
   writeFileSync,
@@ -113,6 +114,36 @@ const LEGACY_HOOK_PATH_SUFFIXES: Record<keyof typeof CODEX_HOOK_COMMANDS, string
   UserPromptSubmit: ["hooks/userpromptsubmit.mjs", "hooks/codex/userpromptsubmit.mjs"],
   Stop: ["hooks/stop.mjs", "hooks/codex/stop.mjs"],
 };
+
+type CodexVersionRunner = (
+  file: string,
+  args: string[],
+  options: {
+    encoding: BufferEncoding;
+    stdio: ["ignore", "pipe", "ignore"];
+    timeout: number;
+  },
+) => string | Buffer;
+
+export function probeCodexCliVersion(runCommand: CodexVersionRunner = execFileSync): string | null {
+  try {
+    const output = process.platform === "win32"
+      ? runCommand("cmd.exe", ["/d", "/s", "/c", "codex --version"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 5000,
+      })
+      : runCommand("codex", ["--version"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1500,
+      });
+    const version = String(output).trim();
+    return version.length > 0 ? version : "available (version output empty)";
+  } catch {
+    return null;
+  }
+}
 
 function getTomlSection(raw: string, sectionName: string): string | null {
   const lines = raw.split(/\r?\n/);
@@ -459,6 +490,16 @@ export class CodexAdapter extends BaseAdapter implements HookAdapter {
 
   validateHooks(_pluginRoot: string): DiagnosticResult[] {
     const results: DiagnosticResult[] = [];
+    const codexCliVersion = probeCodexCliVersion();
+
+    results.push({
+      check: "Codex CLI binary",
+      status: codexCliVersion ? "pass" : "warn",
+      message: codexCliVersion
+        ? `codex --version resolved to ${codexCliVersion}`
+        : "Could not run codex --version; hooks need the Codex CLI available on PATH",
+      ...(codexCliVersion ? {} : { fix: "Install Codex CLI or make codex available on PATH" }),
+    });
 
     try {
       const raw = readFileSync(this.getSettingsPath(), "utf-8");
@@ -607,8 +648,9 @@ export class CodexAdapter extends BaseAdapter implements HookAdapter {
   }
 
   getInstalledVersion(): string {
-    // Codex CLI has no marketplace or plugin system
-    return "not installed";
+    // Codex uses standalone MCP registration; there is no platform-owned
+    // plugin version to compare against the context-mode npm package.
+    return "standalone";
   }
 
   // ── Upgrade ────────────────────────────────────────────

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -296,7 +296,10 @@ export interface HookAdapter {
   /** Check if the plugin is registered/enabled on this platform. */
   checkPluginRegistration(): DiagnosticResult;
 
-  /** Get the installed version from this platform's registry/marketplace. */
+  /**
+   * Get the installed version from this platform's registry/marketplace, or
+   * "standalone" when no platform-owned plugin version exists.
+   */
   getInstalledVersion(): string;
 
   // ── Upgrade ────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -894,7 +894,12 @@ async function doctor(): Promise<number> {
     );
   }
 
-  if (installedVersion === "not installed") {
+  if (installedVersion === "standalone") {
+    p.log.info(
+      color.dim(`${adapter.name}: standalone MCP mode`) +
+        " — no platform plugin version to compare",
+    );
+  } else if (installedVersion === "not installed") {
     p.log.info(
       color.dim(`${adapter.name}: not installed`) +
         " — using standalone MCP mode",

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -574,7 +574,15 @@ describe("CodexAdapter", () => {
     it("passes when all required Codex hooks are configured", () => {
       adapter.configureAllHooks("/ignored/plugin/root");
       const results = adapter.validateHooks("/ignored/plugin/root");
-      expect(results.every((result) => result.status === "pass")).toBe(true);
+      // The "Codex CLI binary" check is a runtime environment probe added
+      // by PR #686 — it shells out to `codex --version` and reports `warn`
+      // when the binary is absent (e.g. CI runners without Codex installed).
+      // That probe is orthogonal to the hook-config validation this test is
+      // pinning, so exclude it from the all-pass assertion. Probe-specific
+      // behaviour (pass/warn shape) is covered separately by the unit tests
+      // around probeCodexCliVersion() at L295-299.
+      const configChecks = results.filter((r) => r.check !== "Codex CLI binary");
+      expect(configChecks.every((result) => result.status === "pass")).toBe(true);
       expect(results.map((result) => result.check)).toContain("PreCompact hook");
       expect(results.map((result) => result.check)).toContain("UserPromptSubmit hook");
       expect(results.map((result) => result.check)).toContain("Stop hook");

--- a/tests/adapters/codex.test.ts
+++ b/tests/adapters/codex.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { CodexAdapter } from "../../src/adapters/codex/index.js";
+import { CodexAdapter, probeCodexCliVersion } from "../../src/adapters/codex/index.js";
 import { resolveSessionDbPath, SessionDB } from "../../src/session/db.js";
 
 describe("CodexAdapter", () => {
@@ -281,6 +281,29 @@ describe("CodexAdapter", () => {
         else process.env.CODEX_HOME = savedCodexHome;
         rmSync(codexHome, { recursive: true, force: true });
       }
+    });
+  });
+
+  // ── Version diagnostics ───────────────────────────────
+
+  describe("version diagnostics", () => {
+    it("reports standalone MCP mode instead of a missing platform plugin", () => {
+      expect(adapter.getInstalledVersion()).toBe("standalone");
+    });
+
+    it("trims Codex CLI version probe output", () => {
+      expect(probeCodexCliVersion(() => "codex-cli 0.132.0\n")).toBe("codex-cli 0.132.0");
+    });
+
+    it("returns null when the Codex CLI version probe fails", () => {
+      expect(probeCodexCliVersion(() => {
+        throw new Error("ENOENT");
+      })).toBeNull();
+    });
+
+    it("surfaces Codex CLI binary availability in diagnostics", () => {
+      const checks = adapter.validateHooks("");
+      expect(checks.some((result) => result.check === "Codex CLI binary")).toBe(true);
     });
   });
 

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -1018,6 +1018,18 @@ describe("Bin entry uses cli.bundle.mjs", () => {
     expect(loop).toContain(": WARN");
   });
 
+  it("cli doctor treats standalone adapters as not version-comparable", () => {
+    const src = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
+    const versionStart = src.indexOf("Checking versions");
+    const versionBlock = src.slice(versionStart, versionStart + 1800);
+
+    expect(versionBlock).toContain('installedVersion === "standalone"');
+    expect(versionBlock).toContain("standalone MCP mode");
+    expect(versionBlock).toContain("no platform plugin version to compare");
+    expect(versionBlock.indexOf('installedVersion === "standalone"'))
+      .toBeLessThan(versionBlock.indexOf('installedVersion === "not installed"'));
+  });
+
   it("upgrade still reaches hook configuration when already on latest", () => {
     const src = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
     const alreadyLatestIdx = src.indexOf("Already on latest");


### PR DESCRIPTION
## What / Why / How

`context-mode doctor` currently hard-codes the Codex adapter's installed version as `not installed`, so Codex users see `Codex CLI: not installed — using standalone MCP mode` even when `codex --version` resolves successfully. I reproduced this on Windows with `CONTEXT_MODE_PLATFORM=codex`: the machine had `codex-cli 0.132.0`, but the doctor version section still looked like the Codex CLI itself was missing.

This PR separates the two states:

- adds a Codex diagnostic that probes `codex --version` (`cmd.exe /c` on Windows so npm `.cmd` shims resolve, `execFileSync` on POSIX)
- returns a `standalone` sentinel for Codex because it has no platform-owned plugin version to compare against the `context-mode` npm package
- teaches `doctor` to render that sentinel as `standalone MCP mode — no platform plugin version to compare`
- adds adapter/CLI tests so this does not regress back to the misleading `not installed` path

This is intentionally diagnostic-only: no hook config, MCP registration, bundle, or install flow changes.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- [x] `pnpm exec vitest run tests/adapters/codex.test.ts tests/core/cli.test.ts` — 221 tests passed
- [x] `pnpm run typecheck`
- [x] `git diff --check`
- [x] `CONTEXT_MODE_PLATFORM=codex pnpm exec tsx src/cli.ts doctor` on Windows confirmed:
  - `Codex CLI binary: PASS — codex --version resolved to codex-cli 0.132.0`
  - `Codex CLI: standalone MCP mode — no platform plugin version to compare`

## Duplicate check

- Open PRs checked: only #685 is open and it touches stats aggregation, not Codex doctor/version diagnostics.
- Searched prior PRs/issues for `Codex CLI: not installed`, `Codex CLI binary`, `standalone MCP mode`, and `codex --version doctor`; no active or merged PR appears to cover this exact diagnostic split.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)
