### PR TITLE
test(insight): use junction for Windows node_modules link

### DIFF
--- a/tests/analytics/insight-cors.test.ts
+++ b/tests/analytics/insight-cors.test.ts
@@ -159,7 +159,11 @@ function startInsight(runtime: "node" | "bun" = "node"): { port: number; child: 
   mkdirSync(join(tempInsightDir, "dist"), { recursive: true });
   cpSync(SOURCE_SERVER, join(tempInsightDir, "server.mjs"));
   writeFileSync(join(tempInsightDir, "dist", DIST_INDEX_NAME), "<!doctype html><html><body>stub</body></html>");
-  symlinkSync(resolve(ROOT, "node_modules"), join(tempRoot, "node_modules"), "dir");
+  symlinkSync(
+    resolve(ROOT, "node_modules"),
+    join(tempRoot, "node_modules"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
 
   const { sessionsDir, contentDir } = seedFixtureDBs(tempRoot);
   const port = 49152 + Math.floor(Math.random() * 16383);


### PR DESCRIPTION
## Summary
- use a Windows junction for the temporary `node_modules` link in the ctx-insight CORS test
- keep the existing directory symlink behavior on non-Windows platforms

## Problem
On normal Windows setups without Developer Mode/admin symlink privileges, the directory symlink used by the test harness can fail with `EPERM`, so the ctx-insight CORS test fails before the insight server starts.

## Validation
- `pnpm exec vitest run tests/analytics/insight-cors.test.ts --reporter=dot`
- `pnpm exec vitest run tests/core/server.test.ts -t 'ctx_insight|insight-cache' --reporter=dot`
- `git diff --check`