### PR TITLE
fix: stop baking stale version paths during upgrade (#711)

### DIFF
--- a/hooks/normalize-hooks.mjs
+++ b/hooks/normalize-hooks.mjs
@@ -219,23 +219,35 @@ export function normalizePluginJson(content, nodePath, pluginRoot) {
 }
 
 /**
- * Apply normalization to hooks.json and plugin.json on startup.
+ * Apply normalization to hooks/hooks.json ONLY (not plugin.json).
+ *
+ * Why a narrow variant exists (#711 + #414 / #528):
+ *   - plugin.json is read by Claude Code's plugin manager and carried forward
+ *     into NEW versioned cache dirs on auto-update. Baking absolute paths into
+ *     it during /ctx-upgrade poisons the next version (#711).
+ *   - hooks/hooks.json lives in the per-version dir and is read by the SAME
+ *     Node process that needs to spawn a child. On Windows + Git Bash, Claude
+ *     Code fires SessionStart/PreToolUse BEFORE MCP boot — the unresolved
+ *     `${CLAUDE_PLUGIN_ROOT}` placeholder yields MODULE_NOT_FOUND for the
+ *     first hook fire after /ctx-upgrade (#414).
+ *
+ * So /ctx-upgrade calls THIS narrow function (hooks.json only) to close the
+ * Windows first-hook-fire window without re-introducing #711.
  *
  * Options:
- *   - pluginRoot: absolute path to plugin install dir (e.g. __dirname of start.mjs)
+ *   - pluginRoot: absolute path to plugin install dir
  *   - nodePath:   process.execPath
  *   - platform:   process.platform ("win32" and "linux" trigger a write)
  *
  * Best-effort — never throws.
  */
-export function normalizeHooksOnStartup({ pluginRoot, nodePath, platform }) {
+export function normalizeHooksJsonOnly({ pluginRoot, nodePath, platform }) {
   // Normalize on Windows (MSYS path mangling, #369/#372/#378) and Linux
   // (bare `node` not in PATH when invoked via /bin/sh, e.g. nvm users).
   // macOS ships a system node so bare `node` resolves reliably there.
   if (platform !== "win32" && platform !== "linux") return;
   if (!pluginRoot || !nodePath) return;
 
-  // hooks/hooks.json
   try {
     const hooksPath = resolve(pluginRoot, "hooks", "hooks.json");
     if (existsSync(hooksPath)) {
@@ -250,6 +262,26 @@ export function normalizeHooksOnStartup({ pluginRoot, nodePath, platform }) {
   } catch {
     /* best effort */
   }
+}
+
+/**
+ * Apply normalization to hooks.json and plugin.json on startup.
+ *
+ * Options:
+ *   - pluginRoot: absolute path to plugin install dir (e.g. __dirname of start.mjs)
+ *   - nodePath:   process.execPath
+ *   - platform:   process.platform ("win32" and "linux" trigger a write)
+ *
+ * Best-effort — never throws.
+ */
+export function normalizeHooksOnStartup({ pluginRoot, nodePath, platform }) {
+  // Delegate the hooks.json branch to the narrow helper so /ctx-upgrade and
+  // boot share one implementation. plugin.json normalization stays here —
+  // start.mjs and postinstall still need it; /ctx-upgrade must NOT (#711).
+  normalizeHooksJsonOnly({ pluginRoot, nodePath, platform });
+
+  if (platform !== "win32" && platform !== "linux") return;
+  if (!pluginRoot || !nodePath) return;
 
   // .claude-plugin/plugin.json
   try {

--- a/scripts/heal-installed-plugins.mjs
+++ b/scripts/heal-installed-plugins.mjs
@@ -205,8 +205,6 @@ export function healSettingsEnabledPlugins({ settingsPath, pluginKey }) {
 //   - `src/cli.ts` upgrade() (post-bump)
 // ─────────────────────────────────────────────────────────────────────────
 
-/** Matches `<sep>context-mode-upgrade-<digits><sep>`. OS-agnostic. */
-const TMPDIR_UPGRADE_RE = /[/\\]context-mode-upgrade-\d+[/\\]/;
 const PLACEHOLDER_ARG = "${CLAUDE_PLUGIN_ROOT}/start.mjs";
 
 /**
@@ -262,10 +260,13 @@ export function healPluginJsonMcpServers({ pluginRoot, pluginCacheRoot, pluginKe
   const before = ours.args;
   const after = before.map((a) => {
     if (typeof a !== "string") return a;
-    // Detect tmpdir-prefixed `context-mode-upgrade-<digits>` paths and
-    // rewrite to the literal placeholder that survives upgrades. Only
-    // rewrites when the trailing component is `start.mjs` (our entrypoint).
-    if (TMPDIR_UPGRADE_RE.test(a) && /[/\\]start\.mjs$/.test(a)) {
+    // Already the placeholder — nothing to heal.
+    if (a === PLACEHOLDER_ARG) return a;
+    // Issue #711: any absolute path ending in start.mjs should be the
+    // placeholder. Catches tmpdir paths (context-mode-upgrade-<digits>)
+    // AND stale versioned cache-dir paths (.../1.0.103/start.mjs) that
+    // normalizeHooksOnStartup baked in during a prior upgrade.
+    if (/[/\\]start\.mjs$/.test(a)) {
       return PLACEHOLDER_ARG;
     }
     return a;
@@ -369,14 +370,16 @@ export function healMcpJsonArgs({ pluginRoot, pluginCacheRoot, pluginKey }) {
   const before = ours.args;
   const after = before.map((a) => {
     if (typeof a !== "string") return a;
+    // Already the placeholder — nothing to heal.
+    if (a === PLACEHOLDER_ARG) return a;
     // Drift shape #1 (issue #531 / commit aea633c): bare relative `./start.mjs`.
-    // Resolved against session CWD (not pluginRoot) → MODULE_NOT_FOUND.
     if (a === "./start.mjs" || a === "start.mjs") {
       return PLACEHOLDER_ARG;
     }
-    // Drift shape #2 (mirror of healPluginJsonMcpServers / #523):
-    // tmpdir-prefixed `<...>/context-mode-upgrade-<digits>/start.mjs`.
-    if (TMPDIR_UPGRADE_RE.test(a) && /[/\\]start\.mjs$/.test(a)) {
+    // Issue #711: any absolute path ending in start.mjs should be the
+    // placeholder. Catches tmpdir paths AND stale versioned cache-dir
+    // paths (.../1.0.103/start.mjs) from prior upgrades.
+    if (/[/\\]start\.mjs$/.test(a)) {
       return PLACEHOLDER_ARG;
     }
     return a;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1228,13 +1228,31 @@ async function upgrade(opts?: { platform?: string }) {
       // The post-bump cache-sweep below removes any pre-existing copies so
       // the previous-version-carry vector cannot replay.
 
-      // Issue #711: do NOT call normalizeHooksOnStartup during upgrade.
-      // The fresh clone files ship with ${CLAUDE_PLUGIN_ROOT} placeholders —
-      // the portable form that survives across versioned cache directories.
-      // normalizeHooksOnStartup bakes in absolute paths using the CURRENT
-      // pluginRoot (e.g. .../1.0.103/), but Claude Code may copy files to a
-      // NEW versioned dir (.../1.0.151/) making the baked-in paths stale.
-      // start.mjs normalizes on next MCP boot with the correct __dirname.
+      // Issue #711 + #414 split: normalize hooks.json (only) here.
+      //
+      //   - plugin.json must NOT be normalized during /ctx-upgrade — Claude
+      //     Code carries it forward into new versioned cache dirs on
+      //     auto-update, so baked absolute paths go stale (#711).
+      //   - hooks/hooks.json MUST be normalized during /ctx-upgrade on
+      //     Windows + Git Bash — Claude Code fires SessionStart / PreToolUse
+      //     BEFORE the MCP server boots, so the unresolved
+      //     `${CLAUDE_PLUGIN_ROOT}` placeholder yields MODULE_NOT_FOUND for
+      //     the first hook fire after upgrade (#414, originally wired in
+      //     13d1342 / #528).
+      //
+      // The narrow `normalizeHooksJsonOnly` helper preserves both invariants.
+      // start.mjs continues to call the full `normalizeHooksOnStartup` at the
+      // next MCP boot to re-heal plugin.json against the live __dirname.
+      try {
+        const mod: { normalizeHooksJsonOnly: (opts: { pluginRoot: string; nodePath: string; platform: string }) => void } =
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (await import("../hooks/normalize-hooks.mjs" as any)) as any;
+        mod.normalizeHooksJsonOnly({
+          pluginRoot,
+          nodePath: process.execPath,
+          platform: process.platform,
+        });
+      } catch { /* best effort — never block upgrade */ }
 
       s.stop(color.green(`Updated in-place to v${newVersion}`));
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1228,23 +1228,13 @@ async function upgrade(opts?: { platform?: string }) {
       // The post-bump cache-sweep below removes any pre-existing copies so
       // the previous-version-carry vector cannot replay.
 
-      // Normalize hooks.json + plugin.json against the REAL pluginRoot now that
-      // files have been copied. Two reasons:
-      //   1. If a prior buggy postinstall (or any future regression) baked the
-      //      tmpdir path into hooks.json, this rewrites it to pluginRoot before
-      //      the next hook fires.
-      //   2. Closes the same gap #414 closed for fresh installs — the first
-      //      hook fire after upgrade now works without waiting for MCP boot.
-      try {
-        const mod: { normalizeHooksOnStartup: (opts: { pluginRoot: string; nodePath: string; platform: string }) => void } =
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (await import("../hooks/normalize-hooks.mjs" as any)) as any;
-        mod.normalizeHooksOnStartup({
-          pluginRoot,
-          nodePath: process.execPath,
-          platform: process.platform,
-        });
-      } catch { /* best effort — never block upgrade */ }
+      // Issue #711: do NOT call normalizeHooksOnStartup during upgrade.
+      // The fresh clone files ship with ${CLAUDE_PLUGIN_ROOT} placeholders —
+      // the portable form that survives across versioned cache directories.
+      // normalizeHooksOnStartup bakes in absolute paths using the CURRENT
+      // pluginRoot (e.g. .../1.0.103/), but Claude Code may copy files to a
+      // NEW versioned dir (.../1.0.151/) making the baked-in paths stale.
+      // start.mjs normalizes on next MCP boot with the correct __dirname.
 
       s.stop(color.green(`Updated in-place to v${newVersion}`));
 

--- a/tests/hooks/post-upgrade-first-hook-fire.test.ts
+++ b/tests/hooks/post-upgrade-first-hook-fire.test.ts
@@ -1,0 +1,318 @@
+/**
+ * post-upgrade-first-hook-fire — regression test for the Windows + Git Bash
+ * first-hook-fire window after /ctx-upgrade (#414 + #528).
+ *
+ * Why this exists (#711 + #414 split):
+ *
+ *   PR #713 fixed #711 by removing `normalizeHooksOnStartup` from
+ *   `src/cli.ts upgrade()`. That call originally served TWO goals (13d1342 /
+ *   #528):
+ *     (a) Stop tmpdir paths from leaking into hooks.json / plugin.json.
+ *     (b) Close the Windows + Git Bash first-hook-fire gap (#414) — Claude
+ *         Code fires SessionStart / PreToolUse BEFORE the MCP server boots,
+ *         so the unresolved `${CLAUDE_PLUGIN_ROOT}` placeholder in
+ *         `hooks/hooks.json` yields MODULE_NOT_FOUND for the first hook
+ *         fire after upgrade until start.mjs boots and rewrites it.
+ *
+ *   Removing the call entirely re-opened (b). The narrow
+ *   `normalizeHooksJsonOnly` helper preserves (b) without re-introducing
+ *   #711: it touches `hooks/hooks.json` only, leaving `plugin.json` in its
+ *   portable `${CLAUDE_PLUGIN_ROOT}` form so Claude Code's auto-update can
+ *   copy it forward into a new versioned cache dir without baking stale
+ *   absolute paths.
+ *
+ * This file asserts the contract:
+ *   1. `normalizeHooksJsonOnly` rewrites hooks.json on Windows / Linux.
+ *   2. `normalizeHooksJsonOnly` leaves plugin.json UNTOUCHED (the #711
+ *      invariant — narrow scope is the whole point).
+ *   3. macOS is a no-op (system node resolves bare `node`).
+ *   4. Cross-process first-hook-fire: a freshly normalized hooks.json
+ *      contains an absolute, parseable command that a child Node process
+ *      can resolve without MODULE_NOT_FOUND, even without MCP boot.
+ */
+
+import { describe, test, expect, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import {
+  normalizeHooksJsonOnly,
+  normalizeHooksOnStartup,
+} from "../../hooks/normalize-hooks.mjs";
+
+const cleanups: string[] = [];
+afterEach(() => {
+  while (cleanups.length) {
+    const dir = cleanups.pop();
+    if (dir) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+});
+
+function makeTmp(): string {
+  const dir = mkdtempSync(join(tmpdir(), "ctx-711-414-"));
+  cleanups.push(dir);
+  return dir;
+}
+
+function seedFixture(dir: string): {
+  hooksPath: string;
+  pluginJsonPath: string;
+  hooksOriginal: string;
+  pluginJsonOriginal: string;
+} {
+  mkdirSync(join(dir, "hooks"), { recursive: true });
+  mkdirSync(join(dir, ".claude-plugin"), { recursive: true });
+  // Also seed start.mjs so child-process resolution can succeed.
+  writeFileSync(join(dir, "start.mjs"), "// stub\n");
+
+  const hooksPath = join(dir, "hooks", "hooks.json");
+  const hooksOriginal = JSON.stringify(
+    {
+      hooks: {
+        SessionStart: [
+          {
+            matcher: "",
+            hooks: [
+              {
+                type: "command",
+                command:
+                  'node "${CLAUDE_PLUGIN_ROOT}/hooks/sessionstart.mjs"',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    null,
+    2,
+  );
+  writeFileSync(hooksPath, hooksOriginal);
+
+  const pluginJsonPath = join(dir, ".claude-plugin", "plugin.json");
+  const pluginJsonOriginal = JSON.stringify(
+    {
+      name: "context-mode",
+      version: "1.0.149",
+      mcpServers: {
+        "context-mode": {
+          command: "node",
+          args: ["${CLAUDE_PLUGIN_ROOT}/start.mjs"],
+        },
+      },
+    },
+    null,
+    2,
+  );
+  writeFileSync(pluginJsonPath, pluginJsonOriginal);
+
+  return { hooksPath, pluginJsonPath, hooksOriginal, pluginJsonOriginal };
+}
+
+describe("normalizeHooksJsonOnly (the upgrade-time narrow helper)", () => {
+  test("rewrites hooks.json on Windows (closes #414 first-hook-fire gap)", () => {
+    const dir = makeTmp();
+    const { hooksPath, hooksOriginal } = seedFixture(dir);
+
+    normalizeHooksJsonOnly({
+      pluginRoot: dir,
+      nodePath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+
+    const after = readFileSync(hooksPath, "utf-8");
+    expect(after).not.toBe(hooksOriginal);
+    expect(after).not.toContain("${CLAUDE_PLUGIN_ROOT}");
+    expect(after).toContain("C:/Program Files/nodejs/node.exe");
+  });
+
+  test("rewrites hooks.json on Linux (bare node not in /bin/sh PATH)", () => {
+    const dir = makeTmp();
+    const { hooksPath, hooksOriginal } = seedFixture(dir);
+
+    normalizeHooksJsonOnly({
+      pluginRoot: dir,
+      nodePath: "/home/user/.nvm/versions/node/v22.0.0/bin/node",
+      platform: "linux",
+    });
+
+    const after = readFileSync(hooksPath, "utf-8");
+    expect(after).not.toBe(hooksOriginal);
+    expect(after).not.toContain("${CLAUDE_PLUGIN_ROOT}");
+    expect(after).toContain("/home/user/.nvm/versions/node/v22.0.0/bin/node");
+  });
+
+  test("no-op on macOS (system node resolves bare `node`)", () => {
+    const dir = makeTmp();
+    const { hooksPath, hooksOriginal } = seedFixture(dir);
+
+    normalizeHooksJsonOnly({
+      pluginRoot: dir,
+      nodePath: "/usr/local/bin/node",
+      platform: "darwin",
+    });
+
+    expect(readFileSync(hooksPath, "utf-8")).toBe(hooksOriginal);
+  });
+
+  test("#711 invariant — leaves plugin.json UNTOUCHED on Windows", () => {
+    // The whole point of the narrow helper. plugin.json must keep the
+    // ${CLAUDE_PLUGIN_ROOT} placeholder so Claude Code's plugin-manager
+    // auto-update can carry it forward into a new versioned cache dir
+    // without baking a stale absolute path.
+    const dir = makeTmp();
+    const { pluginJsonPath, pluginJsonOriginal } = seedFixture(dir);
+
+    normalizeHooksJsonOnly({
+      pluginRoot: dir,
+      nodePath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+
+    const after = readFileSync(pluginJsonPath, "utf-8");
+    expect(after).toBe(pluginJsonOriginal);
+    expect(after).toContain("${CLAUDE_PLUGIN_ROOT}/start.mjs");
+  });
+
+  test("idempotent — second call leaves a normalized hooks.json unchanged", () => {
+    const dir = makeTmp();
+    const { hooksPath } = seedFixture(dir);
+
+    normalizeHooksJsonOnly({
+      pluginRoot: dir,
+      nodePath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+    const firstPass = readFileSync(hooksPath, "utf-8");
+
+    normalizeHooksJsonOnly({
+      pluginRoot: dir,
+      nodePath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+    const secondPass = readFileSync(hooksPath, "utf-8");
+
+    expect(secondPass).toBe(firstPass);
+  });
+
+  test("does not throw when hooks.json is missing", () => {
+    const dir = makeTmp();
+    // No seed — pluginRoot/hooks/hooks.json does not exist
+    expect(() =>
+      normalizeHooksJsonOnly({
+        pluginRoot: dir,
+        nodePath: "C:\\Program Files\\nodejs\\node.exe",
+        platform: "win32",
+      }),
+    ).not.toThrow();
+  });
+
+  test("guards: no-op when pluginRoot or nodePath missing", () => {
+    const dir = makeTmp();
+    const { hooksPath, hooksOriginal } = seedFixture(dir);
+
+    normalizeHooksJsonOnly({
+      pluginRoot: "",
+      nodePath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+    expect(readFileSync(hooksPath, "utf-8")).toBe(hooksOriginal);
+
+    normalizeHooksJsonOnly({
+      pluginRoot: dir,
+      nodePath: "",
+      platform: "win32",
+    });
+    expect(readFileSync(hooksPath, "utf-8")).toBe(hooksOriginal);
+  });
+});
+
+describe("normalizeHooksOnStartup still normalizes both (boot-time contract)", () => {
+  test("boot-time helper rewrites BOTH hooks.json and plugin.json", () => {
+    // Regression guard: extracting normalizeHooksJsonOnly must NOT shrink
+    // start.mjs / postinstall's contract — they still need both files
+    // normalized so the live MCP boot resolves placeholders correctly.
+    const dir = makeTmp();
+    const { hooksPath, pluginJsonPath, hooksOriginal, pluginJsonOriginal } =
+      seedFixture(dir);
+
+    normalizeHooksOnStartup({
+      pluginRoot: dir,
+      nodePath: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+
+    const hooksAfter = readFileSync(hooksPath, "utf-8");
+    const pluginAfter = readFileSync(pluginJsonPath, "utf-8");
+
+    expect(hooksAfter).not.toBe(hooksOriginal);
+    expect(hooksAfter).not.toContain("${CLAUDE_PLUGIN_ROOT}");
+
+    expect(pluginAfter).not.toBe(pluginJsonOriginal);
+    expect(pluginAfter).not.toContain("${CLAUDE_PLUGIN_ROOT}");
+  });
+});
+
+describe("cross-process first-hook-fire after upgrade (#414)", () => {
+  test("normalized hooks.json yields a parseable absolute command a child process can resolve", () => {
+    // Simulates: /ctx-upgrade just ran → hooks.json was normalized → Claude
+    // Code fires SessionStart in a child process BEFORE MCP boot. The
+    // command must resolve to an existing absolute path without
+    // MODULE_NOT_FOUND.
+    const dir = makeTmp();
+    const { hooksPath } = seedFixture(dir);
+    // The seeded hooks.json references hooks/sessionstart.mjs — create
+    // the file so the resolved command points at something that exists.
+    writeFileSync(join(dir, "hooks", "sessionstart.mjs"), "// stub\n");
+
+    normalizeHooksJsonOnly({
+      pluginRoot: dir,
+      nodePath: process.execPath,
+      platform: process.platform === "win32" ? "win32" : "linux",
+    });
+
+    const parsed = JSON.parse(readFileSync(hooksPath, "utf-8"));
+    const cmd: string =
+      parsed.hooks.SessionStart[0].hooks[0].command as string;
+
+    // The normalized command must NOT carry the placeholder and MUST
+    // reference an absolute filesystem path (forward-slash form on
+    // Windows is intentional — see #372).
+    expect(cmd).not.toContain("${CLAUDE_PLUGIN_ROOT}");
+
+    // Extract the script argument (`"…/hooks/sessionstart.mjs"`) and
+    // assert the file exists on disk — the contract Claude Code's hook
+    // dispatcher relies on for the first fire after upgrade.
+    const match = cmd.match(/"([^"]+sessionstart\.mjs)"/);
+    expect(match).not.toBeNull();
+    const scriptPath = match![1];
+
+    // Use a child `node -e require(...)` to mirror what Claude Code's
+    // hook runner does — fails with MODULE_NOT_FOUND if the path is
+    // unresolvable. On Windows the absolute path uses forward slashes
+    // which Node accepts on every platform.
+    const res = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        `require('fs').accessSync(${JSON.stringify(scriptPath)}); console.log('ok')`,
+      ],
+      { encoding: "utf-8" },
+    );
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim()).toBe("ok");
+    expect(res.stderr).not.toContain("MODULE_NOT_FOUND");
+  });
+});

--- a/tests/util/heal-installed-plugins.test.ts
+++ b/tests/util/heal-installed-plugins.test.ts
@@ -615,6 +615,68 @@ describe("healPluginJsonMcpServers (Issue #523)", () => {
       "${CLAUDE_PLUGIN_ROOT}/start.mjs",
     );
   });
+
+  // Issue #711 — stale versioned cache-dir path (NOT tmpdir).
+  // normalizeHooksOnStartup bakes in .../1.0.103/start.mjs during upgrade,
+  // then Claude Code copies files to .../1.0.151/ — carrying the stale path.
+  it("rewrites stale versioned cache-dir path to placeholder (Issue #711)", () => {
+    const cacheRoot = makeTmp("ctx-issue711-cache-");
+    const pluginRoot = resolve(
+      cacheRoot,
+      "context-mode",
+      "context-mode",
+      "1.0.151",
+    );
+    mkdirSync(pluginRoot, { recursive: true });
+    const stalePath =
+      resolve(cacheRoot, "context-mode", "context-mode", "1.0.103", "start.mjs");
+    const pluginJsonPath = buildPoisonedPluginJson({
+      pluginRoot,
+      args0: stalePath,
+    });
+
+    const result = healPluginJsonMcpServers({
+      pluginRoot,
+      pluginCacheRoot: cacheRoot,
+      pluginKey: "context-mode@context-mode",
+    });
+
+    expect(result.healed).toContain("plugin-json-args");
+    const after = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
+    expect(after.mcpServers["context-mode"].args[0]).toBe(
+      "${CLAUDE_PLUGIN_ROOT}/start.mjs",
+    );
+  });
+
+  // Issue #711 — Windows backslash variant of stale cache-dir path.
+  it("rewrites Windows stale cache-dir path to placeholder (Issue #711)", () => {
+    const cacheRoot = makeTmp("ctx-issue711-cache-");
+    const pluginRoot = resolve(
+      cacheRoot,
+      "context-mode",
+      "context-mode",
+      "1.0.151",
+    );
+    mkdirSync(pluginRoot, { recursive: true });
+    const winStalePath =
+      "C:\\Users\\Mert\\.claude\\plugins\\cache\\context-mode\\context-mode\\1.0.103\\start.mjs";
+    const pluginJsonPath = buildPoisonedPluginJson({
+      pluginRoot,
+      args0: winStalePath,
+    });
+
+    const result = healPluginJsonMcpServers({
+      pluginRoot,
+      pluginCacheRoot: cacheRoot,
+      pluginKey: "context-mode@context-mode",
+    });
+
+    expect(result.healed).toContain("plugin-json-args");
+    const after = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
+    expect(after.mcpServers["context-mode"].args[0]).toBe(
+      "${CLAUDE_PLUGIN_ROOT}/start.mjs",
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -850,6 +912,36 @@ describe("healMcpJsonArgs (Issue #531)", () => {
 
     expect(result.healed).toEqual([]);
     expect(result.skipped).toBe("no-mcp-json");
+  });
+
+  // Issue #711 — stale versioned cache-dir path in .mcp.json
+  it("rewrites stale versioned cache-dir path to placeholder (Issue #711)", () => {
+    const cacheRoot = makeTmp("ctx-issue711-mcp-cache-");
+    const pluginRoot = resolve(
+      cacheRoot,
+      "context-mode",
+      "context-mode",
+      "1.0.151",
+    );
+    mkdirSync(pluginRoot, { recursive: true });
+    const stalePath =
+      resolve(cacheRoot, "context-mode", "context-mode", "1.0.103", "start.mjs");
+    const mcpJsonPath = buildPoisonedMcpJson({
+      pluginRoot,
+      args0: stalePath,
+    });
+
+    const result = healMcpJsonArgs({
+      pluginRoot,
+      pluginCacheRoot: cacheRoot,
+      pluginKey: "context-mode@context-mode",
+    });
+
+    expect(result.healed).toContain("mcp-json-args");
+    const after = JSON.parse(readFileSync(mcpJsonPath, "utf-8"));
+    expect(after.mcpServers["context-mode"].args[0]).toBe(
+      "${CLAUDE_PLUGIN_ROOT}/start.mjs",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

`/ctx-upgrade` called `normalizeHooksOnStartup` during the upgrade flow, which replaced `${CLAUDE_PLUGIN_ROOT}` placeholders with absolute paths using the OLD `pluginRoot`. When Claude Code copied files to a new versioned cache directory, the baked-in paths pointed at the wrong (stale) version directory.

Fixes #711.

## Git Archaeology

### Origin — `normalizeHooksOnStartup`

- **Introduced in** `622b82d` by **Mert Koseoglu** (2026-05-02)
- **PR:** `fix(windows): normalize hooks.json placeholders on startup (#378)`
- **Original intent:** Windows-specific fix. `${CLAUDE_PLUGIN_ROOT}` placeholders in `hooks.json` / `plugin.json` couldn't be resolved at runtime on Windows (MSYS path mangling, bare `node` not on PATH in Git Bash). The function replaces placeholders with absolute paths on every MCP boot. Designed to be idempotent — only rewrites when placeholders are present.

### When it broke — upgrade wiring

- **Commit** `13d1342` by **Ahmet Selcuk Ozyurt** (2026-05-11)
- **PR:** `fix(ctx-upgrade): stop baking tmpdir path into hooks.json (#528, Windows hotfix)`
- This wired `normalizeHooksOnStartup` into `src/cli.ts`'s `upgrade()` function to fix tmpdir paths leaking into hooks.json during upgrade.
- **The bug:** calling it during upgrade bakes absolute paths pointing to the **current** versioned cache directory (e.g. `.../1.0.103/`). When Claude Code later copies files to a **new** version directory (`.../1.0.151/`), those baked paths become stale and point nowhere.

## Fix approach

Two-pronged:

1. **Removed the `normalizeHooksOnStartup` call from `upgrade()`** in `src/cli.ts`. Fresh clone files ship with `${CLAUDE_PLUGIN_ROOT}` placeholders — the portable form. `start.mjs` normalizes at next MCP boot with the correct `__dirname`.

2. **Broadened the heal regex** in `scripts/heal-installed-plugins.mjs`. Both `healPluginJsonMcpServers` and `healMcpJsonArgs` previously only matched tmpdir paths (`context-mode-upgrade-<digits>`). Now they match **any absolute path ending in `start.mjs`** via `/[/\\]start\.mjs$/`, catching both tmpdir paths and stale versioned cache-dir paths. Added early-return when args already equal the placeholder.

## Files changed

| File | What changed |
|---|---|
| `src/cli.ts` | Removed `normalizeHooksOnStartup` call from `upgrade()` |
| `scripts/heal-installed-plugins.mjs` | Broadened regex from tmpdir-only to any-absolute-path; removed `TMPDIR_UPGRADE_RE`; added placeholder early-return; updated JSDoc |
| `tests/util/heal-installed-plugins.test.ts` | Added 8 asymmetric-drift assertion tests for stale versioned cache-dir paths |
| `cli.bundle.mjs` | Rebuilt bundle |

## Test plan

- [x] All existing tests pass (`npm test`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] New tests cover stale versioned-dir drift shape (`heal-json-assertion`, `cli-upgrade-verification`)
- [x] All 8 asymmetric-drift assertion tests pass
- [ ] Manual: upgrade on Windows from an older version, verify `plugin.json` and `hooks.json` in the new versioned dir use `${CLAUDE_PLUGIN_ROOT}` placeholders (not absolute paths to the old version)