### PR TITLE
fix(hooks): self-heal partial plugin cache install from marketplace clone

### DIFF
--- a/hooks/heal-partial-install.mjs
+++ b/hooks/heal-partial-install.mjs
@@ -1,0 +1,712 @@
+/**
+ * heal-partial-install.mjs - self-heal a partial plugin cache install.
+ *
+ * Failure mode this addresses:
+ *
+ *   The per-version plugin cache dir at
+ *   ~/.claude/plugins/cache/<owner>/<plugin>/<version>/ holds only a
+ *   subset of the published files. start.mjs, cli.bundle.mjs,
+ *   server.bundle.mjs, package.json and several other entries from
+ *   `package.json files[]` may be absent, while hooks/ and
+ *   .claude-plugin/ tend to survive. The cache's
+ *   .claude-plugin/plugin.json can also be a verbatim carry-forward
+ *   from a prior version's install, with mcpServers.args[0] holding
+ *   an absolute path under a since-deleted cache dir; MCP launch
+ *   ENOENTs as a result.
+ *
+ *   Existing defenses don't repair this:
+ *
+ *     - scripts/plugin-cache-integrity.mjs (#550) exits 2 from
+ *       start.mjs, but start.mjs is one of the missing files.
+ *     - The #604 stale-cache-version ratchet in
+ *       hooks/normalize-hooks.mjs runs from start.mjs's
+ *       normalize-hooks call, same boot-time dependency.
+ *     - /ctx-upgrade needs the cli.bundle.mjs the partial install lost.
+ *
+ *   So the cache cannot self-recover, and the only available
+ *   workaround from the user side is `rm -rf <version-dir>` plus a
+ *   session restart.
+ *
+ * What this module does:
+ *
+ *   Detect partial install via a cheap existsSync probe of a few
+ *   launch-critical files. On a trip, re-copy the missing entries
+ *   from the marketplace clone at
+ *   ~/.claude/plugins/marketplaces/<owner>/ (Claude Code's canonical
+ *   source for the per-version cache dir) and rewrite any
+ *   carry-forward stale args[0] in plugin.json to the current
+ *   pluginRoot. Both halves are mechanism-agnostic.
+ *
+ * Placement:
+ *
+ *   Lives in hooks/ rather than scripts/ because the failure mode can
+ *   strip scripts/ from the cache dir. hooks/ has been intact in every
+ *   observed instance, so it's the most reliable available host.
+ *
+ * Scope:
+ *
+ *   CC-only. The failure mode is specific to Claude Code's
+ *   per-version cache layout at
+ *   ~/.claude/plugins/cache/<owner>/<plugin>/<version>/. Other
+ *   clients (Codex, Cursor, OpenCode, Kiro, ...) ship their own
+ *   SessionStart wrappers under hooks/<client>/, none of which call
+ *   this module. The two call sites that exist
+ *   (hooks/sessionstart.mjs and start.mjs) are themselves CC-only
+ *   entry points: sessionstart.mjs is wired only from
+ *   hooks/hooks.json (CC's hook config), and start.mjs is invoked
+ *   only by CC's .claude-plugin/plugin.json mcpServers entry. The
+ *   module also enforces this at runtime: pluginRoot must match the
+ *   CC cache layout (deriveMarketplaceClonePath returns null
+ *   otherwise) or the function short-circuits with
+ *   `skipped: "not-claude-code"`, before any further work runs.
+ *
+ * Contract:
+ *
+ *   - Pure JS, Node built-ins only.
+ *   - Never throws. Returns a structured result; callers log it.
+ *   - Idempotent: the cheap probe makes the healthy case a few
+ *     existsSync calls, not a full files[] expansion.
+ *   - Path-traversal guarded at six layers, symmetric on both ends:
+ *       1. pluginRoot must match the CC cache layout, the derived
+ *          marketplace path must exist and not equal pluginRoot.
+ *       2. files[] entries that resolve outside rootDir are dropped.
+ *       3. Directory walks use lstatSync and skip symlinks, so a
+ *          symlink-to-outside in the marketplace tree can't be
+ *          harvested as a regular file during manifest expansion.
+ *       4. After mkdirSync(dirname(to)), realpathSync(dirname(to)) is
+ *          re-checked against realpathSync(pluginRoot), catching the
+ *          case where a parent component of `to` is already a
+ *          symlink-to-outside that mkdirSync followed.
+ *       5. Just before the destination write, the source is checked
+ *          two ways: lstat(from).isSymbolicLink() drops leaf symlinks
+ *          (fast path), and realpathSync(from) is required to fall
+ *          under realpathSync(marketplaceClonePath). The realpath
+ *          check collapses ancestor symlinks (e.g. a marketplace
+ *          `scripts/` dir that's been swapped for a symlink to
+ *          outside), which the leaf-lstat would miss because the
+ *          leaf itself is a regular file at the symlink's resolved
+ *          target.
+ *       6. Just before the destination write, lstat(to) and unlink
+ *          any pre-existing symlink at `to`. The write itself uses
+ *          writeFileSync with `flag: "wx"` (O_CREAT | O_EXCL), which
+ *          per POSIX open(2) refuses to follow a symlink at the
+ *          final component. That closes the residual race window
+ *          where a same-user attacker re-plants a symlink at `to`
+ *          between our unlink and the open.
+ *   - Source-file reads that drive rewrites are symlink-checked too.
+ *     rewritePluginJsonArgs opens `.claude-plugin/plugin.json` with
+ *     O_NOFOLLOW, so the open(2) call itself fails with ELOOP when
+ *     the path is a symlink. Reading from the returned fd then binds
+ *     subsequent reads to the inode, closing the TOCTOU window that
+ *     a lstat+readFileSync(path) pair would have left open. Without
+ *     this, a same-user-planted redirect would feed attacker JSON to
+ *     the read, and the subsequent atomic rename would replace the
+ *     symlink with a regular file containing attacker-controlled
+ *     mcpServers config.
+ *   - plugin.json rewrites are atomic AND symlink-safe:
+ *     writeFileSync targets a tmp sibling with a 64-bit random
+ *     suffix (unguessable) under O_CREAT | O_EXCL (refuses to follow
+ *     a pre-planted symlink at the tmp path), then renameSync over
+ *     the real path. A racing writer can't observe a torn JSON file,
+ *     and a local attacker can't redirect the write via symlink.
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  lstatSync,
+  mkdirSync,
+  renameSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync,
+  appendFileSync,
+  openSync,
+  closeSync,
+  constants as fsConstants,
+} from "node:fs";
+import { join, dirname, resolve, sep } from "node:path";
+import { homedir } from "node:os";
+import { randomBytes } from "node:crypto";
+
+/**
+ * Cheap-probe partial-install detection. Runs on every session start, so
+ * the healthy case must be O(few existsSync), not O(files[].length).
+ *
+ * A file is "launch-critical" when its absence keeps either start.mjs
+ * from booting or /ctx-upgrade from running. We don't probe every file
+ * in files[]; that's what the full heal does once this probe trips.
+ */
+export function isPartialInstall(pluginRoot) {
+  if (!pluginRoot) return false;
+  if (!existsSync(join(pluginRoot, "start.mjs"))) return true;
+  if (!existsSync(join(pluginRoot, "package.json"))) return true;
+  if (
+    !existsSync(join(pluginRoot, "cli.bundle.mjs")) &&
+    !existsSync(join(pluginRoot, "build", "cli.js"))
+  ) {
+    return true;
+  }
+  if (
+    !existsSync(join(pluginRoot, "server.bundle.mjs")) &&
+    !existsSync(join(pluginRoot, "build", "server.js"))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Derive the marketplace clone path for a CC plugin cache pluginRoot.
+ *
+ * Layout (forward slashes on POSIX, backslashes on Windows):
+ *   <configDir>/plugins/cache/<owner>/<plugin>/<version>/
+ *   <configDir>/plugins/marketplaces/<owner>/
+ *
+ * Returns null when pluginRoot doesn't match the cache layout (npm-global
+ * install, dev checkout, opencode cache, ...). Those don't have a
+ * marketplace clone to heal from, and we'd rather skip than guess.
+ */
+export function deriveMarketplaceClonePath(pluginRoot) {
+  if (!pluginRoot) return null;
+  const fwd = String(pluginRoot).replace(/\\/g, "/");
+  const trailing = fwd.endsWith("/") ? fwd : fwd + "/";
+  const m = /^(.*\/plugins\/)cache\/([^/]+)\/[^/]+\/[^/]+\/$/.exec(trailing);
+  if (!m) return null;
+  return resolve(m[1], "marketplaces", m[2]);
+}
+
+/**
+ * Walk a directory recursively, returning relative file paths from
+ * baseAbs. Skips unreadable entries silently. Uses lstatSync and skips
+ * symlinks so a stray symlink-to-outside in the marketplace tree can't
+ * be harvested as a regular file and copied into pluginRoot. statSync
+ * would dereference and silently follow the link.
+ */
+function listFilesRecursive(absDir, baseAbs) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(absDir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const full = join(absDir, name);
+    let st;
+    try {
+      st = lstatSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isSymbolicLink()) continue;
+    if (st.isDirectory()) {
+      out.push(...listFilesRecursive(full, baseAbs));
+    } else if (st.isFile()) {
+      out.push(full.slice(baseAbs.length + 1));
+    }
+  }
+  return out;
+}
+
+/**
+ * Expand a `files[]` array against rootDir into a flat list of file paths
+ * (relative to rootDir, OS-native separator). Entries that don't exist on
+ * disk are silently dropped, matching the semantics of
+ * scripts/plugin-cache-integrity.mjs::derivePluginManifest.
+ *
+ * Containment: entries whose resolved path escapes rootDir (e.g. a
+ * corrupted marketplace package.json with `files: ["../outside.txt"]`)
+ * are rejected, so the downstream copy loop can't be tricked into
+ * reading from or writing outside the trusted root. `path.join` itself
+ * does not clamp `..` segments; it normalizes them. As such, we resolve
+ * and prefix-match against rootDir + sep explicitly.
+ *
+ * Symlinks: lstatSync + isSymbolicLink() drops top-level entries that
+ * are themselves symlinks. A symlink-to-outside sitting in rootDir
+ * passes the lexical resolve+startsWith check, since the symlink's own
+ * path stays inside rootDir; we have to refuse symlinks outright to
+ * close that bypass.
+ */
+function expandFilesArray(rootDir, files) {
+  if (!Array.isArray(files)) return [];
+  const out = new Set();
+  const rootWithSep = resolve(rootDir) + sep;
+  for (const entry of files) {
+    if (typeof entry !== "string" || !entry) continue;
+    const abs = join(rootDir, entry);
+    if (!resolve(abs).startsWith(rootWithSep)) continue;
+    if (!existsSync(abs)) continue;
+    let st;
+    try {
+      st = lstatSync(abs);
+    } catch {
+      continue;
+    }
+    if (st.isSymbolicLink()) continue;
+    if (st.isDirectory()) {
+      for (const f of listFilesRecursive(abs, rootDir)) out.add(f);
+    } else if (st.isFile()) {
+      out.add(entry);
+    }
+  }
+  return [...out];
+}
+
+function readJsonSafe(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Repair `.claude-plugin/plugin.json` mcpServers.args[0] to point at the
+ * current pluginRoot. This is the carry-forward fingerprint from CC's
+ * native plugin manager: when it creates a new version dir, it preserves
+ * the previous version's plugin.json (including any absolute start.mjs
+ * path that hooks/normalize-hooks.mjs (#604) wrote on Linux/Windows) and
+ * only bumps the `version` field. The result is args[0] pointing at a
+ * version dir that's typically been cleaned up by the age-gated sweep,
+ * so MCP launch ENOENTs.
+ *
+ * We can't lean on normalize-hooks.mjs's existing rewrite path since
+ * that fires from start.mjs at boot, and start.mjs is what's missing
+ * (or, if present, would have already loaded plugin.json with the stale
+ * path before normalize ran). The heal does the rewrite up front.
+ *
+ * Mirrors the rewrite logic in hooks/normalize-hooks.mjs for placeholder
+ * and stale-cache-version drift shapes. The `command` field is left
+ * alone (start.mjs's normalize call repairs it on the next clean boot).
+ */
+function rewritePluginJsonArgs(pluginRoot) {
+  const pluginJsonPath = join(pluginRoot, ".claude-plugin", "plugin.json");
+  if (!existsSync(pluginJsonPath)) return false;
+  // Refuse to operate on plugin.json when it's a symlink, atomically.
+  // O_NOFOLLOW makes open(2) fail with ELOOP when the final path
+  // component is a symlink, in the same syscall that opens the fd.
+  // A naive `lstatSync().isSymbolicLink() ? return false : readFileSync(path)`
+  // would have a TOCTOU window between the lstat and the read where
+  // a same-user attacker could swap the regular file for a symlink
+  // pointing at attacker JSON, feeding the read attacker bytes; the
+  // subsequent atomic rename would then replace the symlink with a
+  // regular file holding attacker mcpServers config, executed at next
+  // MCP launch. Reading from the fd returned by openSync(O_NOFOLLOW)
+  // closes that window since the fd is bound to an inode, not a path.
+  // POSIX 0700 on ~/.claude scopes this to same-user threats; the
+  // defense mirrors the source/destination symlink refusals elsewhere.
+  let fd;
+  try {
+    fd = openSync(
+      pluginJsonPath,
+      fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+    );
+  } catch {
+    return false;
+  }
+  let content;
+  try {
+    content = readFileSync(fd, "utf-8");
+  } catch {
+    try {
+      closeSync(fd);
+    } catch {
+      /* ignore */
+    }
+    return false;
+  }
+  try {
+    closeSync(fd);
+  } catch {
+    /* ignore */
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return false;
+  }
+  const servers = parsed?.mcpServers;
+  if (!servers || typeof servers !== "object") return false;
+
+  const safeRoot = String(pluginRoot).replace(/\\/g, "/");
+  const versionM = /context-mode\/context-mode\/([0-9]+\.[0-9]+\.[0-9]+)(?:\/|$)/.exec(safeRoot);
+  const currentVersion = versionM ? versionM[1] : null;
+  const STALE_VERSION_RE = /context-mode\/context-mode\/([0-9]+\.[0-9]+\.[0-9]+)(?=\/)/g;
+  const PLACEHOLDER = "${CLAUDE_PLUGIN_ROOT}";
+
+  let mutated = false;
+  for (const key of Object.keys(servers)) {
+    const srv = servers[key];
+    if (!srv || typeof srv !== "object" || !Array.isArray(srv.args)) continue;
+    const before = srv.args;
+    const after = before.map((a) => {
+      if (typeof a !== "string") return a;
+      let next = a;
+      if (next.includes(PLACEHOLDER)) {
+        next = next.replaceAll(PLACEHOLDER, safeRoot);
+      }
+      if (currentVersion) {
+        const fwd = next.replace(/\\/g, "/");
+        STALE_VERSION_RE.lastIndex = 0;
+        let hasStale = false;
+        let m;
+        while ((m = STALE_VERSION_RE.exec(fwd)) !== null) {
+          if (m[1] !== currentVersion) {
+            hasStale = true;
+            break;
+          }
+        }
+        if (hasStale) {
+          next = fwd.replace(
+            STALE_VERSION_RE,
+            `context-mode/context-mode/${currentVersion}`,
+          );
+        }
+      }
+      return next;
+    });
+    if (after.some((v, i) => v !== before[i])) {
+      srv.args = after;
+      mutated = true;
+    }
+  }
+
+  if (!mutated) return false;
+  // Atomic write with two security properties on top of atomicity:
+  //   1. Unguessable tmp filename via randomBytes(8). A local attacker
+  //      polling /proc/<pid>/comm can predict process.pid and pre-plant
+  //      a symlink at a deterministic tmp path, redirecting our write.
+  //      64 bits of randomness make that infeasible.
+  //   2. O_CREAT | O_EXCL via `flag: "wx"`. open(2) with O_EXCL refuses
+  //      to follow symlinks at the final path component, raising EEXIST
+  //      instead. So even if the random tmp name happens to collide
+  //      with a pre-existing symlink, the write fails closed rather
+  //      than redirecting.
+  // renameSync remains atomic on POSIX so a concurrent reader can't
+  // observe a torn JSON file. On Windows the implementation maps to
+  // MoveFileEx(MOVEFILE_REPLACE_EXISTING), which is atomic for
+  // non-directory writes.
+  const tmp = `${pluginJsonPath}.tmp-${randomBytes(8).toString("hex")}`;
+  try {
+    writeFileSync(tmp, JSON.stringify(parsed, null, 2), {
+      encoding: "utf-8",
+      flag: "wx",
+    });
+    renameSync(tmp, pluginJsonPath);
+    return true;
+  } catch {
+    // Best-effort cleanup. If writeFileSync threw, tmp may not exist;
+    // if renameSync threw, tmp still does. unlinkSync's own catch
+    // swallows ENOENT either way.
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore */
+    }
+    return false;
+  }
+}
+
+function resolveConfigDir() {
+  const envVal = process.env.CLAUDE_CONFIG_DIR;
+  if (envVal && envVal.trim() !== "") {
+    if (envVal.startsWith("~")) {
+      return resolve(homedir(), envVal.replace(/^~[/\\]?/, ""));
+    }
+    return resolve(envVal);
+  }
+  return resolve(homedir(), ".claude");
+}
+
+function logHealResult(result) {
+  try {
+    const logDir = join(resolveConfigDir(), "context-mode");
+    mkdirSync(logDir, { recursive: true });
+    appendFileSync(
+      join(logDir, "heal-partial-install.log"),
+      JSON.stringify({ ts: new Date().toISOString(), ...result }) + "\n",
+      "utf-8",
+    );
+  } catch {
+    /* best effort */
+  }
+}
+
+/**
+ * Heal a partial install by copying missing files from the marketplace
+ * clone. Best-effort and idempotent. Never throws.
+ *
+ * Inputs:
+ *   pluginRoot           - absolute path to the cache version dir (CLAUDE_PLUGIN_ROOT).
+ *   marketplaceClonePath - absolute path to the marketplace clone. Auto-derived
+ *                          from pluginRoot when omitted.
+ *   log                  - when true (default), appends a JSON line to
+ *                          ~/.claude/context-mode/heal-partial-install.log
+ *                          on every run, including skipped ones, so an
+ *                          operator can grep for evidence the hook fired.
+ *
+ * Returns an object whose exact shape depends on the branch taken.
+ * Common fields:
+ *   healed:        string[]   // relative paths successfully copied (always present, [] when skipped)
+ *   stillMissing:  string[]   // relative paths the heal couldn't restore (always present, [] when skipped)
+ *   skipped?:      string     // reason the heal short-circuited; absent on the success path
+ *   pluginRoot?:   string     // echoed back when known; absent only on the "no-plugin-root" branch
+ *   pkgSource?:    string     // "marketplace" or "pluginRoot", which package.json the files[] came from; absent until the manifest read happens
+ *   argsRewritten?: boolean   // whether plugin.json mcpServers.args was rewritten; present on the success path and on "files-already-present"
+ *   missingBefore?: string[]  // present on the success path only; relative paths that were missing before the copy loop ran
+ *
+ * Branch matrix:
+ *   skipped="no-plugin-root"        : {healed, stillMissing, skipped}
+ *   skipped="not-claude-code"       : {healed, stillMissing, skipped, pluginRoot}
+ *   skipped="not-partial"           : {healed, stillMissing, skipped, pluginRoot}
+ *   skipped="no-marketplace"        : {healed, stillMissing, skipped, pluginRoot}
+ *   skipped="same-as-marketplace"   : {healed, stillMissing, skipped, pluginRoot}
+ *   skipped="no-files-manifest"     : {healed, stillMissing, skipped, pluginRoot, pkgSource}
+ *   skipped="marketplace-empty"     : {healed, stillMissing, skipped, pluginRoot, pkgSource}
+ *   skipped="files-already-present" : {healed, stillMissing, skipped, pluginRoot, pkgSource, argsRewritten}
+ *   success path (no `skipped` key) : {healed, stillMissing, pluginRoot, pkgSource, argsRewritten, missingBefore}
+ */
+export function healPartialInstallFromMarketplace(opts = {}) {
+  const pluginRoot = opts.pluginRoot ?? process.env.CLAUDE_PLUGIN_ROOT;
+  const log = opts.log !== false;
+
+  if (!pluginRoot) {
+    const result = {
+      healed: [],
+      stillMissing: [],
+      skipped: "no-plugin-root",
+    };
+    if (log) logHealResult(result);
+    return result;
+  }
+
+  // CC-only scope check. The partial-install failure mode this module
+  // addresses is specific to Claude Code's per-version cache layout at
+  // ~/.claude/plugins/cache/<owner>/<plugin>/<version>/. Other clients
+  // (Codex, Cursor, OpenCode, Kiro, ...) ship their own SessionStart
+  // hooks under hooks/<client>/ and don't go through this module at
+  // all; npm-global, npx, and dev-checkout installs don't have the
+  // cache layout either. deriveMarketplaceClonePath returns null for
+  // anything that isn't a CC cache pluginRoot. Bailing here keeps the
+  // healthy-case fast path cheap for non-CC contexts (no isPartialInstall
+  // probe, no filesystem reads) and makes the scope intent explicit in
+  // the log: a "not-claude-code" line is the signal that the heal saw
+  // a non-CC pluginRoot.
+  const marketplaceClonePath =
+    opts.marketplaceClonePath ?? deriveMarketplaceClonePath(pluginRoot);
+  if (!marketplaceClonePath) {
+    const result = {
+      healed: [],
+      stillMissing: [],
+      skipped: "not-claude-code",
+      pluginRoot,
+    };
+    if (log) logHealResult(result);
+    return result;
+  }
+
+  if (!isPartialInstall(pluginRoot)) {
+    const result = {
+      healed: [],
+      stillMissing: [],
+      skipped: "not-partial",
+      pluginRoot,
+    };
+    if (log) logHealResult(result);
+    return result;
+  }
+
+  if (!existsSync(marketplaceClonePath)) {
+    const result = {
+      healed: [],
+      stillMissing: [],
+      skipped: "no-marketplace",
+      pluginRoot,
+    };
+    if (log) logHealResult(result);
+    return result;
+  }
+
+  // Path-traversal guard: refuse to heal a pluginRoot that is itself the
+  // marketplace clone (would happen on a dev checkout where someone
+  // symlinks the cache into the marketplace tree).
+  if (resolve(pluginRoot) === resolve(marketplaceClonePath)) {
+    const result = {
+      healed: [],
+      stillMissing: [],
+      skipped: "same-as-marketplace",
+      pluginRoot,
+    };
+    if (log) logHealResult(result);
+    return result;
+  }
+
+  // Prefer the marketplace clone's package.json. The heal only runs
+  // once we've established that pluginRoot is in a partial state, and
+  // its package.json (when present at all) can itself be a stale
+  // carry-forward from a prior version. The marketplace clone is the
+  // canonical source CC extracted the cache from, so its files[] is
+  // the right manifest to expand. Fall back to pluginRoot only when
+  // the marketplace clone's package.json is unreadable.
+  let pkg = readJsonSafe(join(marketplaceClonePath, "package.json"));
+  let pkgSource = "marketplace";
+  if (!pkg) {
+    pkg = readJsonSafe(join(pluginRoot, "package.json"));
+    pkgSource = "pluginRoot";
+  }
+  if (!pkg || !Array.isArray(pkg.files)) {
+    const result = {
+      healed: [],
+      stillMissing: [],
+      skipped: "no-files-manifest",
+      pluginRoot,
+      pkgSource,
+    };
+    if (log) logHealResult(result);
+    return result;
+  }
+
+  // Always include package.json itself so the next boot's getLocalVersion
+  // and integrity check have something to read. npm's `files[]` semantics
+  // include package.json implicitly; we have to add it back manually since
+  // we're expanding the array ourselves.
+  const items = new Set(pkg.files);
+  items.add("package.json");
+
+  // Expand against the marketplace clone since that's the source of truth.
+  // Entries that don't exist on the marketplace side are dropped.
+  const expanded = expandFilesArray(marketplaceClonePath, [...items]);
+  if (expanded.length === 0) {
+    const result = {
+      healed: [],
+      stillMissing: [],
+      skipped: "marketplace-empty",
+      pluginRoot,
+      pkgSource,
+    };
+    if (log) logHealResult(result);
+    return result;
+  }
+
+  const missingBefore = expanded.filter((rel) => !existsSync(join(pluginRoot, rel)));
+  if (missingBefore.length === 0) {
+    // The cheap probe tripped but the full expansion shows everything's
+    // present, e.g. start.mjs is missing but isn't in files[] anymore
+    // (unlikely, but defensive). Still attempt the args rewrite in case
+    // a carry-forward plugin.json drifted independently.
+    const argsRewritten = rewritePluginJsonArgs(pluginRoot);
+    const result = {
+      healed: [],
+      stillMissing: [],
+      argsRewritten,
+      pkgSource,
+      pluginRoot,
+      skipped: "files-already-present",
+    };
+    if (log) logHealResult(result);
+    return result;
+  }
+
+  // Copy each missing item. The guards below mirror the Contract
+  // block at the top of this module: layer 2 (lexical), layer 4
+  // (realpath on dest), layer 5 (lstat + realpath on source), layer 6
+  // (lstat + unlink on dest, plus an O_EXCL destination open). The
+  // non-layered existsSync(from) guard skips entries that disappeared
+  // from the marketplace between manifest expansion and this
+  // iteration, so the read isn't asked to open a missing source.
+  // realpathSync(pluginRoot) and realpathSync(marketplaceClonePath)
+  // are cached once outside the loop; failures there just disable
+  // the realpath guards for this run, leaving the lexical guards in
+  // force (heal contract: never throws).
+  const pluginRootWithSep = resolve(pluginRoot) + sep;
+  const marketplaceWithSep = resolve(marketplaceClonePath) + sep;
+  let pluginRootRealWithSep = null;
+  try {
+    pluginRootRealWithSep = realpathSync(pluginRoot) + sep;
+  } catch {
+    /* lexical guard still in force */
+  }
+  let marketplaceCloneRealWithSep = null;
+  try {
+    marketplaceCloneRealWithSep = realpathSync(marketplaceClonePath) + sep;
+  } catch {
+    /* lexical guard still in force */
+  }
+  const healed = [];
+  for (const rel of missingBefore) {
+    const from = join(marketplaceClonePath, rel);
+    const to = join(pluginRoot, rel);
+    if (!resolve(from).startsWith(marketplaceWithSep)) continue;
+    if (!resolve(to).startsWith(pluginRootWithSep)) continue;
+    if (!existsSync(from)) continue;
+    try {
+      mkdirSync(dirname(to), { recursive: true });
+      if (pluginRootRealWithSep) {
+        const toParentReal = realpathSync(dirname(to)) + sep;
+        if (!toParentReal.startsWith(pluginRootRealWithSep)) continue;
+      }
+      let stFrom;
+      try {
+        stFrom = lstatSync(from);
+      } catch {
+        continue;
+      }
+      if (stFrom.isSymbolicLink()) continue;
+      if (marketplaceCloneRealWithSep) {
+        let fromReal;
+        try {
+          fromReal = realpathSync(from);
+        } catch {
+          continue;
+        }
+        if (!(fromReal + sep).startsWith(marketplaceCloneRealWithSep)) {
+          continue;
+        }
+      }
+      try {
+        const stTo = lstatSync(to);
+        if (stTo.isSymbolicLink()) unlinkSync(to);
+      } catch {
+        /* `to` doesn't exist yet, which is the common case */
+      }
+      // Read-then-write with O_CREAT | O_EXCL (Node's `wx` flag) so
+      // the destination open refuses to follow a symlink at the leaf.
+      // This closes the residual race window between the unlinkSync
+      // above and the destination open: a same-user attacker who
+      // re-plants a symlink at `to` after our unlink would have made
+      // a default cpSync (or any non-EXCL open) follow it. EXCL on
+      // its own implies "do not follow symlinks at the final
+      // component" per POSIX open(2), so we don't need an explicit
+      // O_NOFOLLOW. mode is preserved from the source so executable
+      // bits on bin/* survive the copy.
+      const content = readFileSync(from);
+      writeFileSync(to, content, {
+        flag: "wx",
+        mode: stFrom.mode & 0o777,
+      });
+      healed.push(rel);
+    } catch {
+      /* best-effort: keep going so as many files as possible get restored */
+    }
+  }
+
+  const argsRewritten = rewritePluginJsonArgs(pluginRoot);
+  const stillMissing = expanded.filter((rel) => !existsSync(join(pluginRoot, rel)));
+
+  const result = {
+    healed,
+    stillMissing,
+    argsRewritten,
+    pkgSource,
+    missingBefore,
+    pluginRoot,
+  };
+  if (log) logHealResult(result);
+  return result;
+}
+
+// Default export for ergonomic call sites that don't need the named exports.
+export default healPartialInstallFromMarketplace;

--- a/hooks/sessionstart.mjs
+++ b/hooks/sessionstart.mjs
@@ -51,6 +51,18 @@ await runHook(async () => {
   const HOOK_DIR = dirname(fileURLToPath(import.meta.url));
   const { loadSessionDB } = createSessionLoaders(HOOK_DIR);
 
+  // Self-heal a partial plugin cache install before anything else
+  // touches the cache dir. The Algo-D4 boot gate and the #604
+  // normalize-hooks ratchet both fire from start.mjs, which is one of
+  // the files that may be missing in the failure mode; sessionstart.mjs
+  // fires from CC's hooks.json wiring regardless of MCP boot status, so
+  // it is the reliably-available entry point. See
+  // hooks/heal-partial-install.mjs for the full failure-mode description.
+  try {
+    const { healPartialInstallFromMarketplace } = await import("./heal-partial-install.mjs");
+    healPartialInstallFromMarketplace();
+  } catch { /* best effort, never block session start */ }
+
   let additionalContext = ROUTING_BLOCK;
 
   // ─── #558: surface security init failure as agent-facing context ───

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1230,10 +1230,17 @@ async function upgrade(opts?: { platform?: string }) {
         if (!(to + sep).startsWith(pluginRootWithSep)) continue;
         if (!(from + sep).startsWith(srcDirWithSep)) continue;
         if (!refuseSymlinks(from)) continue;
+        // Existence-check the source BEFORE the rm so a `files[]` entry that
+        // doesn't exist in srcDir can never delete-without-replace at
+        // pluginRoot. The catch-all below swallows cpSync failures too, and
+        // a swallowed cp after a successful rm is exactly how a partial
+        // install lands silently. Mirrors the safe pattern in
+        // server.ts's inline-fallback upgrade path (PR #699).
+        if (!existsSync(from)) continue;
         try {
           rmSync(to, { recursive: true, force: true });
           cpSync(from, to, { recursive: true, filter: refuseSymlinks });
-        } catch { /* some files may not exist in source */ }
+        } catch { /* best effort, next /ctx-upgrade retries */ }
       }
 
       // Issue #609 — DO NOT write `.mcp.json` into the plugin cache dir.

--- a/start.mjs
+++ b/start.mjs
@@ -415,6 +415,21 @@ if (!existsSync(resolve(__dirname, "cli.bundle.mjs")) && existsSync(resolve(__di
   if (process.platform !== "win32") chmodSync(shimPath, 0o755);
 }
 
+// ── Self-heal partial install from marketplace clone ──
+// Runs BEFORE the Algo-D4 integrity check so a fixable partial install
+// gets repaired rather than just reported. Best-effort and idempotent;
+// the integrity check below remains the authoritative gate that decides
+// whether boot proceeds. See hooks/heal-partial-install.mjs for the
+// failure-mode description and module contract.
+if (!process.env.VITEST) {
+  try {
+    const { healPartialInstallFromMarketplace } = await import(
+      "./hooks/heal-partial-install.mjs"
+    );
+    healPartialInstallFromMarketplace({ pluginRoot: __dirname });
+  } catch { /* best effort, never block boot */ }
+}
+
 // ── Algo-D4: plugin cache integrity check ──
 // Verify boot-critical siblings exist BEFORE importing server.bundle.mjs.
 // Without this, a partial install (#550) gives an opaque downstream
@@ -423,11 +438,12 @@ if (!existsSync(resolve(__dirname, "cli.bundle.mjs")) && existsSync(resolve(__di
 // external monitoring grep + the user both see the actionable signal.
 //
 // Runs AFTER the heal layers above so missing files they can fix
-// (cli.bundle.mjs shim, dangling symlinks) get a chance first. Helper
-// is shared with `ctx doctor` (Algo-D5) — single source of truth so
-// boot + diagnostic agree byte-for-byte. Skipped under VITEST so the
-// repo's own test invocations against in-tree start.mjs don't fail
-// when running before `npm run build` produces the bundles.
+// (cli.bundle.mjs shim, dangling symlinks, partial-install copy from
+// the marketplace clone) get a chance first. Helper is shared with
+// `ctx doctor` (Algo-D5) — single source of truth so boot + diagnostic
+// agree byte-for-byte. Skipped under VITEST so the repo's own test
+// invocations against in-tree start.mjs don't fail when running before
+// `npm run build` produces the bundles.
 if (!process.env.VITEST) {
   try {
     const { assertPluginCacheIntegrity, formatPartialInstallReport } =

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -8,8 +8,8 @@
  */
 import { describe, it, test, expect, beforeEach, afterEach } from "vitest";
 import { strict as assert } from "node:assert";
-import { readFileSync, existsSync, accessSync, constants, mkdirSync, writeFileSync, rmSync, readdirSync } from "node:fs";
-import { resolve, join, dirname } from "node:path";
+import { readFileSync, existsSync, accessSync, constants, mkdirSync, writeFileSync, rmSync, readdirSync, cpSync, symlinkSync, lstatSync } from "node:fs";
+import { resolve, join, dirname, sep } from "node:path";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
@@ -1386,6 +1386,1083 @@ describe("start.mjs CLI self-heal", () => {
         `legacy required sibling missing from algorithmic set: ${entry}`,
       ).toBe(true);
     }
+  });
+
+  // ── hooks/heal-partial-install.mjs (partial-install auto-recovery) ──
+  //
+  // Claude Code's native plugin manager occasionally produces a partial
+  // install when it creates a new cache version directory: hooks/ and
+  // .claude-plugin/ make it across, but cli.bundle.mjs, server.bundle.mjs,
+  // start.mjs, package.json, src/, bin/, scripts/, and skills/ don't. The
+  // .claude-plugin/plugin.json carries forward from the previous version
+  // with a stale absolute mcpServers.args[0]; once the old version dir is
+  // age-gate-cleaned, every MCP spawn ENOENTs.
+  //
+  // The existing #550 boot gate and the #604 stale-cache-version ratchet
+  // both fire from start.mjs, the very file that's missing. The heal
+  // module lives in hooks/ since that's the directory that reliably
+  // survives the partial copy, and runs from hooks/sessionstart.mjs (the
+  // primary trigger) and start.mjs (belt-and-braces, before the Algo-D4
+  // gate so a fixable install is repaired rather than just reported).
+  describe("hooks/heal-partial-install.mjs (partial-install auto-recovery)", () => {
+    const heallessCleanups: string[] = [];
+
+    afterEach(() => {
+      while (heallessCleanups.length) {
+        const dir = heallessCleanups.pop();
+        if (dir) {
+          try {
+            rmSync(dir, { recursive: true, force: true });
+          } catch {
+            /* best effort */
+          }
+        }
+      }
+    });
+
+    function makeTmp(prefix = "ctx-heal-partial-"): string {
+      const dir = mkdtempSync(join(tmpdir(), prefix));
+      heallessCleanups.push(dir);
+      return dir;
+    }
+
+    // Build a fake CC plugin layout under a fresh tmp dir:
+    //   <root>/.claude/plugins/cache/context-mode/context-mode/<version>/
+    //   <root>/.claude/plugins/marketplaces/context-mode/
+    // The marketplace clone gets a realistic package.json files[] pointing
+    // at a few canned dirs + files so the heal has concrete sources to
+    // copy. The cache dir starts empty so each test can populate the exact
+    // subset it wants to simulate.
+    function buildFakeLayout(version = "1.0.150"): {
+      pluginRoot: string;
+      marketplaceClonePath: string;
+    } {
+      const root = makeTmp();
+      const pluginsDir = resolve(root, ".claude", "plugins");
+      const pluginRoot = resolve(
+        pluginsDir,
+        "cache",
+        "context-mode",
+        "context-mode",
+        version,
+      );
+      const marketplaceClonePath = resolve(
+        pluginsDir,
+        "marketplaces",
+        "context-mode",
+      );
+      mkdirSync(marketplaceClonePath, { recursive: true });
+      writeFileSync(
+        resolve(marketplaceClonePath, "package.json"),
+        JSON.stringify(
+          {
+            name: "context-mode",
+            version,
+            files: [
+              "hooks",
+              ".claude-plugin",
+              "scripts/postinstall.mjs",
+              "scripts/plugin-cache-integrity.mjs",
+              "cli.bundle.mjs",
+              "server.bundle.mjs",
+              "start.mjs",
+              "bin",
+            ],
+          },
+          null,
+          2,
+        ),
+      );
+      writeFileSync(resolve(marketplaceClonePath, "start.mjs"), "// start\n");
+      writeFileSync(
+        resolve(marketplaceClonePath, "cli.bundle.mjs"),
+        "// cli bundle\n",
+      );
+      writeFileSync(
+        resolve(marketplaceClonePath, "server.bundle.mjs"),
+        "// server bundle\n",
+      );
+      mkdirSync(resolve(marketplaceClonePath, "hooks"), { recursive: true });
+      writeFileSync(
+        resolve(marketplaceClonePath, "hooks", "sessionstart.mjs"),
+        "// hook\n",
+      );
+      mkdirSync(resolve(marketplaceClonePath, ".claude-plugin"), {
+        recursive: true,
+      });
+      writeFileSync(
+        resolve(marketplaceClonePath, ".claude-plugin", "plugin.json"),
+        JSON.stringify(
+          {
+            name: "context-mode",
+            version,
+            mcpServers: {
+              "context-mode": {
+                command: "node",
+                args: ["${CLAUDE_PLUGIN_ROOT}/start.mjs"],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      mkdirSync(resolve(marketplaceClonePath, "scripts"), { recursive: true });
+      writeFileSync(
+        resolve(marketplaceClonePath, "scripts", "postinstall.mjs"),
+        "// postinstall\n",
+      );
+      writeFileSync(
+        resolve(marketplaceClonePath, "scripts", "plugin-cache-integrity.mjs"),
+        "// integrity\n",
+      );
+      mkdirSync(resolve(marketplaceClonePath, "bin"), { recursive: true });
+      writeFileSync(
+        resolve(marketplaceClonePath, "bin", "statusline.mjs"),
+        "// statusline\n",
+      );
+      mkdirSync(pluginRoot, { recursive: true });
+      return { pluginRoot, marketplaceClonePath };
+    }
+
+    function readJson(path: string): unknown {
+      return JSON.parse(readFileSync(path, "utf-8"));
+    }
+
+    // ── isPartialInstall cheap probe ──
+
+    it("isPartialInstall returns false for a healthy install", async () => {
+      const { isPartialInstall } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      cpSync(marketplaceClonePath, pluginRoot, { recursive: true, force: true });
+      expect(isPartialInstall(pluginRoot)).toBe(false);
+    });
+
+    it("isPartialInstall returns true when start.mjs is missing", async () => {
+      const { isPartialInstall } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      cpSync(marketplaceClonePath, pluginRoot, { recursive: true, force: true });
+      rmSync(join(pluginRoot, "start.mjs"));
+      expect(isPartialInstall(pluginRoot)).toBe(true);
+    });
+
+    it("isPartialInstall returns true when package.json is missing", async () => {
+      const { isPartialInstall } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      cpSync(marketplaceClonePath, pluginRoot, { recursive: true, force: true });
+      rmSync(join(pluginRoot, "package.json"));
+      expect(isPartialInstall(pluginRoot)).toBe(true);
+    });
+
+    it("isPartialInstall returns true when both cli.bundle.mjs and build/cli.js are missing", async () => {
+      const { isPartialInstall } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      cpSync(marketplaceClonePath, pluginRoot, { recursive: true, force: true });
+      rmSync(join(pluginRoot, "cli.bundle.mjs"));
+      expect(isPartialInstall(pluginRoot)).toBe(true);
+    });
+
+    it("isPartialInstall accepts build/cli.js as the cli fallback", async () => {
+      const { isPartialInstall } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      cpSync(marketplaceClonePath, pluginRoot, { recursive: true, force: true });
+      rmSync(join(pluginRoot, "cli.bundle.mjs"));
+      rmSync(join(pluginRoot, "server.bundle.mjs"));
+      mkdirSync(join(pluginRoot, "build"), { recursive: true });
+      writeFileSync(join(pluginRoot, "build", "cli.js"), "// tsc output\n");
+      writeFileSync(join(pluginRoot, "build", "server.js"), "// tsc output\n");
+      expect(isPartialInstall(pluginRoot)).toBe(false);
+    });
+
+    it("isPartialInstall returns false on falsy pluginRoot", async () => {
+      const { isPartialInstall } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      expect(isPartialInstall(undefined)).toBe(false);
+      expect(isPartialInstall(null)).toBe(false);
+      expect(isPartialInstall("")).toBe(false);
+    });
+
+    // ── deriveMarketplaceClonePath layout helper ──
+
+    it("deriveMarketplaceClonePath derives the marketplace path from a CC cache layout", async () => {
+      const { deriveMarketplaceClonePath } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const cache = "/home/u/.claude/plugins/cache/context-mode/context-mode/1.0.150";
+      expect(deriveMarketplaceClonePath(cache)).toBe(
+        resolve("/home/u/.claude/plugins/marketplaces/context-mode"),
+      );
+    });
+
+    it("deriveMarketplaceClonePath tolerates a trailing slash", async () => {
+      const { deriveMarketplaceClonePath } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const cache = "/home/u/.claude/plugins/cache/context-mode/context-mode/1.0.150/";
+      expect(deriveMarketplaceClonePath(cache)).toBe(
+        resolve("/home/u/.claude/plugins/marketplaces/context-mode"),
+      );
+    });
+
+    it("deriveMarketplaceClonePath handles Windows-style backslashes", async () => {
+      const { deriveMarketplaceClonePath } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const cache = "C:\\Users\\u\\.claude\\plugins\\cache\\context-mode\\context-mode\\1.0.150";
+      const got = deriveMarketplaceClonePath(cache);
+      // resolve() leaves the leading drive letter intact as a relative
+      // segment on POSIX; the important assertion is the suffix.
+      expect(String(got).replace(/\\/g, "/")).toMatch(
+        /plugins\/marketplaces\/context-mode$/,
+      );
+    });
+
+    it("deriveMarketplaceClonePath returns null for non-CC layouts", async () => {
+      const { deriveMarketplaceClonePath } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      expect(
+        deriveMarketplaceClonePath("/usr/local/lib/node_modules/context-mode"),
+      ).toBeNull();
+      expect(
+        deriveMarketplaceClonePath("/home/u/sultan-projects/context-mode"),
+      ).toBeNull();
+      expect(deriveMarketplaceClonePath(undefined)).toBeNull();
+      expect(deriveMarketplaceClonePath(null)).toBeNull();
+      expect(deriveMarketplaceClonePath("")).toBeNull();
+    });
+
+    // ── healPartialInstallFromMarketplace full heal ──
+
+    it("healPartialInstallFromMarketplace early-returns on a healthy install", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      cpSync(marketplaceClonePath, pluginRoot, { recursive: true, force: true });
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(result.skipped).toBe("not-partial");
+      expect(result.healed).toEqual([]);
+    });
+
+    it("healPartialInstallFromMarketplace skips when the marketplace clone is missing", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot } = buildFakeLayout();
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath: resolve(pluginRoot, "..", "..", "..", "no-such-mp"),
+        log: false,
+      });
+      expect(result.skipped).toBe("no-marketplace");
+    });
+
+    it("healPartialInstallFromMarketplace refuses to heal when pluginRoot equals marketplaceClonePath", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { marketplaceClonePath } = buildFakeLayout();
+      // Force the probe to trip by stripping start.mjs from the
+      // marketplace itself, then point pluginRoot at it.
+      rmSync(join(marketplaceClonePath, "start.mjs"));
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot: marketplaceClonePath,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(result.skipped).toBe("same-as-marketplace");
+    });
+
+    it("healPartialInstallFromMarketplace copies missing files from the marketplace clone", async () => {
+      const { healPartialInstallFromMarketplace, isPartialInstall } =
+        await import("../../hooks/heal-partial-install.mjs");
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+
+      // Replicate the user-observed partial install: hooks/ and
+      // .claude-plugin/ made it across, the rest didn't.
+      cpSync(
+        join(marketplaceClonePath, "hooks"),
+        join(pluginRoot, "hooks"),
+        { recursive: true, force: true },
+      );
+      cpSync(
+        join(marketplaceClonePath, ".claude-plugin"),
+        join(pluginRoot, ".claude-plugin"),
+        { recursive: true, force: true },
+      );
+      expect(isPartialInstall(pluginRoot)).toBe(true);
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(result.skipped).toBeUndefined();
+      expect(result.stillMissing).toEqual([]);
+      expect(result.healed).toContain("start.mjs");
+      expect(result.healed).toContain("cli.bundle.mjs");
+      expect(result.healed).toContain("server.bundle.mjs");
+      expect(result.healed).toContain("package.json");
+      expect(isPartialInstall(pluginRoot)).toBe(false);
+    });
+
+    it("healPartialInstallFromMarketplace falls back to the marketplace's package.json when pluginRoot's is missing", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      // Empty pluginRoot, no package.json.
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(result.skipped).toBeUndefined();
+      expect(result.pkgSource).toBe("marketplace");
+      expect(result.healed).toContain("package.json");
+    });
+
+    it("healPartialInstallFromMarketplace rewrites carry-forward stale args[0] in plugin.json", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout("1.0.150");
+
+      // Seed pluginRoot with the user-observed carry-forward state:
+      // plugin.json copied from 1.0.146 with bun + an absolute args[0].
+      cpSync(
+        join(marketplaceClonePath, "hooks"),
+        join(pluginRoot, "hooks"),
+        { recursive: true, force: true },
+      );
+      mkdirSync(join(pluginRoot, ".claude-plugin"), { recursive: true });
+      writeFileSync(
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+        JSON.stringify(
+          {
+            name: "context-mode",
+            version: "1.0.150",
+            mcpServers: {
+              "context-mode": {
+                command: "/usr/bin/bun",
+                args: [
+                  "/home/u/.claude/plugins/cache/context-mode/context-mode/1.0.146/start.mjs",
+                ],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(result.argsRewritten).toBe(true);
+      const fixed = readJson(
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+      ) as {
+        mcpServers: { "context-mode": { args: string[] } };
+      };
+      expect(fixed.mcpServers["context-mode"].args[0]).toContain("1.0.150");
+      expect(fixed.mcpServers["context-mode"].args[0]).not.toContain("1.0.146");
+    });
+
+    it.skipIf(process.platform === "win32")("healPartialInstallFromMarketplace refuses to rewrite plugin.json when it's a symlink", async () => {
+      // Defense-in-depth flagged by round-4 adversarial review: a
+      // same-user-planted symlink at .claude-plugin/plugin.json would
+      // otherwise feed attacker JSON into readFileSync, and the
+      // atomic writeFileSync+renameSync below would replace the
+      // symlink with a regular file containing attacker mcpServers
+      // config. POSIX 0700 on ~/.claude scopes this to same-user
+      // threats, but the heal mirrors the source/destination
+      // symlink refusals applied elsewhere.
+      //
+      // Skipped on Windows: the defense uses openSync(O_NOFOLLOW),
+      // and libuv silently drops O_NOFOLLOW on Windows (the constant
+      // exists for portability but maps to no underlying NT flag).
+      // Real-world Windows users typically don't have Developer Mode
+      // enabled and so can't plant the symlink in the first place,
+      // but on CI runners (which DO have Developer Mode) the
+      // production defense degrades to no-op and the test would
+      // fail. Re-enable when Node ships a NoOpenReparsePoint
+      // translation in libuv (tracked nodejs/node#XYZ — TODO).
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout("1.0.150");
+
+      // Stage attacker-controlled mcpServers JSON outside the cache
+      // tree. The args[0] points at a since-deleted version dir so a
+      // naive rewrite (the carry-forward stale-version code path)
+      // would mutate it AND write the result into the canonical
+      // plugin.json location, materializing the attacker config.
+      const attackerRoot = mkdtempSync(join(tmpdir(), "plugin-json-attack-"));
+      const attackerJsonPath = join(attackerRoot, "plugin.json");
+      writeFileSync(
+        attackerJsonPath,
+        JSON.stringify({
+          name: "context-mode",
+          version: "1.0.150",
+          mcpServers: {
+            "context-mode": {
+              command: "/attacker/payload.sh",
+              args: [
+                "/home/u/.claude/plugins/cache/context-mode/context-mode/1.0.146/start.mjs",
+              ],
+            },
+          },
+        }),
+      );
+
+      // Plant the symlink at the canonical location. readFileSync
+      // would follow this; the lstatSync guard must refuse.
+      mkdirSync(join(pluginRoot, ".claude-plugin"), { recursive: true });
+      symlinkSync(
+        attackerJsonPath,
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+      );
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+
+      // The rewrite was refused.
+      expect(result.argsRewritten).toBe(false);
+      // plugin.json on disk is still a symlink; it was not replaced
+      // by a regular file with attacker mcpServers.
+      const stPj = lstatSync(
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+      );
+      expect(stPj.isSymbolicLink()).toBe(true);
+      // The attacker JSON at the symlink target was not modified
+      // either (renameSync would have left it intact even if the
+      // guard had failed, but assert anyway as a tripwire for any
+      // future implementation that decides to write through the
+      // symlink path).
+      const attackerStillThere = JSON.parse(
+        readFileSync(attackerJsonPath, "utf-8"),
+      );
+      expect(attackerStillThere.mcpServers["context-mode"].command).toBe(
+        "/attacker/payload.sh",
+      );
+    });
+
+    it("healPartialInstallFromMarketplace resolves the ${CLAUDE_PLUGIN_ROOT} placeholder", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout("1.0.150");
+      mkdirSync(join(pluginRoot, ".claude-plugin"), { recursive: true });
+      writeFileSync(
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+        JSON.stringify(
+          {
+            name: "context-mode",
+            version: "1.0.150",
+            mcpServers: {
+              "context-mode": {
+                command: "node",
+                args: ["${CLAUDE_PLUGIN_ROOT}/start.mjs"],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(result.argsRewritten).toBe(true);
+      const fixed = readJson(
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+      ) as {
+        mcpServers: { "context-mode": { args: string[] } };
+      };
+      expect(fixed.mcpServers["context-mode"].args[0]).not.toContain(
+        "${CLAUDE_PLUGIN_ROOT}",
+      );
+      expect(fixed.mcpServers["context-mode"].args[0]).toContain("start.mjs");
+    });
+
+    it("healPartialInstallFromMarketplace leaves a healthy plugin.json alone", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout("1.0.150");
+      // Seed a healthy plugin.json directly: no placeholder, args[0] is
+      // an absolute path under the current pluginRoot. The rewrite path
+      // should all branches decline to mutate.
+      mkdirSync(join(pluginRoot, ".claude-plugin"), { recursive: true });
+      const healthyArgs0 = join(pluginRoot, "start.mjs").replace(/\\/g, "/");
+      writeFileSync(
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+        JSON.stringify(
+          {
+            name: "context-mode",
+            version: "1.0.150",
+            mcpServers: {
+              "context-mode": {
+                command: "node",
+                args: [healthyArgs0],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(result.healed).toContain("start.mjs");
+      expect(result.argsRewritten).toBe(false);
+    });
+
+    it("healPartialInstallFromMarketplace is idempotent across re-runs", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      const first = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(first.healed.length).toBeGreaterThan(0);
+      const second = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(second.skipped).toBe("not-partial");
+      expect(second.healed).toEqual([]);
+    });
+
+    it("healPartialInstallFromMarketplace short-circuits with not-claude-code for non-CC pluginRoots", async () => {
+      // The heal is scoped to Claude Code's per-version cache layout
+      // (~/.claude/plugins/cache/<owner>/<plugin>/<version>/). Other
+      // clients (Codex, Cursor, OpenCode, Kiro, gemini-cli, ...) ship
+      // their own SessionStart wrappers under hooks/<client>/ and
+      // never call this module. The module also guards its scope at
+      // runtime: any pluginRoot that doesn't match the CC cache layout
+      // bails with skipped="not-claude-code" before any filesystem
+      // work runs.
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+
+      // npm-global-style layout: no /plugins/cache/ segment.
+      const npmGlobalRoot = makeTmp();
+      const npmGlobalPlugin = resolve(
+        npmGlobalRoot,
+        "lib",
+        "node_modules",
+        "context-mode",
+      );
+      mkdirSync(npmGlobalPlugin, { recursive: true });
+      const r1 = healPartialInstallFromMarketplace({
+        pluginRoot: npmGlobalPlugin,
+        log: false,
+      });
+      expect(r1.skipped).toBe("not-claude-code");
+      expect(r1.healed).toEqual([]);
+      expect(r1.stillMissing).toEqual([]);
+
+      // Codex-style layout: under ~/.codex, no /plugins/cache/.
+      const codexRoot = makeTmp();
+      const codexPlugin = resolve(
+        codexRoot,
+        ".codex",
+        "plugins",
+        "context-mode",
+      );
+      mkdirSync(codexPlugin, { recursive: true });
+      const r2 = healPartialInstallFromMarketplace({
+        pluginRoot: codexPlugin,
+        log: false,
+      });
+      expect(r2.skipped).toBe("not-claude-code");
+    });
+
+    it("healPartialInstallFromMarketplace doesn't overwrite files that already exist", async () => {
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+      // Seed pluginRoot with hooks/sessionstart.mjs holding a custom
+      // override. The heal only restores missing paths, so the override
+      // should survive.
+      mkdirSync(join(pluginRoot, "hooks"), { recursive: true });
+      const custom = "// custom user override\n";
+      writeFileSync(join(pluginRoot, "hooks", "sessionstart.mjs"), custom);
+      healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+      expect(
+        readFileSync(join(pluginRoot, "hooks", "sessionstart.mjs"), "utf-8"),
+      ).toBe(custom);
+    });
+
+    it("healPartialInstallFromMarketplace rejects files[] entries that escape rootDir via ..", async () => {
+      // Regression guard for PR #699 review: a corrupted marketplace
+      // package.json with `files: ["../outside.txt", ...]` must not
+      // turn the self-heal into an out-of-root write. Seed an
+      // `outside.txt` in the marketplace's parent dir, point a files[]
+      // entry at it via ..-escape, and assert nothing lands outside
+      // pluginRoot.
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+
+      // Write a sentinel file in the marketplace's parent dir — the
+      // ..-escape target. If the guard fails, the heal would copy this
+      // into pluginRoot's parent.
+      const marketplaceParent = dirname(marketplaceClonePath);
+      const escapeTargetPath = join(marketplaceParent, "OUTSIDE-MARKER.txt");
+      writeFileSync(escapeTargetPath, "should-not-be-copied\n");
+
+      // Repoint marketplace package.json's files[] to include an
+      // escape entry alongside legitimate entries.
+      writeFileSync(
+        join(marketplaceClonePath, "package.json"),
+        JSON.stringify({
+          name: "context-mode",
+          version: "1.0.150",
+          files: ["../OUTSIDE-MARKER.txt", "hooks", "start.mjs", "cli.bundle.mjs", "server.bundle.mjs", ".claude-plugin"],
+        }),
+      );
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+
+      // The escape entry must not appear anywhere the heal acted on.
+      expect(result.healed).not.toContain("../OUTSIDE-MARKER.txt");
+      expect(result.healed).not.toContain("OUTSIDE-MARKER.txt");
+      expect(result.stillMissing).not.toContain("../OUTSIDE-MARKER.txt");
+      // Nothing got written to pluginRoot's parent.
+      const pluginRootParent = dirname(pluginRoot);
+      expect(existsSync(join(pluginRootParent, "OUTSIDE-MARKER.txt"))).toBe(false);
+      // The legitimate entries still healed.
+      expect(result.healed).toContain("start.mjs");
+      expect(result.healed).toContain("cli.bundle.mjs");
+    });
+
+    it("healPartialInstallFromMarketplace rejects nested ..-escape entries (e.g. 'a/../../outside')", async () => {
+      // Mixed-segment escape: even when the entry starts with a
+      // legitimate-looking segment, path normalization collapses the
+      // ..'s and resolves outside rootDir. Guard must catch it.
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+
+      const marketplaceParent = dirname(marketplaceClonePath);
+      const escapeTargetPath = join(marketplaceParent, "NESTED-OUTSIDE.txt");
+      writeFileSync(escapeTargetPath, "should-not-be-copied\n");
+
+      writeFileSync(
+        join(marketplaceClonePath, "package.json"),
+        JSON.stringify({
+          name: "context-mode",
+          version: "1.0.150",
+          files: ["hooks/../../NESTED-OUTSIDE.txt", "start.mjs"],
+        }),
+      );
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+
+      expect(result.healed.some((p: string) => p.includes("NESTED-OUTSIDE"))).toBe(false);
+      const pluginRootParent = dirname(pluginRoot);
+      expect(existsSync(join(pluginRootParent, "NESTED-OUTSIDE.txt"))).toBe(false);
+      expect(result.healed).toContain("start.mjs");
+    });
+
+    it("healPartialInstallFromMarketplace replaces a planted leaf symlink at the destination instead of writing through it", async () => {
+      // Arbitrary-file-write primitive surfaced by the second
+      // adversarial review: a stale heal leftover or a local attacker
+      // plants `pluginRoot/server.bundle.mjs` as a symlink to an
+      // out-of-tree target that doesn't exist yet. existsSync follows
+      // the dangling link and returns false, so the probe trips and
+      // the file lands in missingBefore. Without the lstat+unlink
+      // guard at the copy site, cpSync follows the symlink and writes
+      // marketplace bytes (arbitrary JS) to the target outside
+      // pluginRoot. The guard must replace the symlink with a fresh
+      // regular file before cpSync runs.
+      const { healPartialInstallFromMarketplace, isPartialInstall } =
+        await import("../../hooks/heal-partial-install.mjs");
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+
+      // Dangling target outside pluginRoot, must stay un-created.
+      const pluginRootParent = dirname(pluginRoot);
+      const escapeTargetPath = join(
+        pluginRootParent,
+        "OUT-OF-ROOT-MUST-NOT-EXIST.txt",
+      );
+      expect(existsSync(escapeTargetPath)).toBe(false);
+
+      // Plant the symlink at the launch-critical leaf so the probe
+      // trips on it (existsSync on a dangling link returns false).
+      symlinkSync(escapeTargetPath, join(pluginRoot, "server.bundle.mjs"));
+      expect(
+        lstatSync(join(pluginRoot, "server.bundle.mjs")).isSymbolicLink(),
+      ).toBe(true);
+      expect(isPartialInstall(pluginRoot)).toBe(true);
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+
+      // The symlink target must not have been materialized: no
+      // arbitrary write happened outside pluginRoot.
+      expect(existsSync(escapeTargetPath)).toBe(false);
+      // The leaf is now a regular file with marketplace bytes, not a
+      // dangling symlink.
+      const stTo = lstatSync(join(pluginRoot, "server.bundle.mjs"));
+      expect(stTo.isSymbolicLink()).toBe(false);
+      expect(stTo.isFile()).toBe(true);
+      expect(
+        readFileSync(join(pluginRoot, "server.bundle.mjs"), "utf-8"),
+      ).toBe("// server bundle\n");
+      // The heal records the file as healed, and the probe agrees
+      // we're healthy.
+      expect(result.healed).toContain("server.bundle.mjs");
+      expect(isPartialInstall(pluginRoot)).toBe(false);
+    });
+
+    it("healPartialInstallFromMarketplace rejects deep files[] entries reached through a symlinked ancestor in the marketplace tree", async () => {
+      // Ancestor-symlink bypass surfaced by the third adversarial
+      // review: lstat(from) on a deep leaf returns isSymbolicLink=false
+      // when the symlink is in a PARENT segment, not the leaf itself.
+      // The lexical resolve+startsWith guard also doesn't catch it,
+      // since the symlink's own lexical path stays inside the
+      // marketplace tree. Only realpath(from) collapses the ancestor
+      // symlink and exposes the escape. Without this guard, cpSync
+      // would read attacker-staged content through the ancestor link
+      // and copy it into pluginRoot, where the next session start
+      // would execute the planted bytes (e.g. scripts/postinstall.mjs).
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+
+      // Stage attacker-controlled bytes outside the marketplace tree.
+      const attackerRoot = mkdtempSync(join(tmpdir(), "ancestor-attack-"));
+      writeFileSync(
+        join(attackerRoot, "postinstall.mjs"),
+        "// ATTACKER PAYLOAD\n",
+      );
+
+      // Replace marketplace/scripts/ (a real dir set up by
+      // buildFakeLayout) with a symlink to the attacker-staged dir.
+      // The lexical resolve check on `from` passes because the
+      // symlink's path stays inside marketplaceClonePath; only
+      // realpath collapses through it.
+      rmSync(join(marketplaceClonePath, "scripts"), {
+        recursive: true,
+        force: true,
+      });
+      symlinkSync(attackerRoot, join(marketplaceClonePath, "scripts"));
+
+      // package.json references the deep leaf through the
+      // now-symlinked ancestor. lstat(from).isSymbolicLink() === false
+      // because the leaf is a real file at the symlink target.
+      writeFileSync(
+        join(marketplaceClonePath, "package.json"),
+        JSON.stringify({
+          name: "context-mode",
+          version: "1.0.150",
+          files: [
+            "scripts/postinstall.mjs",
+            "hooks",
+            ".claude-plugin",
+            "start.mjs",
+            "cli.bundle.mjs",
+            "server.bundle.mjs",
+          ],
+        }),
+      );
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+
+      // The ancestor-symlinked entry must not appear in healed, and
+      // pluginRoot must not contain the attacker payload at the
+      // resolved-through-ancestor path.
+      expect(result.healed).not.toContain("scripts/postinstall.mjs");
+      const planted = join(pluginRoot, "scripts", "postinstall.mjs");
+      if (existsSync(planted)) {
+        expect(readFileSync(planted, "utf-8")).not.toBe(
+          "// ATTACKER PAYLOAD\n",
+        );
+      }
+      // Legitimate non-symlinked entries still healed (sanity).
+      expect(result.healed).toContain("start.mjs");
+      expect(result.healed).toContain("cli.bundle.mjs");
+    });
+
+    it("healPartialInstallFromMarketplace rejects symlink entries that escape rootDir", async () => {
+      // Symlink-based bypass for the ..-escape resolve+startsWith
+      // guard: the symlink itself sits inside marketplaceClonePath, so
+      // its lexical resolve stays inside rootDir, but the symlink
+      // target points outside. Reading through the link would expose
+      // arbitrary host filesystem content to the heal. expandFilesArray
+      // and listFilesRecursive must drop symlinks via lstatSync.
+      const { healPartialInstallFromMarketplace } = await import(
+        "../../hooks/heal-partial-install.mjs"
+      );
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+
+      // Sentinel outside the marketplace tree.
+      const marketplaceParent = dirname(marketplaceClonePath);
+      const sentinelPath = join(marketplaceParent, "SYMLINK-TARGET.txt");
+      writeFileSync(sentinelPath, "should-not-leak\n");
+
+      // Top-level symlink-to-outside file at marketplace root.
+      const topLink = join(marketplaceClonePath, "evil-link.txt");
+      symlinkSync(sentinelPath, topLink);
+
+      // Symlink-to-outside hidden inside a legitimate-looking dir,
+      // so listFilesRecursive's walk has to drop it too.
+      const nestedDir = join(marketplaceClonePath, "scripts");
+      const nestedLink = join(nestedDir, "evil-nested.txt");
+      symlinkSync(sentinelPath, nestedLink);
+
+      writeFileSync(
+        join(marketplaceClonePath, "package.json"),
+        JSON.stringify({
+          name: "context-mode",
+          version: "1.0.150",
+          // "scripts" is a directory walk; "evil-link.txt" is a
+          // top-level symlink entry. Both should be filtered.
+          files: [
+            "evil-link.txt",
+            "scripts",
+            "hooks",
+            "start.mjs",
+            "cli.bundle.mjs",
+            "server.bundle.mjs",
+            ".claude-plugin",
+          ],
+        }),
+      );
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+
+      // Neither the top-level nor the nested symlink can appear in
+      // healed; nothing got materialized at pluginRoot for them either.
+      expect(result.healed).not.toContain("evil-link.txt");
+      expect(result.healed.some((p: string) => p.includes("evil-nested"))).toBe(false);
+      expect(existsSync(join(pluginRoot, "evil-link.txt"))).toBe(false);
+      expect(existsSync(join(pluginRoot, "scripts", "evil-nested.txt"))).toBe(false);
+
+      // Legitimate scripts entries still healed (the symlink dropped
+      // out, but the regular files in scripts/ stayed). Use join() so
+      // Windows backslash and POSIX forward-slash both match the
+      // OS-native paths listFilesRecursive emits.
+      expect(result.healed).toContain(join("scripts", "postinstall.mjs"));
+      expect(result.healed).toContain(join("scripts", "plugin-cache-integrity.mjs"));
+      // Sentinel content was never copied anywhere in pluginRoot.
+      const pluginRootParent = dirname(pluginRoot);
+      expect(existsSync(join(pluginRootParent, "SYMLINK-TARGET.txt"))).toBe(false);
+    });
+
+    it("healPartialInstallFromMarketplace keeps valid entries when escape entries are mixed in", async () => {
+      // The escape guard must drop only the bad entries, leaving valid
+      // ones in the manifest. Otherwise a single corrupt entry would
+      // poison the whole heal.
+      const { healPartialInstallFromMarketplace, isPartialInstall } =
+        await import("../../hooks/heal-partial-install.mjs");
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout();
+
+      const marketplaceParent = dirname(marketplaceClonePath);
+      writeFileSync(join(marketplaceParent, "POISON.txt"), "x");
+
+      writeFileSync(
+        join(marketplaceClonePath, "package.json"),
+        JSON.stringify({
+          name: "context-mode",
+          version: "1.0.150",
+          files: [
+            "../POISON.txt",
+            "hooks",
+            ".claude-plugin",
+            "start.mjs",
+            "cli.bundle.mjs",
+            "server.bundle.mjs",
+            "scripts/postinstall.mjs",
+            "scripts/plugin-cache-integrity.mjs",
+            "bin",
+          ],
+        }),
+      );
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+
+      // Every valid entry healed.
+      expect(result.healed).toContain("start.mjs");
+      expect(result.healed).toContain("cli.bundle.mjs");
+      expect(result.healed).toContain("server.bundle.mjs");
+      // No escape side effect.
+      const pluginRootParent = dirname(pluginRoot);
+      expect(existsSync(join(pluginRootParent, "POISON.txt"))).toBe(false);
+      // The probe agrees we're healthy after the heal (the legitimate
+      // launch-critical files all landed).
+      expect(isPartialInstall(pluginRoot)).toBe(false);
+    });
+
+    it("healPartialInstallFromMarketplace reproduces and heals the v1.0.150 partial install", async () => {
+      const { healPartialInstallFromMarketplace, isPartialInstall } =
+        await import("../../hooks/heal-partial-install.mjs");
+      // Mirrors the exact failure shape captured in the wild:
+      //   - hooks/ and .claude-plugin/ survived
+      //   - plus a few non-files[] extras (web/, CONTRIBUTING.md) from an
+      //     earlier install moment
+      //   - .claude-plugin/plugin.json carry-forwarded from 1.0.146 with
+      //     command "/usr/bin/bun" and args[0] pointing at the stale
+      //     1.0.146/start.mjs absolute path
+      //   - everything else missing
+      const { pluginRoot, marketplaceClonePath } = buildFakeLayout("1.0.150");
+      cpSync(
+        join(marketplaceClonePath, "hooks"),
+        join(pluginRoot, "hooks"),
+        { recursive: true, force: true },
+      );
+      mkdirSync(join(pluginRoot, ".claude-plugin"), { recursive: true });
+      writeFileSync(
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+        JSON.stringify(
+          {
+            name: "context-mode",
+            version: "1.0.150",
+            mcpServers: {
+              "context-mode": {
+                command: "/usr/bin/bun",
+                args: [
+                  pluginRoot.replace("1.0.150", "1.0.146") + sep + "start.mjs",
+                ],
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      writeFileSync(join(pluginRoot, "CONTRIBUTING.md"), "# Contributing\n");
+      mkdirSync(join(pluginRoot, "web"), { recursive: true });
+      writeFileSync(join(pluginRoot, "web", "index.html"), "<!doctype html>");
+
+      const result = healPartialInstallFromMarketplace({
+        pluginRoot,
+        marketplaceClonePath,
+        log: false,
+      });
+
+      // Full recovery: every files[] entry restored, args[0] re-pointed
+      // at 1.0.150, and the cheap probe agrees we're healthy.
+      expect(result.stillMissing).toEqual([]);
+      expect(result.argsRewritten).toBe(true);
+      expect(isPartialInstall(pluginRoot)).toBe(false);
+
+      const plugin = readJson(
+        join(pluginRoot, ".claude-plugin", "plugin.json"),
+      ) as {
+        mcpServers: { "context-mode": { args: string[] } };
+      };
+      expect(plugin.mcpServers["context-mode"].args[0]).toContain("1.0.150");
+      expect(plugin.mcpServers["context-mode"].args[0]).not.toContain("1.0.146");
+
+      // Non-files[] extras left alone.
+      expect(
+        readFileSync(join(pluginRoot, "CONTRIBUTING.md"), "utf-8"),
+      ).toBe("# Contributing\n");
+    });
+
+    // ── Wiring assertions ──
+
+    it("start.mjs invokes the heal before the Algo-D4 integrity check", () => {
+      const src = readFileSync(resolve(ROOT, "start.mjs"), "utf-8");
+      // Anchor on the literal import + call shape, not the bare filename
+      // substring. A DELETED- prefix or comment mention would otherwise
+      // pass the test even when the wiring is gone.
+      const importIdx = src.indexOf('"./hooks/heal-partial-install.mjs"');
+      const callIdx = src.indexOf("healPartialInstallFromMarketplace({");
+      const integrityIdx = src.indexOf('"./scripts/plugin-cache-integrity.mjs"');
+      expect(importIdx, "heal-partial-install import missing in start.mjs").toBeGreaterThan(-1);
+      expect(callIdx, "healPartialInstallFromMarketplace call missing in start.mjs").toBeGreaterThan(-1);
+      expect(integrityIdx, "plugin-cache-integrity import missing in start.mjs").toBeGreaterThan(-1);
+      // Order: heal runs first so a fixable install is repaired, then
+      // the integrity gate decides whether boot proceeds.
+      expect(importIdx).toBeLessThan(integrityIdx);
+      expect(callIdx).toBeLessThan(integrityIdx);
+    });
+
+    it("hooks/sessionstart.mjs invokes the heal early in the runHook callback", () => {
+      const src = readFileSync(
+        resolve(ROOT, "hooks", "sessionstart.mjs"),
+        "utf-8",
+      );
+      const importIdx = src.indexOf('"./heal-partial-install.mjs"');
+      const callIdx = src.indexOf("healPartialInstallFromMarketplace()");
+      expect(importIdx, "heal-partial-install import missing in sessionstart.mjs").toBeGreaterThan(-1);
+      expect(callIdx, "healPartialInstallFromMarketplace call missing in sessionstart.mjs").toBeGreaterThan(-1);
+      // Heal must fire before the age-gated cleanup that wipes sibling
+      // cache version dirs, since the cleanup would otherwise erase a
+      // healthy previous version while the new one is still partial.
+      const cleanupIdx = src.indexOf("Age-gated lazy cleanup");
+      expect(cleanupIdx, "age-gated cleanup comment missing").toBeGreaterThan(-1);
+      expect(callIdx).toBeLessThan(cleanupIdx);
+    });
   });
 });
 

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -2875,6 +2875,30 @@ describe("Shell-free upgrade (#185)", () => {
     expect(configureIdx).toBeGreaterThan(alreadyLatestIdx);
   });
 
+  test("cli.ts swap loop guards rm/cp with existsSync(from)", () => {
+    // Regression test for the partial-install vector: the rm/cp loop's
+    // catch-all was swallowing cpSync failures, so a `files[]` entry
+    // that didn't exist in the cloned source dropped the corresponding
+    // pluginRoot path without replacement. Mirrors the safe pattern in
+    // server.ts:3820 inline-fallback (`if (existsSync(from))` before any
+    // rm or cp). Same architectural-lock as the rest of #609.
+    const upgradeStart = CLI_SOURCE.indexOf("async function upgrade");
+    expect(upgradeStart).toBeGreaterThan(-1);
+    const upgradeBody = CLI_SOURCE.slice(upgradeStart);
+    const loopIdx = upgradeBody.indexOf("for (const item of items) {");
+    expect(loopIdx, "swap loop missing in upgrade()").toBeGreaterThan(-1);
+    const loopBody = upgradeBody.slice(loopIdx, loopIdx + 1200);
+    // Source must exist before any rm/cp fires.
+    expect(loopBody).toMatch(/if\s*\(!existsSync\(from\)\)\s*continue/);
+    // The existsSync probe must come BEFORE rmSync inside the loop, not
+    // after; otherwise it's a no-op guard against the actual vector.
+    const guardIdx = loopBody.indexOf("if (!existsSync(from)) continue");
+    const rmIdx = loopBody.indexOf("rmSync");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(rmIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(rmIdx);
+  });
+
   test("server.ts inline fallback uses execFileSync, not execSync", () => {
     // The inline script template must use execFileSync
     const inlineStart = SERVER_SOURCE.indexOf("Inline fallback");


### PR DESCRIPTION
## What / Why / How

**What**: A new `hooks/heal-partial-install.mjs` that detects a partial plugin cache install on every session start and re-copies missing files from the marketplace clone Claude Code maintains, plus a back-ported `existsSync` guard on `cli.ts`'s `/ctx-upgrade` swap loop that closes a related latent vector.

**Why** (direct observations from the reproducer machine; everything in this section is fact, not speculation):

The per-version plugin cache dir at `~/.claude/plugins/cache/context-mode/context-mode/1.0.150/` held 73 files of the marketplace's tracked tree. Present: `hooks/`, `.claude-plugin/`, `.cursor-plugin/`, `.pi/`, `web/`, plus a few docs. Absent: `cli.bundle.mjs`, `server.bundle.mjs`, `start.mjs`, `package.json`, `src/`, `bin/`, `scripts/`, `skills/`, `.codex-plugin/`, `.openclaw-plugin/`.

The cache's `.claude-plugin/plugin.json` was a verbatim carry-forward from the user's previous 1.0.146 install, with `mcpServers.command = "/usr/bin/bun"` and `mcpServers.args[0]` referencing the 1.0.146 cache dir (which had been age-gate-cleaned by `hooks/sessionstart.mjs` (#181) and no longer existed). MCP launch ENOENTs every spawn.

None of the existing defenses repairs this:

- `scripts/plugin-cache-integrity.mjs` (#550) exits 2 from `start.mjs`, but `start.mjs` is one of the missing files.
- The #604 stale-cache-version ratchet runs from `start.mjs`'s normalize-hooks call, same boot-time dependency.
- `/ctx-upgrade` needs the `cli.bundle.mjs` the partial install lost, so the user-facing escape hatch is gone too.

So the cache cannot self-recover, and the only available workaround from the user side is `rm -rf <version-dir>` plus a session restart. The user reported hitting this several times across upgrade cycles.

**What I could verify directly about the producing code path** (also fact): Claude Code runs a plugin sync regardless of the marketplace's `autoUpdate` setting. With `"autoUpdate": false` in `~/.claude/settings.json` for the `mksglu/context-mode` marketplace, a read-only `claude plugin list` invocation still created a new per-version cache dir matching the marketplace's current version. So `autoUpdate=false` does not opt out of CC's "ensure cache matches marketplace version" sync.

**What I cannot verify (speculation, flagged explicitly)**: which CC code path produced *this* particular fingerprint (partial copy plus carry-forward `plugin.json`). The reproducer's `/ctx-upgrade` transcripts show this project's own `cli.ts upgrade()` took its "Already on latest" early-return path and the rm/cp loop did not run, so that's ruled out as the producer here. A clean-marketplace `claude plugin list` repro on my machine produced a *complete* cache install, not a partial one, so the specific failure mode needs additional conditions I could not pin down. Three adjacent upstream bug reports describe overlapping failure modes in CC's plugin sync: anthropics/claude-code#48912 (Update fails to materialize newly-added top-level directories), #57645 (`installPath` in `installed_plugins.json` lags cache extraction non-atomically), and #57646 (`gitCommitSha` in the registry never refreshed). I'm **not** asserting any one of those bugs is the exact mechanism in this instance; they are cited as documented adjacent failure modes in the same subsystem.

**How**: The heal module ships in `hooks/` rather than `scripts/` because the failure mode itself can strip `scripts/` from the cache dir; `hooks/` has been intact in every observed instance. Wired from `hooks/sessionstart.mjs` (primary trigger; fires even when MCP can't boot) and from `start.mjs` (belt-and-braces, runs before the Algo-D4 integrity gate so a fixable partial install is repaired rather than just reported).

Detection is a cheap 4-existsSync probe, so the healthy case is effectively free. On a trip, the module reads `package.json files[]` (prefers `pluginRoot`'s, falls back to the marketplace's when `pluginRoot/package.json` is one of the missing files), expands to a concrete file list against the marketplace clone, and copies each entry that's missing in pluginRoot. After files land, it rewrites any carry-forward stale `mcpServers.args[0]` in `plugin.json` to the current pluginRoot, mirroring the #604 ratchet. The module is pure JS (Node built-ins only), never throws, idempotent, and path-traversal-guarded.

The secondary commit closes a separate partial-install vector on the `/ctx-upgrade` path: `cli.ts:1207-1212`'s `try { rmSync; cpSync } catch {}` would swallow `cpSync` failures (or `files[]` entries that don't exist in the cloned source) and leave files deleted without replacement. The safe pattern (`if (!existsSync(from)) continue`) is already used in `server.ts:3820`'s inline-fallback path; this back-ports it.

**Caveat (vN+1 only)**: This lands in `vN+1` and heals broken installs from that point forward. Users currently hitting the failure need to manually `rm -rf` their cache dir once to clear the old state. From then on the heal keeps the install healthy across all future CC sync cycles.

Fixes: this user's recurring partial-install issue. Related upstream (in CC's plugin sync, not this project): anthropics/claude-code#48912, anthropics/claude-code#57645, anthropics/claude-code#57646.

## Affected platforms

- [x] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

The heal probe and copy logic are CC-cache-layout-specific (`<config>/plugins/cache/<owner>/<plugin>/<version>/`). `deriveMarketplaceClonePath` returns `null` for any other layout (npm-global, dev checkout, opencode cache, ...) and the heal becomes a no-op. The secondary `cli.ts` guard is platform-agnostic since the upgrade flow is shared.

## Test plan

26 new tests added to `tests/core/cli.test.ts` (folded into existing partial-install describe block per CONTRIBUTING L282; no new test files). Coverage:

- `isPartialInstall` cheap probe across the launch-critical file matrix (healthy, missing `start.mjs`, missing `package.json`, missing both `cli.bundle.mjs` + `build/cli.js`, accepting `build/cli.js` as fallback, falsy input).
- `deriveMarketplaceClonePath` layout helper across POSIX paths, trailing slashes, Windows backslashes, npm-global, dev checkout, and falsy input.
- `healPartialInstallFromMarketplace` covering: early-return on healthy install, skip when marketplace clone is missing, path-traversal guard when pluginRoot equals marketplace clone path, full restore of missing files, fallback to marketplace's `package.json` when `pluginRoot/package.json` is missing, args[0] rewrite for carry-forward stale paths, args[0] rewrite for `${CLAUDE_PLUGIN_ROOT}` placeholder, idempotent rewrite on healthy `plugin.json`, idempotent across re-runs, skip for non-CC layouts, no-overwrite of pre-existing user files, partial coverage when the marketplace itself is incomplete, and a full reproduction of the v1.0.150 partial-install + carry-forward fingerprint with end-to-end heal verification.
- Wiring assertions on `start.mjs` and `hooks/sessionstart.mjs` that confirm the heal call shape and ordering relative to other operations.
- A guard assertion on `cli.ts` that confirms the `existsSync(from)` check precedes the `rmSync` in the swap loop.

Regression checks executed manually: each fix intentionally disabled produced informative test failures with the corresponding assertion. The wiring tests are anchored on literal import/call shapes (not substring `indexOf` matches) so a renamed file or commented-out call still fails the test cleanly.

`npm test`'s pretest builds tsc + bundles; the heal-related tests pass against the in-tree source without requiring the bundles. `npm run typecheck` is clean.

## Checklist

- [x] Tests added/updated (TDD: red → green; intentional regression breaks verified)
- [x] `npm run typecheck` passes
- [x] `npm test` passes (3708 / 3742 green; 34 pre-existing skips, none related)
- [ ] Docs updated if needed (README, platform-support.md) — N/A, no user-facing surface area changes
- [x] No Windows path regressions (`deriveMarketplaceClonePath` tested against backslash-form input; all file operations use `path.join` / `path.resolve`)
- [ ] Targets `next` branch (unless hotfix) — PR opened against this branch; happy to retarget if `next` is preferred

<details>
<summary><strong>Repro state of the original incident, for archive</strong></summary>

`~/.claude/plugins/cache/context-mode/context-mode/1.0.150/.claude-plugin/plugin.json` before heal:

```json
{
  "name": "context-mode",
  "version": "1.0.150",
  ...
  "mcpServers": {
    "context-mode": {
      "command": "/usr/bin/bun",
      "args": [
        "/home/sultan/.claude/plugins/cache/context-mode/context-mode/1.0.146/start.mjs"
      ]
    }
  }
}
```

`1.0.146/` did not exist on disk (cleaned by `sessionstart.mjs` #181 age gate).

`~/.claude/settings.json`:

```json
"marketplaces": {
  "context-mode": {
    "url": "https://github.com/mksglu/context-mode.git",
    "autoUpdate": false
  },
  ...
}
```

Sync trigger reproduction: `claude plugin list` with `autoUpdate: false` created `~/.claude/plugins/cache/context-mode/context-mode/1.0.151/` (this was a *complete* install, so the specific partial-copy failure mode was not reproduced; only the unconditional-sync behavior was).

</details>