### PR TITLE
fix(test): sandbox HOME in CLAUDE_CONFIG_DIR security suite so npm test doesn't clobber ~/.claude/settings.json

### DIFF
--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -638,7 +638,10 @@ describe("Shell-Escape Scanner", () => {
 describe("CLAUDE_CONFIG_DIR honors security policy reader", () => {
   let cfgTmpBase: string;
   let customConfigDir: string;
+  let fakeHome: string;
   let savedEnv: string | undefined;
+  let savedHome: string | undefined;
+  let savedUserprofile: string | undefined;
 
   beforeAll(() => {
     cfgTmpBase = join(tmpdir(), `security-cfg-test-${Date.now()}`);
@@ -656,11 +659,15 @@ describe("CLAUDE_CONFIG_DIR honors security policy reader", () => {
       }),
     );
 
-    // Homedir fallback — distinct content so we can detect which file was read.
-    const homeClaudeDir = join(homedir(), ".claude");
-    mkdirSync(homeClaudeDir, { recursive: true });
+    // Homedir fallback — write to a sandboxed fake HOME under tmpdir() so
+    // running `npm test` from a contributor machine never clobbers the
+    // user's real ~/.claude/settings.json. Matches the env-override
+    // pattern used by the #451 round-3 block below.
+    fakeHome = join(cfgTmpBase, "fake-home");
+    const fakeClaudeDir = join(fakeHome, ".claude");
+    mkdirSync(fakeClaudeDir, { recursive: true });
     writeFileSync(
-      join(homeClaudeDir, "settings.json"),
+      join(fakeClaudeDir, "settings.json"),
       JSON.stringify({
         permissions: {
           allow: [],
@@ -670,11 +677,19 @@ describe("CLAUDE_CONFIG_DIR honors security policy reader", () => {
     );
 
     savedEnv = process.env.CLAUDE_CONFIG_DIR;
+    savedHome = process.env.HOME;
+    savedUserprofile = process.env.USERPROFILE;
+    process.env.HOME = fakeHome;
+    process.env.USERPROFILE = fakeHome;
   });
 
   afterAll(() => {
     if (savedEnv === undefined) delete process.env.CLAUDE_CONFIG_DIR;
     else process.env.CLAUDE_CONFIG_DIR = savedEnv;
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserprofile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserprofile;
     rmSync(cfgTmpBase, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## What / Why / How

**What**: Sandbox `$HOME` for the `CLAUDE_CONFIG_DIR honors security policy reader` describe block in `tests/security.test.ts` so the fixture write lands in a tmp dir instead of overwriting the contributor's real `~/.claude/settings.json`.

**Why** (all directly observed; no speculation):

The block's `beforeAll` writes the homedir fallback fixture straight to `homedir()/.claude/settings.json`:

```ts
const homeClaudeDir = join(homedir(), ".claude");
mkdirSync(homeClaudeDir, { recursive: true });
writeFileSync(
  join(homeClaudeDir, "settings.json"),
  JSON.stringify({
    permissions: {
      allow: [],
      deny: ["Bash(homedir-marker *)"],
    },
  }),
);
```

The matching `afterAll` only removes the tmp dir and restores `CLAUDE_CONFIG_DIR`. The homedir file it wrote is never restored, so any pre-existing `~/.claude/settings.json` content (env vars, allow rules, hooks, enabledPlugins, ...) is gone.

There's no special invocation that would have avoided this:

- `package.json`'s `test` script is plain `vitest run`.
- `vitest.config.ts` has no `setupFiles` or `globalSetup`.
- `tests/setup-home.ts` is documented as opt-in per suite ("Import this helper only from suites that exercise homedir()-backed session state").
- `CONTRIBUTING.md` says `npm test` is the canonical invocation (lines 222, 381, 398).

So the test had always been destructive on contributor machines; CI containers and fresh installs just don't have anything in `~/.claude` to lose, which is why nobody noticed.

I hit this while running the full suite for an unrelated PR. My `~/.claude/settings.json` was overwritten with the minimal fixture; my running CC session then noticed `enabledPlugins.context-mode@context-mode` was missing and the SessionStart hook wasn't registered, and re-added them via context-mode's own self-heal layers, landing the final file in a state that was still nowhere near the pre-test contents. I restored from a backup.

**How**: write the homedir fixture under `tmpdir()/<test-id>/fake-home/.claude/` and point `process.env.HOME` and `process.env.USERPROFILE` at that fake home for the duration of the describe block. Save the original env values in `beforeAll`, restore in `afterAll`. `os.homedir()` reads `$HOME` on POSIX and `$USERPROFILE` on Windows, so the function-under-test (`readBashPolicies`) still resolves through the same fallback path, just into a sandboxed location.

This is the same env-override pattern the next describe block in the same file (`cross-adapter deny-policy parity (#451 round-3)`, lines 746-781) already uses. Just propagates an existing convention to the block that missed it.

No production code changed.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

Test-infrastructure change. No runtime adapter touched.

## Test plan

- `tests/security.test.ts` runs green: 94/94 passing.
- Verified locally that `~/.claude/settings.json` mtime is unchanged across the run.
- `npm run typecheck` passes.

Manual reproduction of the original destructive behavior on `main`:

```bash
$ stat -c "%y" ~/.claude/settings.json
2026-05-24 14:49:23.634873538 -0700
$ git checkout main
$ npm test
...
$ stat -c "%y" ~/.claude/settings.json
# mtime advanced — file was overwritten by the test fixture
```

On this branch the post-run mtime equals the pre-run mtime.

## Checklist

- [x] Tests added/updated (existing assertions still cover the homedir-fallback path)
- [x] `npm run typecheck` passes
- [x] `tests/security.test.ts` runs green (94/94)
- [ ] Docs updated if needed (README, platform-support.md) — N/A
- [x] No Windows path regressions (`$USERPROFILE` is sandboxed alongside `$HOME`; `mkdirSync(..., { recursive: true })` for the nested `.claude` subdir uses `path.join`)
- [x] Targets `next` branch
