### PR TITLE
fix(codex): approve marketplace MCP tools by default

### DIFF
--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -3,7 +3,8 @@
     "context-mode": {
       "command": "node",
       "args": ["./start.mjs"],
-      "cwd": "."
+      "cwd": ".",
+      "default_tools_approval_mode": "approve"
     }
   }
 }

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -38,6 +38,11 @@ describe("cli.bundle.mjs — marketplace install support", () => {
     expect(pkg.files).toContain(".codex-plugin");
   });
 
+  it("Codex plugin MCP manifest approves context-mode tools by default", () => {
+    const mcp = JSON.parse(readFileSync(resolve(ROOT, ".codex-plugin", "mcp.json"), "utf-8"));
+    expect(mcp.mcpServers["context-mode"].default_tools_approval_mode).toBe("approve");
+  });
+
   it("package.json bundle script builds cli.bundle.mjs", () => {
     const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf-8"));
     expect(pkg.scripts.bundle).toContain("cli.bundle.mjs");


### PR DESCRIPTION
## Problem

Refs @Tomodad's Codex marketplace reports in #45:
- https://github.com/mksglu/context-mode/issues/45#issuecomment-4529687281
- https://github.com/mksglu/context-mode/issues/45#issuecomment-4529764345

The Codex marketplace MCP manifest does not set `default_tools_approval_mode`, so context-mode MCP calls can enter Codex's approval/auto-review path before the tool runs. In the reported setup that path failed with a 503 before MCP execution.

## Fix

Add `default_tools_approval_mode: "approve"` to `.codex-plugin/mcp.json` so Codex marketplace installs match the previously working manual MCP config behavior.

Also adds a regression test for the Codex plugin manifest.

## Validation

- `pnpm exec vitest run tests/core/cli.test.ts -t "Codex plugin MCP manifest"`
- `pnpm exec vitest run tests/core/cli.test.ts`
- `pnpm run build`
- Manual E2E: temp `CODEX_HOME`, no manual `[mcp_servers.context-mode]`, installed the patched plugin through a Codex plugin path, then ran `codex exec` and confirmed `ctx_stats` completed through the `context-mode` MCP server on v1.0.151.
- Control E2E: removing the field made the same tool call fall into the approval path and fail before result on my machine.

I could not reproduce the reporter's exact 503 locally; that looks provider/proxy-path-specific. This change avoids the approval/auto-review path for context-mode marketplace tools.

Separate note: I also found a Windows install blocker where `codex plugin add context-mode@context-mode` can fail with `missing plugin.json` because `plugins/context-mode` is a symlink to `..`. I kept that out of this PR because it is a separate install-path issue.