### PR TITLE
fix(insight): count analytics totals independently

### DIFF
--- a/insight/server.mjs
+++ b/insight/server.mjs
@@ -448,6 +448,10 @@ function apiAnalytics() {
     safeAll(db, `SELECT data as detail, created_at, session_id FROM session_events
       WHERE type = 'error_tool' OR type = 'error' ORDER BY created_at DESC LIMIT 20`)
   );
+  const errorCounts = queryAllSessionDBs(db =>
+    safeAll(db, `SELECT COUNT(*) as count FROM session_events
+      WHERE type = 'error_tool' OR type = 'error'`)
+  );
   const fileActivity = queryAllSessionDBs(db =>
     safeAll(db, `SELECT data as file, type as op, COUNT(*) as count FROM session_events
       WHERE type IN ('file_read', 'file_write', 'file') AND data != ''
@@ -563,9 +567,15 @@ function apiAnalytics() {
     safeAll(db, `SELECT substr(data, 1, 100) as task, created_at FROM session_events
       WHERE type = 'task' ORDER BY created_at DESC LIMIT 20`)
   );
+  const taskCounts = queryAllSessionDBs(db =>
+    safeAll(db, `SELECT COUNT(*) as count FROM session_events WHERE type = 'task'`)
+  );
   const prompts = queryAllSessionDBs(db =>
     safeAll(db, `SELECT substr(data, 1, 100) as prompt, created_at, session_id FROM session_events
       WHERE type = 'user_prompt' ORDER BY created_at DESC LIMIT 20`)
+  );
+  const promptCounts = queryAllSessionDBs(db =>
+    safeAll(db, `SELECT COUNT(*) as count FROM session_events WHERE type = 'user_prompt'`)
   );
 
   const rw = readWriteRatio.reduce((a, b) => ({
@@ -573,7 +583,9 @@ function apiAnalytics() {
     total_file_ops: (a.total_file_ops || 0) + (b.total_file_ops || 0),
   }), { reads: 0, writes: 0, total_file_ops: 0 });
   const totalEvents = toolUsage.reduce((a, b) => a + b.count, 0);
-  const totalErrors = errors.length;
+  const totalErrors = errorCounts.reduce((a, b) => a + (b.count || 0), 0);
+  const totalTasks = taskCounts.reduce((a, b) => a + (b.count || 0), 0);
+  const totalPrompts = promptCounts.reduce((a, b) => a + (b.count || 0), 0);
   const totalCompacts = sessionDurations.reduce((a, b) => a + (b.compact_count || 0), 0);
   const sessionsWithCompact = sessionDurations.filter(s => s.compact_count > 0).length;
 
@@ -706,9 +718,9 @@ function apiAnalytics() {
       reads: rw.reads, writes: rw.writes,
       readWriteRatio: rw.writes > 0 ? Math.round(10 * rw.reads / rw.writes) / 10 : rw.reads,
       totalFileOps: rw.total_file_ops, totalSubagents: subagents.total,
-      totalTasks: tasks.length, totalPrompts: prompts.length,
+      totalTasks, totalPrompts,
       promptsPerSession: sessionDurations.length > 0
-        ? Math.round(10 * prompts.length / sessionDurations.length) / 10 : 0,
+        ? Math.round(10 * totalPrompts / sessionDurations.length) / 10 : 0,
       uniqueProjects: nonUnknownProjects.length,
       totalCommits: commitRate.reduce((a, b) => a + (b.commits || 0), 0),
       commitsPerSession: sessionDurations.length > 0

--- a/tests/analytics/insight-cors.test.ts
+++ b/tests/analytics/insight-cors.test.ts
@@ -61,7 +61,7 @@ function seedFixtureDBs(baseDir: string): { sessionsDir: string; contentDir: str
     "/secret/project",
     "2026-04-16T00:00:00Z",
     "2026-04-16T00:05:00Z",
-    1,
+    76,
     0,
   );
   sessionDb.prepare(
@@ -84,6 +84,45 @@ function seedFixtureDBs(baseDir: string): { sessionsDir: string; contentDir: str
     1,
     0,
   );
+  const insertEvent = sessionDb.prepare(
+    "INSERT INTO session_events (id, session_id, type, category, priority, data, source_hook, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+  );
+  for (let i = 0; i < 25; i++) {
+    insertEvent.run(
+      i + 2,
+      "sess-1",
+      "error_tool",
+      "error",
+      "medium",
+      `Read failed ${i + 1}`,
+      "posttooluse",
+      `2026-04-16T00:${String(i + 2).padStart(2, "0")}:00Z`,
+    );
+  }
+  for (let i = 0; i < 25; i++) {
+    insertEvent.run(
+      i + 27,
+      "sess-1",
+      "user_prompt",
+      "user-prompt",
+      "high",
+      `prompt ${i + 1}`,
+      "userpromptsubmit",
+      `2026-04-16T00:31:${String(i).padStart(2, "0")}Z`,
+    );
+  }
+  for (let i = 0; i < 25; i++) {
+    insertEvent.run(
+      i + 52,
+      "sess-1",
+      "task",
+      "task",
+      "medium",
+      `task ${i + 1}`,
+      "posttooluse",
+      `2026-04-16T00:32:${String(i).padStart(2, "0")}Z`,
+    );
+  }
   sessionDb.close();
 
   const contentDb = new Database(join(contentDir, "feedface.db"));
@@ -181,7 +220,7 @@ function startInsight(runtime: "node" | "bun" = "node"): { port: number; child: 
   return { port, child };
 }
 
-describe("Insight API same-machine cross-origin policy", () => {
+describe("Insight API — Node runtime", () => {
   let port: number;
   let serverChild: ChildProcess;
   let serverTempDir: string | undefined;
@@ -246,6 +285,19 @@ describe("Insight API same-machine cross-origin policy", () => {
     expect(res.status).toBe(405);
     expect(res.headers.get("access-control-allow-origin")).toBeNull();
     expect(res.headers.get("access-control-allow-methods")).toBeNull();
+  });
+
+  test("analytics totals count all matching rows even when detail lists are capped (Node)", async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/analytics`);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.errors).toHaveLength(20);
+    expect(body.totals.totalErrors).toBe(25);
+    expect(body.prompts).toHaveLength(20);
+    expect(body.totals.totalPrompts).toBe(26);
+    expect(body.tasks).toHaveLength(20);
+    expect(body.totals.totalTasks).toBe(25);
   });
 
 });


### PR DESCRIPTION
## Summary
- count analytics totals with dedicated aggregate queries instead of capped recent detail lists
- keep recent errors/prompts/tasks capped for dashboard detail sections
- add an Insight API regression test for capped detail lists vs uncapped totals

## Problem
`/api/analytics` used the recent detail arrays to calculate `totalErrors`, `totalPrompts`, and `totalTasks`. Those arrays are intentionally capped at 20 rows for display, so dashboard KPI totals could be underreported when there were more matching records.

## Validation
- `pnpm exec vitest run tests/analytics/insight-cors.test.ts --reporter=dot`
- `pnpm exec vitest run tests/core/server.test.ts -t 'ctx_insight|insight-cache' --reporter=dot`
- `pnpm run build`
- manual `context-mode insight` check: analytics error total matches category analytics error total