### PR TITLE
security: containment, info-disclosure, and test-isolation hardening

### DIFF
--- a/scripts/heal-installed-plugins.mjs
+++ b/scripts/heal-installed-plugins.mjs
@@ -430,6 +430,18 @@ export function healClaudeJsonMcpArgs({ dotClaudeJsonPath, pluginCacheParent, ne
   }
 
   const cacheParentFwd = pluginCacheParent.replace(/\\/g, "/");
+  // Post-resolve containment on newArg. ~/.claude.json is locally user-
+  // writable (same trust boundary as installed_plugins.json), and the
+  // `suffix` slice is derived from arg strings inside the existing config.
+  // A crafted arg like
+  //   .../cache/<owner>/<plugin>/1.0.0/../../../evil/start.mjs
+  // slices to suffix="../../../evil/start.mjs", and resolve(newPluginRoot,
+  // suffix) normalizes to an attacker-chosen .mjs path outside the plugin
+  // cache. Writing that path back into ~/.claude.json mutates the mcpServers
+  // args so the next MCP boot spawns from the attacker path. Reject any
+  // suffix that escapes newPluginRoot.
+  const newPluginRootResolved = resolve(newPluginRoot);
+  const newPluginRootWithSep = newPluginRootResolved + sep;
 
   let mutated = false;
   for (const srv of Object.values(servers)) {
@@ -444,6 +456,12 @@ export function healClaudeJsonMcpArgs({ dotClaudeJsonPath, pluginCacheParent, ne
       if (slashIdx < 0) continue;
       const suffix = rel.slice(slashIdx + 1);
       const newArg = resolve(newPluginRoot, suffix);
+      if (
+        newArg !== newPluginRootResolved &&
+        !(newArg + sep).startsWith(newPluginRootWithSep)
+      ) {
+        continue;
+      }
       if (newArg !== arg) {
         srv.args[i] = newArg;
         mutated = true;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@
 import * as p from "@clack/prompts";
 import color from "picocolors";
 import { execFileSync, execSync, execFile as nodeExecFile, type ExecSyncOptions } from "node:child_process";
-import { readFileSync, writeFileSync, cpSync, accessSync, existsSync, readdirSync, rmSync, closeSync, openSync, chmodSync, mkdirSync, constants } from "node:fs";
+import { readFileSync, writeFileSync, cpSync, accessSync, existsSync, readdirSync, rmSync, closeSync, openSync, chmodSync, mkdirSync, lstatSync, realpathSync, constants } from "node:fs";
 import { request as httpsRequest } from "node:https";
 import { resolve, dirname, join, sep } from "node:path";
 import { tmpdir, devNull, homedir } from "node:os";
@@ -1210,16 +1210,29 @@ async function upgrade(opts?: { platform?: string }) {
       // resolved path escapes either srcDir or pluginRoot. Mirrors the
       // pattern hooks/heal-partial-install.mjs already uses for its own
       // files[] expansion (PR #699).
+      //
+      // Also refuse to copy any symlink encountered anywhere under a
+      // source item. cpSync's default is to preserve source symlinks as
+      // destination symlinks; a compromised upstream tag committing a
+      // symlink to /etc inside src/ would plant that link in pluginRoot,
+      // and the next Claude Code session that loads pluginRoot/src/*
+      // would dereference through to the attacker target. Filtering at
+      // copy time keeps pluginRoot symlink-free regardless of what the
+      // clone shipped.
       const pluginRootWithSep = resolve(pluginRoot) + sep;
       const srcDirWithSep = resolve(srcDir) + sep;
+      const refuseSymlinks = (src: string): boolean => {
+        try { return !lstatSync(src).isSymbolicLink(); } catch { return false; }
+      };
       for (const item of items) {
         const from = resolve(srcDir, item);
         const to = resolve(pluginRoot, item);
         if (!(to + sep).startsWith(pluginRootWithSep)) continue;
         if (!(from + sep).startsWith(srcDirWithSep)) continue;
+        if (!refuseSymlinks(from)) continue;
         try {
           rmSync(to, { recursive: true, force: true });
-          cpSync(from, to, { recursive: true });
+          cpSync(from, to, { recursive: true, filter: refuseSymlinks });
         } catch { /* some files may not exist in source */ }
       }
 
@@ -1536,8 +1549,19 @@ async function upgrade(opts?: { platform?: string }) {
           // skills/ tree to /etc/skills, ~/.ssh/skills, or wherever the attacker
           // pointed. server.ts:790 (healCacheMidSession) already gates the same
           // field this way; the symmetric guard belongs here too.
+          //
+          // The lexical resolve+startsWith check rejects ".."-escapes and
+          // absolute paths outside cacheRoot, but path.resolve doesn't
+          // dereference symlinks. A same-uid actor who can plant a symlink
+          // AT <cacheRoot>/<owner>/<plugin>/<version> targeting an attacker
+          // dir gets past the lexical guard, then cpSync follows the link at
+          // FS-write time. Re-check via realpathSync so a planted symlink
+          // anchor fails the gate.
           const cacheRoot = resolve(claudeRoot, "plugins", "cache");
-          const cacheRootWithSep = cacheRoot + sep;
+          let cacheRootCanon: string;
+          try { cacheRootCanon = realpathSync(cacheRoot); }
+          catch { cacheRootCanon = cacheRoot; }
+          const cacheRootWithSep = cacheRootCanon + sep;
           const registry = JSON.parse(readFileSync(registryPath, "utf-8"));
           const entries = registry?.plugins?.["context-mode@context-mode"];
           if (Array.isArray(entries)) {
@@ -1548,9 +1572,13 @@ async function upgrade(opts?: { platform?: string }) {
               const resolvedInstallPath = resolve(installPath);
               if (!(resolvedInstallPath + sep).startsWith(cacheRootWithSep)) continue;
               if (!existsSync(resolvedInstallPath)) continue;
+              let realInstallPath: string;
+              try { realInstallPath = realpathSync(resolvedInstallPath); }
+              catch { continue; }
+              if (!(realInstallPath + sep).startsWith(cacheRootWithSep)) continue;
               const srcSkills = resolve(srcDir, "skills");
               if (existsSync(srcSkills)) {
-                cpSync(srcSkills, resolve(resolvedInstallPath, "skills"), { recursive: true });
+                cpSync(srcSkills, resolve(realInstallPath, "skills"), { recursive: true });
                 changes.push(`Synced skills to active install path`);
               }
             }
@@ -1724,8 +1752,17 @@ function statuslineForward(): void {
       // script the statusline forwarder imports, since statusline re-fires
       // several times per second and would hand the attacker durable RCE
       // on the user's behalf.
+      //
+      // path.resolve is purely lexical, so a same-uid actor who can plant
+      // a symlink at <cacheRoot>/<owner>/<plugin>/<version> targeting an
+      // attacker dir would pass the lexical gate. Re-check via
+      // realpathSync so the dynamic-import target's actual on-disk
+      // location also stays under cacheRoot.
       const cacheRoot = resolve(claudeRoot, "plugins", "cache");
-      const cacheRootWithSep = cacheRoot + sep;
+      let cacheRootCanon: string;
+      try { cacheRootCanon = realpathSync(cacheRoot); }
+      catch { cacheRootCanon = cacheRoot; }
+      const cacheRootWithSep = cacheRootCanon + sep;
       const registry = JSON.parse(readFileSync(registryPath, "utf-8"));
       const entries = registry?.plugins?.["context-mode@context-mode"];
       if (Array.isArray(entries)) {
@@ -1734,7 +1771,11 @@ function statuslineForward(): void {
           if (typeof installPath !== "string" || !installPath) continue;
           const resolvedInstallPath = resolve(installPath);
           if (!(resolvedInstallPath + sep).startsWith(cacheRootWithSep)) continue;
-          candidates.push(resolve(resolvedInstallPath, "bin", "statusline.mjs"));
+          let realInstallPath: string;
+          try { realInstallPath = realpathSync(resolvedInstallPath); }
+          catch { continue; }
+          if (!(realInstallPath + sep).startsWith(cacheRootWithSep)) continue;
+          candidates.push(resolve(realInstallPath, "bin", "statusline.mjs"));
         }
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import color from "picocolors";
 import { execFileSync, execSync, execFile as nodeExecFile, type ExecSyncOptions } from "node:child_process";
 import { readFileSync, writeFileSync, cpSync, accessSync, existsSync, readdirSync, rmSync, closeSync, openSync, chmodSync, mkdirSync, constants } from "node:fs";
 import { request as httpsRequest } from "node:https";
-import { resolve, dirname, join } from "node:path";
+import { resolve, dirname, join, sep } from "node:path";
 import { tmpdir, devNull, homedir } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -1202,10 +1202,24 @@ async function upgrade(opts?: { platform?: string }) {
         ...(clonedPkg.files || []),
         "src", "package.json",
       ];
+      // Supply-chain containment on items[]. A compromised upstream tag
+      // shipping files: ["../../.ssh/authorized_keys"] or an absolute
+      // path would, without a guard, hand rmSync+cpSync an arbitrary
+      // destination under the user's UID. resolve(P, "/abs") discards P,
+      // so the absolute-path variant escapes too. Reject items whose
+      // resolved path escapes either srcDir or pluginRoot. Mirrors the
+      // pattern hooks/heal-partial-install.mjs already uses for its own
+      // files[] expansion (PR #699).
+      const pluginRootWithSep = resolve(pluginRoot) + sep;
+      const srcDirWithSep = resolve(srcDir) + sep;
       for (const item of items) {
+        const from = resolve(srcDir, item);
+        const to = resolve(pluginRoot, item);
+        if (!(to + sep).startsWith(pluginRootWithSep)) continue;
+        if (!(from + sep).startsWith(srcDirWithSep)) continue;
         try {
-          rmSync(resolve(pluginRoot, item), { recursive: true, force: true });
-          cpSync(resolve(srcDir, item), resolve(pluginRoot, item), { recursive: true });
+          rmSync(to, { recursive: true, force: true });
+          cpSync(from, to, { recursive: true });
         } catch { /* some files may not exist in source */ }
       }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1525,19 +1525,33 @@ async function upgrade(opts?: { platform?: string }) {
       // Issue #460 round-3: honor $CLAUDE_CONFIG_DIR so the registry lookup
       // tracks relocated CC config trees.
       try {
-        const registryPath = resolve(resolveClaudeConfigDir(), "plugins", "installed_plugins.json");
+        const claudeRoot = resolveClaudeConfigDir();
+        const registryPath = resolve(claudeRoot, "plugins", "installed_plugins.json");
         if (existsSync(registryPath)) {
+          // The registry's installPath fields are written by Claude Code under
+          // <claudeRoot>/plugins/cache/<marketplace>/<plugin>/<version>. Any other
+          // shape means the registry has been tampered with by a co-resident
+          // plugin, a malicious postinstall script, or another local actor.
+          // Without containment, cpSync would happily recursive-write the in-repo
+          // skills/ tree to /etc/skills, ~/.ssh/skills, or wherever the attacker
+          // pointed. server.ts:790 (healCacheMidSession) already gates the same
+          // field this way; the symmetric guard belongs here too.
+          const cacheRoot = resolve(claudeRoot, "plugins", "cache");
+          const cacheRootWithSep = cacheRoot + sep;
           const registry = JSON.parse(readFileSync(registryPath, "utf-8"));
           const entries = registry?.plugins?.["context-mode@context-mode"];
           if (Array.isArray(entries)) {
             for (const entry of entries) {
-              const installPath = entry.installPath;
-              if (installPath && installPath !== pluginRoot && existsSync(installPath)) {
-                const srcSkills = resolve(srcDir, "skills");
-                if (existsSync(srcSkills)) {
-                  cpSync(srcSkills, resolve(installPath, "skills"), { recursive: true });
-                  changes.push(`Synced skills to active install path`);
-                }
+              const installPath = entry?.installPath;
+              if (typeof installPath !== "string" || !installPath) continue;
+              if (installPath === pluginRoot) continue;
+              const resolvedInstallPath = resolve(installPath);
+              if (!(resolvedInstallPath + sep).startsWith(cacheRootWithSep)) continue;
+              if (!existsSync(resolvedInstallPath)) continue;
+              const srcSkills = resolve(srcDir, "skills");
+              if (existsSync(srcSkills)) {
+                cpSync(srcSkills, resolve(resolvedInstallPath, "skills"), { recursive: true });
+                changes.push(`Synced skills to active install path`);
               }
             }
           }
@@ -1703,14 +1717,24 @@ function statuslineForward(): void {
   try {
     const registryPath = resolve(claudeRoot, "plugins", "installed_plugins.json");
     if (existsSync(registryPath)) {
+      // Same trust boundary as the cpSync site in upgrade() and as
+      // server.ts:790's healCacheMidSession: only honor installPath values
+      // that resolve under <claudeRoot>/plugins/cache. A stray /etc or
+      // ~/.ssh entry written by another local actor must not become the
+      // script the statusline forwarder imports, since statusline re-fires
+      // several times per second and would hand the attacker durable RCE
+      // on the user's behalf.
+      const cacheRoot = resolve(claudeRoot, "plugins", "cache");
+      const cacheRootWithSep = cacheRoot + sep;
       const registry = JSON.parse(readFileSync(registryPath, "utf-8"));
       const entries = registry?.plugins?.["context-mode@context-mode"];
       if (Array.isArray(entries)) {
         for (const entry of entries) {
           const installPath = entry?.installPath;
-          if (typeof installPath === "string" && installPath) {
-            candidates.push(resolve(installPath, "bin", "statusline.mjs"));
-          }
+          if (typeof installPath !== "string" || !installPath) continue;
+          const resolvedInstallPath = resolve(installPath);
+          if (!(resolvedInstallPath + sep).startsWith(cacheRootWithSep)) continue;
+          candidates.push(resolve(resolvedInstallPath, "bin", "statusline.mjs"));
         }
       }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3879,7 +3879,7 @@ server.registerTool(
       // across cmd.exe, PowerShell, and bash (node -e '...' breaks on Windows).
       const scriptLines = [
         `import{execFileSync}from"node:child_process";`,
-        `import{cpSync,rmSync,existsSync,mkdtempSync,readFileSync,writeFileSync}from"node:fs";`,
+        `import{cpSync,rmSync,existsSync,mkdtempSync,readFileSync,writeFileSync,lstatSync}from"node:fs";`,
         `import{join,resolve,sep}from"node:path";`,
         `import{tmpdir}from"node:os";`,
         `const P=${JSON.stringify(pluginRoot)};`,
@@ -3897,9 +3897,14 @@ server.registerTool(
         // guard: a compromised upstream package.json with files:["../etc"]
         // would otherwise let path.join follow ".." out of pluginRoot.
         // path.resolve normalizes "..", so the lexical startsWith catches
-        // both relative-".." traversal and absolute-path bypass.
+        // both relative-".." traversal and absolute-path bypass. Plus a
+        // symlink filter so a committed symlink inside the clone can't
+        // plant itself in pluginRoot (cpSync default preserves source
+        // symlinks; a planted symlink in pluginRoot/src then redirects
+        // every subsequent load through to an attacker target).
         `const PW=resolve(P)+sep;const TW=resolve(T)+sep;`,
-        `for(const item of items){const from=resolve(T,item);const to=resolve(P,item);if(!(to+sep).startsWith(PW))continue;if(!(from+sep).startsWith(TW))continue;if(existsSync(from)){rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true,force:true});}}`,
+        `const noSymlink=(src)=>{try{return !lstatSync(src).isSymbolicLink()}catch{return false}};`,
+        `for(const item of items){const from=resolve(T,item);const to=resolve(P,item);if(!(to+sep).startsWith(PW))continue;if(!(from+sep).startsWith(TW))continue;if(!noSymlink(from))continue;if(existsSync(from)){rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true,force:true,filter:noSymlink});}}`,
         // Issue #609: do NOT write .mcp.json into the cache dir. Claude Code reads
         // .claude-plugin/plugin.json.mcpServers as the canonical MCP source — the
         // per-version .mcp.json file is a stale-write vector. Same architectural

--- a/src/server.ts
+++ b/src/server.ts
@@ -911,8 +911,22 @@ let _lifetimeCache: { tokens: number; computedAt: number } | undefined;
  * (`pid-<parent pid>`), so a status line script can derive
  * the same id from `$PPID` without coupling to MCP.
  */
+// CLAUDE_SESSION_ID flows from the hosting process (Claude Code, pi, etc.)
+// straight into a path.join, and path.join collapses ".." into the result,
+// so a host env CLAUDE_SESSION_ID=../../evil writes "stats-evil.json" two
+// levels above statsDir. The env var is not under direct MCP-tool-caller
+// control, but in CI / multi-tenant contexts where the host env is partly
+// influenceable this is an arbitrary-write primitive within the MCP server
+// process's filesystem permissions. Constrain to a UUID-shaped charset
+// before splicing into the stats filename.
+const SESSION_ID_RE = /^[A-Za-z0-9._-]+$/;
+function sanitizeSessionId(raw: string): string {
+  return SESSION_ID_RE.test(raw) ? raw : `pid-${process.ppid}`;
+}
+
 function getStatsFilePath(): string {
-  const sessionId = process.env.CLAUDE_SESSION_ID || `pid-${process.ppid}`;
+  const raw = process.env.CLAUDE_SESSION_ID || `pid-${process.ppid}`;
+  const sessionId = sanitizeSessionId(raw);
   const statsDir = ensureWritableStorageDir(resolveStatsStorageDir(getDefaultSessionDir));
   return join(statsDir, `stats-${sessionId}.json`);
 }
@@ -2710,6 +2724,25 @@ async function fetchWithManualRedirect(initialUrl) {
   throw new Error('SSRF blocked: redirect chain exceeded ' + MAX_REDIRECTS + ' hops');
 }
 
+// Subprocess response-body size cap. A malicious or unexpectedly large
+// endpoint reachable through ctx_fetch_and_index would otherwise stream
+// gigabytes into resp.text(), then into outputPath, then into the parent
+// MCP server's heap via readFileSync. 50 MB is far above typical web
+// page / API response sizes (~1-5 MB) but bounded enough to keep parent
+// heap survivable. Cap both early via Content-Length and after the read.
+const MAX_FETCH_BYTES = 50 * 1024 * 1024;
+async function safeText(resp) {
+  const cl = parseInt(resp.headers.get('content-length') || '0', 10);
+  if (cl > MAX_FETCH_BYTES) {
+    throw new Error('Response too large: Content-Length ' + cl + ' exceeds ' + MAX_FETCH_BYTES);
+  }
+  const text = await resp.text();
+  if (text.length > MAX_FETCH_BYTES) {
+    throw new Error('Response too large: ' + text.length + ' bytes exceeds ' + MAX_FETCH_BYTES);
+  }
+  return text;
+}
+
 async function main() {
   const resp = await fetchWithManualRedirect(url);
   if (!resp.ok) { console.error("HTTP " + resp.status); process.exit(1); }
@@ -2717,7 +2750,7 @@ async function main() {
 
   // --- JSON responses ---
   if (contentType.includes('application/json') || contentType.includes('+json')) {
-    const text = await resp.text();
+    const text = await safeText(resp);
     try {
       const pretty = JSON.stringify(JSON.parse(text), null, 2);
       emit('json', pretty);
@@ -2729,7 +2762,7 @@ async function main() {
 
   // --- HTML responses (default for text/html, application/xhtml+xml) ---
   if (contentType.includes('text/html') || contentType.includes('application/xhtml')) {
-    const html = await resp.text();
+    const html = await safeText(resp);
     const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
     td.use(gfm);
     td.remove(['script', 'style', 'nav', 'header', 'footer', 'noscript']);
@@ -2738,7 +2771,7 @@ async function main() {
   }
 
   // --- Everything else: plain text, CSV, XML, etc. ---
-  const text = await resp.text();
+  const text = await safeText(resp);
   emit('text', text);
 }
 main();
@@ -2973,6 +3006,16 @@ async function fetchOneUrl(url: string, source: string | undefined, force: boole
     const header = (result.stdout || "").trim();
     let markdown: string;
     try {
+      // Parent-side defense-in-depth on the subprocess output size. The
+      // embedded safeText() in buildFetchCode already caps before writing,
+      // but a torn write (subprocess killed mid-write, fs cache desync,
+      // etc.) could still leave an oversized file. Bail before slurping
+      // multiple gigabytes into the long-running MCP server's heap.
+      const MAX_FETCH_OUTPUT_BYTES = 50 * 1024 * 1024;
+      const fileSize = statSync(outputPath).size;
+      if (fileSize > MAX_FETCH_OUTPUT_BYTES) {
+        return { kind: "fetch_error", url, error: `subprocess output ${fileSize} bytes exceeds cap ${MAX_FETCH_OUTPUT_BYTES}`, reason: "read" };
+      }
       markdown = readFileSync(outputPath, "utf-8").trim();
     } catch {
       return { kind: "fetch_error", url, error: "could not read subprocess output", reason: "read" };

--- a/src/server.ts
+++ b/src/server.ts
@@ -3810,7 +3810,7 @@ server.registerTool(
       const scriptLines = [
         `import{execFileSync}from"node:child_process";`,
         `import{cpSync,rmSync,existsSync,mkdtempSync,readFileSync,writeFileSync}from"node:fs";`,
-        `import{join}from"node:path";`,
+        `import{join,resolve,sep}from"node:path";`,
         `import{tmpdir}from"node:os";`,
         `const P=${JSON.stringify(pluginRoot)};`,
         `const T=mkdtempSync(join(tmpdir(),"ctx-upgrade-"));`,
@@ -3823,7 +3823,13 @@ server.registerTool(
         `console.log("- [x] Built from source");`,
         `const pkg=JSON.parse(readFileSync(join(T,"package.json"),"utf8"));`,
         `const items=[...(Array.isArray(pkg.files)?pkg.files:[]),"src","package.json"];`,
-        `for(const item of items){const from=join(T,item);const to=join(P,item);if(existsSync(from)){rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true,force:true});}}`,
+        // Supply-chain containment on items[]. Mirror the cli.ts upgrade()
+        // guard: a compromised upstream package.json with files:["../etc"]
+        // would otherwise let path.join follow ".." out of pluginRoot.
+        // path.resolve normalizes "..", so the lexical startsWith catches
+        // both relative-".." traversal and absolute-path bypass.
+        `const PW=resolve(P)+sep;const TW=resolve(T)+sep;`,
+        `for(const item of items){const from=resolve(T,item);const to=resolve(P,item);if(!(to+sep).startsWith(PW))continue;if(!(from+sep).startsWith(TW))continue;if(existsSync(from)){rmSync(to,{recursive:true,force:true});cpSync(from,to,{recursive:true,force:true});}}`,
         // Issue #609: do NOT write .mcp.json into the cache dir. Claude Code reads
         // .claude-plugin/plugin.json.mcpServers as the canonical MCP source — the
         // per-version .mcp.json file is a stale-write vector. Same architectural

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createRequire } from "node:module";
-import { existsSync, unlinkSync, readdirSync, readFileSync, writeFileSync, renameSync, rmSync, mkdirSync, cpSync, statSync, symlinkSync, lstatSync } from "node:fs";
+import { existsSync, unlinkSync, readdirSync, readFileSync, writeFileSync, renameSync, rmSync, mkdirSync, cpSync, statSync, symlinkSync, lstatSync, realpathSync } from "node:fs";
 import { execSync, spawnSync, type ChildProcess, type SpawnSyncOptions, type SpawnSyncReturns } from "node:child_process";
 import { join, dirname, resolve, sep, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -2045,6 +2045,33 @@ EXAMPLE: ctx_index(path: "/path/to/large-spec.md", source: "openapi-v2-spec")`,
       // resolved path is a directory, walk it bounded and re-enter `index()`
       // per-file so the security gate at store.ts:845 (TOCTOU defense from
       // #442 round-3) keeps running for every file.
+      //
+      // Root-level symlink defense: the deny-glob check above ran on the
+      // user-supplied `path`. If `path` is a symlink whose target lands in
+      // a sensitive directory (e.g. `/tmp/link -> /etc`), statSync would
+      // happily report directory and walkDirectoryDetailed would
+      // realpathSync internally, walking /etc with the user's deny globs
+      // bound to /tmp/link instead of the real target. Detect the symlink
+      // with lstatSync, follow it once, and re-apply the deny check
+      // against the realpath so the user's deny globs see the actual
+      // walk root.
+      if (resolvedPath && existsSync(resolvedPath)) {
+        const lst = lstatSync(resolvedPath);
+        if (lst.isSymbolicLink()) {
+          let realTarget: string;
+          try {
+            realTarget = realpathSync(resolvedPath);
+          } catch {
+            return trackResponse("ctx_index", {
+              content: [{ type: "text" as const, text: "Error: symlink target could not be resolved." }],
+            });
+          }
+          if (realTarget !== resolvedPath) {
+            const realDenied = checkFilePathDenyPolicy(realTarget, "ctx_index");
+            if (realDenied) return realDenied;
+          }
+        }
+      }
       if (resolvedPath && existsSync(resolvedPath) && statSync(resolvedPath).isDirectory()) {
         const store = getStore();
         const projectDir = getProjectDir();

--- a/src/server.ts
+++ b/src/server.ts
@@ -4289,6 +4289,40 @@ server.registerTool(
     const insightContentDirResolved = explicitContentDir ? resolve(explicitContentDir) : join(dirname(sessDir), "content");
     const cacheDir = join(dirname(sessDir), "insight-cache");
 
+    // Confused-deputy guard on explicit overrides. The spawned insight
+    // server reads every .db file under sessDir and insightContentDir, and
+    // its /api/content DELETE endpoint can rewrite hex-named .db files in
+    // those trees. A prompt-injected caller passing sessionDir="~/.ssh"
+    // or contentDir="~/.gnupg" would otherwise let the dashboard
+    // enumerate (and, for hex-named SQLite files, mutate rows in) those
+    // directories. Contain explicit overrides to the adapter's config
+    // root: broad enough for the documented "multi-install setups or
+    // pointing at a sibling project's data" use case, narrow enough to
+    // block /etc, ~/.ssh, /tmp/<foreign-user>, etc.
+    if (explicitSessionDir || explicitContentDir) {
+      const defaultSessDir = getSessionDir();
+      const containmentRoot = dirname(dirname(defaultSessDir));
+      const containmentRootWithSep = resolve(containmentRoot) + sep;
+      const isContained = (dir: string): boolean =>
+        (resolve(dir) + sep).startsWith(containmentRootWithSep);
+      if (explicitSessionDir && !isContained(sessDir)) {
+        return trackResponse("ctx_insight", {
+          content: [{
+            type: "text" as const,
+            text: `Error: sessionDir must resolve under ${containmentRoot} (got ${sessDir}).`,
+          }],
+        });
+      }
+      if (explicitContentDir && !isContained(insightContentDirResolved)) {
+        return trackResponse("ctx_insight", {
+          content: [{
+            type: "text" as const,
+            text: `Error: contentDir must resolve under ${containmentRoot} (got ${insightContentDirResolved}).`,
+          }],
+        });
+      }
+    }
+
     // Verify source exists
     if (!existsSync(join(insightSource, "server.mjs"))) {
       return trackResponse("ctx_insight", {

--- a/tests/adapters/cursor.test.ts
+++ b/tests/adapters/cursor.test.ts
@@ -213,10 +213,13 @@ describe("CursorAdapter", () => {
 
     afterEach(() => {
       rmSync(tempDir, { recursive: true, force: true });
-      try { rmSync(resolve(".cursor", "mcp.json"), { force: true }); } catch { /* best effort */ }
-      if (!projectCursorDirExisted) {
-        try { rmSync(resolve(".cursor"), { recursive: true, force: true }); } catch { /* best effort */ }
-      }
+      // Pre-fix this rmSync targeted resolve(".cursor", "mcp.json") in
+      // the contributor's real repo root (process.cwd()). Tests that
+      // write that path now chdir into tempDir for the write, so the
+      // file we need to remove also lives inside tempDir and is gone
+      // when the tempDir cleanup above fires. Nothing else to do.
+      void projectCursorDir;
+      void projectCursorDirExisted;
     });
 
     it("generates native Cursor hook entries for v1 hooks only", () => {
@@ -272,21 +275,32 @@ describe("CursorAdapter", () => {
     });
 
     it("detects Cursor MCP registration from project config", () => {
-      mkdirSync(resolve(".cursor"), { recursive: true });
-      writeFileSync(
-        resolve(".cursor", "mcp.json"),
-        JSON.stringify({
-          mcpServers: {
-            "context-mode": {
-              command: "context-mode",
+      // Pre-fix this test wrote .cursor/mcp.json to process.cwd() (the
+      // contributor's repo root). chdir into the per-test tempDir so the
+      // write lands in the sandbox. The adapter's checkPluginRegistration
+      // reads .cursor/mcp.json relative to cwd, so the same chdir lets
+      // the assertion see the test fixture.
+      const origCwd = process.cwd();
+      process.chdir(tempDir);
+      try {
+        mkdirSync(resolve(".cursor"), { recursive: true });
+        writeFileSync(
+          resolve(".cursor", "mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "context-mode": {
+                command: "context-mode",
+              },
             },
-          },
-        }, null, 2),
-      );
+          }, null, 2),
+        );
 
-      const result = adapter.checkPluginRegistration();
-      expect(result.status).toBe("pass");
-      expect(result.message).toContain(join(".cursor", "mcp.json"));
+        const result = adapter.checkPluginRegistration();
+        expect(result.status).toBe("pass");
+        expect(result.message).toContain(join(".cursor", "mcp.json"));
+      } finally {
+        process.chdir(origCwd);
+      }
     });
   });
 
@@ -385,19 +399,27 @@ describe("CursorAdapter", () => {
   // and resolves the self-contradiction where a plugin-only install could still
   // emit `MCP registration: warn` while `Plugin install: pass`.
   describe("cursor doctor — plugin install detection", () => {
-    let projectCursorDirExisted: boolean;
+    let tempDir: string;
+    let origCwd: string;
 
     beforeEach(() => {
       clearPluginRoots();
-      projectCursorDirExisted = existsSync(resolve(".cursor"));
+      // Same sandboxing as the "hook config management" block above: tests
+      // here writeFileSync(resolve(".cursor", "mcp.json"), ...) and the
+      // afterEach rmSync(force:true) would otherwise clobber the
+      // contributor's real .cursor/mcp.json. chdir into a tmpdir for the
+      // duration of each test so every resolve(".cursor", ...) below
+      // lands inside the sandbox.
+      tempDir = mkdtempSync(join(tmpdir(), "cursor-doctor-test-"));
+      origCwd = process.cwd();
+      process.chdir(tempDir);
     });
 
     afterEach(() => {
       clearPluginRoots();
-      try { rmSync(resolve(".cursor", "mcp.json"), { force: true }); } catch { /* best effort */ }
-      if (!projectCursorDirExisted) {
-        try { rmSync(resolve(".cursor"), { recursive: true, force: true }); } catch { /* best effort */ }
-      }
+      // Restore cwd BEFORE removing tempDir.
+      process.chdir(origCwd);
+      rmSync(tempDir, { recursive: true, force: true });
     });
 
     // Case A — clean machine. No plugin roots → empty array, no throw.

--- a/tests/cli/upgrade-mcp-json-assertion.test.ts
+++ b/tests/cli/upgrade-mcp-json-assertion.test.ts
@@ -39,7 +39,11 @@ const ROOT = resolve(__dirname, "..", "..");
 
 const cliSrc = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
 const upgradeIdx = cliSrc.indexOf("async function upgrade");
-const upgradeBody = cliSrc.slice(upgradeIdx, upgradeIdx + 16000);
+// The window must cover updatePluginRegistry + the post-bump sweep block.
+// Containment hardening can push sweepStaleMcpJson past a tighter slice;
+// 24000 bytes gives ~7.7 KB of headroom so future inserts inside upgrade()
+// do not silently shift the assertion off-window.
+const upgradeBody = cliSrc.slice(upgradeIdx, upgradeIdx + 24000);
 
 describe("cli.ts upgrade() — Issue #609 .mcp.json sweep assertion", () => {
   test("post-bump block invokes sweepStaleMcpJson from the shared module", () => {

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -2060,6 +2060,92 @@ describe("Upgrade syncs skills to active install path (#228)", () => {
   });
 });
 
+describe("installed_plugins.json installPath containment", () => {
+  // installed_plugins.json is written by Claude Code itself with installPath
+  // values under <claudeRoot>/plugins/cache/<marketplace>/<plugin>/<version>.
+  // Any installPath that resolves elsewhere has been tampered with by a co-
+  // resident plugin, a malicious postinstall, or another local actor. cli.ts
+  // consumes the field in two hot places: the upgrade() skills sync (cpSync
+  // into installPath) and statuslineForward() (dynamic import from
+  // installPath/bin/statusline.mjs, ~3-5 Hz while CC is open). Both sites
+  // need the same lexical guard that server.ts:790 already uses on the
+  // same field.
+
+  const CLI_SOURCE = readFileSync(resolve(ROOT, "src/cli.ts"), "utf-8");
+
+  test("upgrade() skills cpSync gates installPath under <claudeRoot>/plugins/cache", () => {
+    // Bound the slice to the upgrade() skills-sync block.
+    const upgradeStart = CLI_SOURCE.indexOf("async function upgrade");
+    expect(upgradeStart).toBeGreaterThan(0);
+    const skillsBlock = CLI_SOURCE
+      .slice(upgradeStart)
+      .match(/Sync skills to the active install path[\s\S]*?best effort — registry may not exist or be malformed/);
+    expect(skillsBlock).not.toBeNull();
+    expect(skillsBlock![0]).toContain('resolve(claudeRoot, "plugins", "cache")');
+    expect(skillsBlock![0]).toMatch(/\(resolvedInstallPath \+ sep\)\.startsWith\(cacheRootWithSep\)/);
+    // The pre-fix shape passed installPath verbatim to cpSync without
+    // normalizing or gating it.
+    expect(skillsBlock![0]).not.toMatch(
+      /cpSync\(srcSkills, resolve\(installPath, "skills"\),/,
+    );
+  });
+
+  test("statuslineForward() candidate selection gates installPath under <claudeRoot>/plugins/cache", () => {
+    // Slice to the statuslineForward() function body.
+    const statuslineStart = CLI_SOURCE.indexOf("statuslineForward");
+    expect(statuslineStart).toBeGreaterThan(0);
+    const tail = CLI_SOURCE.slice(statuslineStart);
+    // The candidate-building block runs between the candidates[] declaration
+    // and the candidates.find() that picks the script to import.
+    const candidateBlock = tail.match(
+      /candidates: string\[\] = \[[\s\S]*?candidates\.find\(/,
+    );
+    expect(candidateBlock).not.toBeNull();
+    expect(candidateBlock![0]).toContain('resolve(claudeRoot, "plugins", "cache")');
+    expect(candidateBlock![0]).toMatch(/\(resolvedInstallPath \+ sep\)\.startsWith\(cacheRootWithSep\)/);
+    // The pre-fix shape pushed any installPath string into candidates without
+    // gating it.
+    expect(candidateBlock![0]).not.toMatch(
+      /candidates\.push\(resolve\(installPath, "bin", "statusline\.mjs"\)\)/,
+    );
+  });
+
+  test("algorithm: containment rejects installPath values outside the cache root", async () => {
+    // Sandbox a fake <claudeRoot> tree with a cache dir holding one
+    // legitimate plugin entry, plus a malicious entry pointing at an
+    // attacker-chosen directory outside the cache. Replay the production
+    // guard; assert only the legitimate entry survives.
+    const claudeRoot = mkdtempSync(join(tmpdir(), "installpath-containment-"));
+    try {
+      const cacheRoot = resolve(claudeRoot, "plugins", "cache");
+      const legitCacheDir = resolve(cacheRoot, "context-mode", "context-mode", "1.0.0");
+      const attackerDir = resolve(claudeRoot, "outside-cache", "evil");
+      mkdirSync(legitCacheDir, { recursive: true });
+      mkdirSync(attackerDir, { recursive: true });
+
+      const { sep } = await import("node:path");
+      const cacheRootWithSep = cacheRoot + sep;
+      const inputs = [
+        { installPath: legitCacheDir, label: "legit" },
+        { installPath: attackerDir, label: "outside-cache" },
+        { installPath: "/etc", label: "absolute-system" },
+        // Relative-".." escape: legitimate prefix then ".." up and out.
+        { installPath: join(legitCacheDir, "..", "..", "..", "..", "outside-cache", "evil"), label: "traversal" },
+      ];
+      const accepted: string[] = [];
+      for (const { installPath, label } of inputs) {
+        if (typeof installPath !== "string" || !installPath) continue;
+        const resolvedInstallPath = resolve(installPath);
+        if (!(resolvedInstallPath + sep).startsWith(cacheRootWithSep)) continue;
+        accepted.push(label);
+      }
+      expect(accepted).toEqual(["legit"]);
+    } finally {
+      rmSync(claudeRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 // ── better-sqlite3 binding self-heal (#408) ───────────────────────────────
 //
 // On Windows, `npm rebuild better-sqlite3` falls through to node-gyp when

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -1657,6 +1657,16 @@ describe("ctx-upgrade swap loop supply-chain containment", () => {
     expect(CLI_SOURCE).toMatch(
       /import\s*\{[^}]*\bsep\b[^}]*\}\s*from\s*"node:path"/,
     );
+    // F30 hardening: symlinks inside source items must be filtered, not
+    // copied as destination symlinks. A planted symlink would otherwise
+    // bypass the lexical containment at copy time.
+    expect(loopBlock![0]).toContain("refuseSymlinks");
+    expect(loopBlock![0]).toMatch(/lstatSync\(src\)\.isSymbolicLink\(\)/);
+    expect(loopBlock![0]).toMatch(/cpSync\(from, to, \{ recursive: true, filter: refuseSymlinks \}\)/);
+    // lstatSync must be imported from node:fs.
+    expect(CLI_SOURCE).toMatch(
+      /import\s*\{[^}]*\blstatSync\b[^}]*\}\s*from\s*"node:fs"/,
+    );
   });
 
   test("server.ts inline-fallback upgrade script rejects swap-loop items that escape pluginRoot or srcDir", () => {
@@ -1671,6 +1681,13 @@ describe("ctx-upgrade swap loop supply-chain containment", () => {
     expect(SERVER_SOURCE).not.toMatch(
       /for\(const item of items\)\{const from=join\(T,item\);const to=join\(P,item\);if\(existsSync\(from\)\)/,
     );
+    // F30 hardening for the inline script.
+    expect(SERVER_SOURCE).toMatch(
+      /import\{[^}]*\blstatSync\b[^}]*\}from"node:fs"/,
+    );
+    expect(SERVER_SOURCE).toContain('const noSymlink=(src)=>{try{return !lstatSync(src).isSymbolicLink()}catch{return false}};');
+    expect(SERVER_SOURCE).toContain("if(!noSymlink(from))continue;");
+    expect(SERVER_SOURCE).toContain("filter:noSymlink");
   });
 
   test("algorithm: lexical containment guard rejects relative and absolute traversal items", async () => {
@@ -2097,6 +2114,13 @@ describe("installed_plugins.json installPath containment", () => {
     expect(skillsBlock![0]).not.toMatch(
       /cpSync\(srcSkills, resolve\(installPath, "skills"\),/,
     );
+    // F30 hardening: realpathSync re-check defeats symlink-anchor bypasses
+    // where the cacheRoot-anchored installPath is itself a symlink to an
+    // attacker target.
+    expect(skillsBlock![0]).toMatch(/realpathSync\(cacheRoot\)/);
+    expect(skillsBlock![0]).toMatch(/realpathSync\(resolvedInstallPath\)/);
+    expect(skillsBlock![0]).toMatch(/\(realInstallPath \+ sep\)\.startsWith\(cacheRootWithSep\)/);
+    expect(skillsBlock![0]).toMatch(/cpSync\(srcSkills, resolve\(realInstallPath, "skills"\)/);
   });
 
   test("statuslineForward() candidate selection gates installPath under <claudeRoot>/plugins/cache", () => {
@@ -2117,6 +2141,72 @@ describe("installed_plugins.json installPath containment", () => {
     expect(candidateBlock![0]).not.toMatch(
       /candidates\.push\(resolve\(installPath, "bin", "statusline\.mjs"\)\)/,
     );
+    // F30 hardening: realpathSync re-check on the candidate's installPath.
+    expect(candidateBlock![0]).toMatch(/realpathSync\(cacheRoot\)/);
+    expect(candidateBlock![0]).toMatch(/realpathSync\(resolvedInstallPath\)/);
+    expect(candidateBlock![0]).toMatch(/\(realInstallPath \+ sep\)\.startsWith\(cacheRootWithSep\)/);
+    expect(candidateBlock![0]).toMatch(/candidates\.push\(resolve\(realInstallPath, "bin", "statusline\.mjs"\)\)/);
+    // realpathSync must be imported from node:fs.
+    expect(CLI_SOURCE).toMatch(
+      /import\s*\{[^}]*\brealpathSync\b[^}]*\}\s*from\s*"node:fs"/,
+    );
+  });
+
+  test("algorithm: realpath re-check rejects symlink-anchor planted at cacheRoot/<owner>/<plugin>/<version>", async () => {
+    // Sandbox: build <fakeClaudeRoot>/plugins/cache/owner/plugin/version
+    // as a SYMLINK targeting an attacker-controlled directory outside
+    // cacheRoot. The lexical resolve+startsWith check passes (the symlink
+    // path itself is under cacheRoot). realpathSync follows the link and
+    // returns the attacker target -- which then fails the post-realpath
+    // startsWith gate.
+    const fs = await import("node:fs");
+    // Canonicalize the base directory up front: on macOS, mkdtempSync(tmpdir())
+    // returns a path under /var/folders, which is itself a symlink to
+    // /private/var/folders. Without realpathSync here, the legit-installPath
+    // arm below trips the lexical startsWith gate (resolved input still
+    // /var/folders/..., cacheRootCanon is /private/var/folders/...). Same
+    // canonicalization production users get when ~/.claude lives on a real
+    // (non-symlinked) path.
+    const base = fs.realpathSync(
+      mkdtempSync(join(tmpdir(), "installpath-symlink-anchor-")),
+    );
+    try {
+      const cacheRoot = resolve(base, ".claude", "plugins", "cache");
+      const legitVersionDir = resolve(cacheRoot, "owner", "plugin", "1.0.0");
+      const attackerDir = resolve(base, "attacker-target");
+      mkdirSync(legitVersionDir, { recursive: true });
+      mkdirSync(attackerDir, { recursive: true });
+      writeFileSync(join(attackerDir, "marker.txt"), "PWNED");
+
+      // Planted symlink anchor: <cacheRoot>/owner/plugin/2.0.0 -> attackerDir.
+      // On Windows without symlink privilege / Developer Mode, symlinkSync
+      // with type "dir" fails with EPERM; "junction" works without privilege
+      // and still reports isSymbolicLink()===true under lstatSync.
+      const plantedAnchor = resolve(cacheRoot, "owner", "plugin", "2.0.0");
+      const symlinkType = process.platform === "win32" ? "junction" : "dir";
+      fs.symlinkSync(attackerDir, plantedAnchor, symlinkType);
+
+      const cacheRootCanon = fs.realpathSync(cacheRoot);
+      const cacheRootWithSep = cacheRootCanon + require("node:path").sep;
+
+      const isAccepted = (installPath: string): boolean => {
+        const resolvedInstallPath = resolve(installPath);
+        if (!(resolvedInstallPath + require("node:path").sep).startsWith(cacheRootWithSep)) return false;
+        let realInstallPath: string;
+        try { realInstallPath = fs.realpathSync(resolvedInstallPath); }
+        catch { return false; }
+        return (realInstallPath + require("node:path").sep).startsWith(cacheRootWithSep);
+      };
+
+      // Legit version dir: accepted.
+      expect(isAccepted(legitVersionDir)).toBe(true);
+      // Symlink anchor: lexical passes, realpath escapes -> rejected.
+      expect(isAccepted(plantedAnchor)).toBe(false);
+      // Direct attacker path: lexical rejects immediately.
+      expect(isAccepted(attackerDir)).toBe(false);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
   });
 
   test("algorithm: containment rejects installPath values outside the cache root", async () => {

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -190,7 +190,9 @@ describe(".mcp.json — MCP server config", () => {
       /sweepStaleMcpJson[^;]*from\s+["']\.\.\/scripts\/heal-installed-plugins\.mjs["']/,
     );
     const upgradeStart = src.indexOf("async function upgrade");
-    const upgradeSrc = src.slice(upgradeStart, upgradeStart + 16000);
+    // Slice the whole upgrade region rather than a fixed-width window so
+    // pattern lookups stay valid as the function grows under feature work.
+    const upgradeSrc = src.slice(upgradeStart);
     // Order constraint: sweep runs AFTER updatePluginRegistry so the
     // cleanup operates against the final on-disk shape.
     const updateIdx = upgradeSrc.indexOf("updatePluginRegistry");
@@ -1530,7 +1532,9 @@ describe("Cache dir safety (#181)", () => {
 describe("statuslineForward survives stale getPluginRoot() (post-upgrade)", () => {
   const CLI_SOURCE = readFileSync(resolve(ROOT, "src/cli.ts"), "utf-8");
   const fnStart = CLI_SOURCE.indexOf("function statuslineForward");
-  const fnBody = CLI_SOURCE.slice(fnStart, fnStart + 2000);
+  // Slice through end-of-file rather than a fixed-width window so pattern
+  // lookups stay valid as the function picks up defensive checks.
+  const fnBody = CLI_SOURCE.slice(fnStart);
 
   test("statuslineForward falls back to the marketplace clone path", () => {
     // After ctx-upgrade, the running CLI binary may live in a cache dir that
@@ -2039,8 +2043,13 @@ describe("Upgrade syncs skills to active install path (#228)", () => {
   });
 
   test("upgrade only syncs when installPath differs from pluginRoot", () => {
-    // Must check installPath !== pluginRoot before copying
-    expect(upgradeBody).toMatch(/installPath.*!==.*pluginRoot|installPath\s*&&\s*installPath\s*!==\s*pluginRoot/);
+    // Must short-circuit when installPath === pluginRoot before copying.
+    // Accept either the original `installPath !== pluginRoot` conjunction
+    // form OR the refactored early-continue form (`if (installPath ===
+    // pluginRoot) continue;`).
+    expect(upgradeBody).toMatch(
+      /installPath.*!==.*pluginRoot|installPath\s*===\s*pluginRoot/,
+    );
   });
 
   test("upgrade does NOT blindly copy to marketplace or cache directories", () => {

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -1623,6 +1623,99 @@ describe("ctx-upgrade syncs marketplace clone (#418)", () => {
   });
 });
 
+describe("ctx-upgrade swap loop supply-chain containment", () => {
+  const CLI_SOURCE = readFileSync(resolve(ROOT, "src/cli.ts"), "utf-8");
+  const SERVER_SOURCE = readFileSync(resolve(ROOT, "src/server.ts"), "utf-8");
+
+  // Both /ctx-upgrade swap loops iterate `pkg.files[]` read from a freshly
+  // cloned upstream package.json. Without containment, a compromised
+  // upstream tag shipping files: ["../../.ssh/authorized_keys"] (or, at
+  // the cli.ts site, an absolute path) would let rmSync+cpSync escape
+  // pluginRoot. Mirrors the lexical guard pattern that
+  // hooks/heal-partial-install.mjs already uses (PR #699).
+
+  test("cli.ts upgrade() rejects swap-loop items that escape pluginRoot or srcDir", () => {
+    // The block of interest is bounded by the comment about reading
+    // files from the cloned package.json and the next Issue #609 marker.
+    const loopBlock = CLI_SOURCE.match(
+      /Read files list from cloned repo's package\.json[\s\S]*?Issue #609/,
+    );
+    expect(loopBlock).not.toBeNull();
+    expect(loopBlock![0]).toContain("resolve(pluginRoot) + sep");
+    expect(loopBlock![0]).toContain("resolve(srcDir) + sep");
+    expect(loopBlock![0]).toMatch(/\(to \+ sep\)\.startsWith\(pluginRootWithSep\)/);
+    expect(loopBlock![0]).toMatch(/\(from \+ sep\)\.startsWith\(srcDirWithSep\)/);
+    // The pre-fix unguarded form must not return.
+    expect(loopBlock![0]).not.toMatch(
+      /rmSync\(resolve\(pluginRoot, item\),[^)]*\);\s*\n\s*cpSync\(resolve\(srcDir, item\)/,
+    );
+    // sep must be imported from node:path.
+    expect(CLI_SOURCE).toMatch(
+      /import\s*\{[^}]*\bsep\b[^}]*\}\s*from\s*"node:path"/,
+    );
+  });
+
+  test("server.ts inline-fallback upgrade script rejects swap-loop items that escape pluginRoot or srcDir", () => {
+    // The inline-script lines are literal-string template segments inside
+    // the ctx_upgrade handler's scriptLines array, so the guards land as
+    // quoted lines in src/server.ts.
+    expect(SERVER_SOURCE).toContain('import{join,resolve,sep}from"node:path"');
+    expect(SERVER_SOURCE).toContain("const PW=resolve(P)+sep;const TW=resolve(T)+sep;");
+    expect(SERVER_SOURCE).toContain("if(!(to+sep).startsWith(PW))continue;");
+    expect(SERVER_SOURCE).toContain("if(!(from+sep).startsWith(TW))continue;");
+    // The pre-fix unguarded join-only form must not return.
+    expect(SERVER_SOURCE).not.toMatch(
+      /for\(const item of items\)\{const from=join\(T,item\);const to=join\(P,item\);if\(existsSync\(from\)\)/,
+    );
+  });
+
+  test("algorithm: lexical containment guard rejects relative and absolute traversal items", async () => {
+    // Sandbox replay of the guard logic. Two trees: pluginRoot/ and
+    // srcDir/. Plant a victim file at base/OUTSIDE/victim.txt and an
+    // absolute-path probe at base/etc/passwd. Run the same guard the
+    // production swap loop uses; assert the malicious items are skipped
+    // and the legitimate item is the only one accepted.
+    const base = mkdtempSync(join(tmpdir(), "swap-loop-containment-"));
+    try {
+      const pluginRoot = join(base, "plugin", "root");
+      const srcDir = join(base, "src", "dir");
+      const outside = join(base, "OUTSIDE");
+      const etc = join(base, "etc");
+      mkdirSync(pluginRoot, { recursive: true });
+      mkdirSync(srcDir, { recursive: true });
+      mkdirSync(outside, { recursive: true });
+      mkdirSync(etc, { recursive: true });
+      writeFileSync(join(outside, "victim.txt"), "ATTACKER_WOULD_DELETE_ME");
+      writeFileSync(join(etc, "passwd"), "PRETEND_PASSWD");
+      mkdirSync(join(srcDir, "src"), { recursive: true });
+      writeFileSync(join(srcDir, "src", "index.ts"), "ok");
+
+      const { sep } = await import("node:path");
+      const pluginRootWithSep = resolve(pluginRoot) + sep;
+      const srcDirWithSep = resolve(srcDir) + sep;
+      const items = [
+        "../../OUTSIDE/victim.txt", // relative traversal
+        join(etc, "passwd"),         // absolute-path bypass
+        "src",                       // legitimate
+      ];
+      const accepted: string[] = [];
+      for (const item of items) {
+        const from = resolve(srcDir, item);
+        const to = resolve(pluginRoot, item);
+        if (!(to + sep).startsWith(pluginRootWithSep)) continue;
+        if (!(from + sep).startsWith(srcDirWithSep)) continue;
+        accepted.push(item);
+      }
+      expect(accepted).toEqual(["src"]);
+      // Victim files must remain untouched.
+      expect(existsSync(join(outside, "victim.txt"))).toBe(true);
+      expect(existsSync(join(etc, "passwd"))).toBe(true);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("Shell-free upgrade (#185)", () => {
   const CLI_SOURCE = readFileSync(resolve(ROOT, "src/cli.ts"), "utf-8");
   const SERVER_SOURCE = readFileSync(resolve(ROOT, "src/server.ts"), "utf-8");

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -2442,7 +2442,12 @@ describe("ctx_upgrade tool: inline fallback for missing CLI", () => {
     expect(serverSrc).toContain('readFileSync(join(T,"package.json"),"utf8")');
     expect(serverSrc).toContain("pkg.files");
     expect(serverSrc).toContain("Array.isArray(pkg.files)");
-    expect(serverSrc).toContain("cpSync(from,to,{recursive:true,force:true})");
+    // The inline cpSync passes `filter:noSymlink` to refuse copying symlinks
+    // back into the plugin tree. Anchor on this shape so future drift toward
+    // the unfiltered form is caught.
+    expect(serverSrc).toContain(
+      "cpSync(from,to,{recursive:true,force:true,filter:noSymlink})",
+    );
     expect(serverSrc).toMatch(/npm.*install/);
   });
 

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -1870,6 +1870,84 @@ describe("ctx_insight: port schema rejects invalid values (#441)", () => {
   }, 20_000);
 });
 
+describe("ctx_insight: explicit sessionDir/contentDir containment", () => {
+  // The handler resolves sessionDir / contentDir overrides and passes them
+  // to the spawned insight server as INSIGHT_SESSION_DIR / INSIGHT_CONTENT_DIR.
+  // The server then enumerates every *.db file in those dirs (info disclosure)
+  // and, for hex-named files, can DELETE rows via /api/content. Without
+  // containment, a prompt-injected MCP caller passing sessionDir="/etc" or
+  // contentDir="~/.ssh" turns the dashboard into a confused-deputy
+  // enumerator over the user's filesystem. The fix gates explicit overrides
+  // against the adapter's config root: broad enough for the documented
+  // "multi-install setups or pointing at a sibling project's data" use case,
+  // narrow enough to block /etc, ~/.ssh, /tmp/<foreign-user>, etc.
+
+  const SERVER_SOURCE = readFileSync(
+    resolve(__dirname, "../../src/server.ts"),
+    "utf-8",
+  );
+
+  test("ctx_insight handler rejects explicit overrides outside the containment root", () => {
+    // Slice to the ctx_insight handler body. Bounded by the registerTool
+    // call for "ctx_insight" and the next "// ── " section divider that
+    // closes the handler.
+    const handlerStart = SERVER_SOURCE.indexOf('server.registerTool(\n  "ctx_insight"');
+    expect(handlerStart).toBeGreaterThan(0);
+    const handlerSlice = SERVER_SOURCE.slice(handlerStart, handlerStart + 12000);
+    expect(handlerSlice).toContain("Confused-deputy guard on explicit overrides");
+    expect(handlerSlice).toMatch(
+      /if \(explicitSessionDir \|\| explicitContentDir\) \{/,
+    );
+    expect(handlerSlice).toMatch(/const containmentRoot = dirname\(dirname\(defaultSessDir\)\);/);
+    expect(handlerSlice).toMatch(/const containmentRootWithSep = resolve\(containmentRoot\) \+ sep;/);
+    expect(handlerSlice).toMatch(
+      /Error: sessionDir must resolve under \$\{containmentRoot\}/,
+    );
+    expect(handlerSlice).toMatch(
+      /Error: contentDir must resolve under \$\{containmentRoot\}/,
+    );
+  });
+
+  test("algorithm: containment accepts in-tree dirs and rejects /etc and traversal escapes", () => {
+    // Replay the guard logic against a sandbox tree whose default sessions
+    // dir is <root>/.claude/context-mode/sessions. The containment root
+    // derives as dirname(dirname(defaultSessDir)) = <root>/.claude.
+    const base = mkdtempSync(join(tmpdir(), "ctx-insight-containment-"));
+    try {
+      const fakeClaudeRoot = join(base, ".claude");
+      const defaultSessDir = join(fakeClaudeRoot, "context-mode", "sessions");
+      mkdirSync(defaultSessDir, { recursive: true });
+
+      const sepLocal = require("node:path").sep as string;
+      const dirnameLocal = (require("node:path") as typeof import("node:path")).dirname;
+      const containmentRoot = dirnameLocal(dirnameLocal(defaultSessDir));
+      const containmentRootWithSep = resolve(containmentRoot) + sepLocal;
+      const isContained = (dir: string): boolean =>
+        (resolve(dir) + sepLocal).startsWith(containmentRootWithSep);
+
+      // In-tree: legitimate.
+      expect(isContained(defaultSessDir)).toBe(true);
+      expect(isContained(join(fakeClaudeRoot, "context-mode", "content"))).toBe(true);
+      expect(isContained(join(fakeClaudeRoot, "other-install", "sessions"))).toBe(true);
+
+      // Outside the containment root: rejected.
+      expect(isContained("/etc")).toBe(false);
+      expect(isContained(join(base, ".ssh"))).toBe(false);
+      expect(isContained(join(base, "elsewhere"))).toBe(false);
+
+      // Relative-".." escape: resolves outside, rejected.
+      expect(isContained(join(defaultSessDir, "..", "..", "..", "elsewhere"))).toBe(false);
+
+      // Prefix collision: a sibling whose name starts with the same chars
+      // as containmentRoot must not slip through. The trailing sep on
+      // containmentRoot is the safeguard.
+      expect(isContained(fakeClaudeRoot + "-evil")).toBe(false);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // ctx_execute_file: projectRoot env cascade parity with ctx_index
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -6246,3 +6246,70 @@ describe("ctx_index: directory path support (#687)", () => {
     }
   }, 30_000);
 });
+
+describe("ctx_index: root-level symlink defense in directory dispatch", () => {
+  // The directory-dispatch branch used statSync to decide whether to walk
+  // a path as a directory. statSync follows symlinks, so a path like
+  // `/tmp/link -> /etc` reported as a directory and walkDirectoryDetailed
+  // then realpathSync'd internally and indexed /etc. The deny-glob check
+  // at the head of the handler had run against `/tmp/link`, not /etc, so a
+  // user whose deny globs include /etc but not /tmp would still see /etc
+  // contents land in the FTS5 store. Fix: detect root-level symlinks with
+  // lstatSync, realpath them once, and re-apply the deny check against
+  // the actual walk target before dispatching.
+
+  const SERVER_SOURCE = readFileSync(
+    resolve(__dirname, "../../src/server.ts"),
+    "utf-8",
+  );
+
+  test("ctx_index handler lstats and re-deny-checks symlinks before directory dispatch", () => {
+    const dispatchBlock = SERVER_SOURCE.match(
+      /Root-level symlink defense[\s\S]*?if \(resolvedPath && existsSync\(resolvedPath\) && statSync\(resolvedPath\)\.isDirectory\(\)\)/,
+    );
+    expect(dispatchBlock).not.toBeNull();
+    const block = dispatchBlock![0];
+    expect(block).toMatch(/const lst = lstatSync\(resolvedPath\);/);
+    expect(block).toMatch(/lst\.isSymbolicLink\(\)/);
+    expect(block).toMatch(/realpathSync\(resolvedPath\)/);
+    expect(block).toMatch(
+      /const realDenied = checkFilePathDenyPolicy\(realTarget, "ctx_index"\);/,
+    );
+    expect(block).toMatch(/if \(realDenied\) return realDenied;/);
+    expect(SERVER_SOURCE).toMatch(
+      /import\s*\{[^}]*\brealpathSync\b[^}]*\}\s*from\s*"node:fs"/,
+    );
+  });
+
+  test("algorithm: lstatSync + realpath identifies a symlinked directory whose target differs", () => {
+    // The behavior the fix depends on: lstatSync on a symlink reports
+    // isSymbolicLink()=true and isDirectory()=false. realpathSync resolves
+    // to the target. statSync, by contrast, would report isDirectory()=true
+    // and silently follow -- the pre-fix dispatch relied on that.
+    const base = mkdtempSync(join(tmpdir(), "ctx-index-symlink-defense-"));
+    try {
+      const realDir = join(base, "real");
+      const linkPath = join(base, "link");
+      mkdirSync(realDir, { recursive: true });
+      writeFileSync(join(realDir, "marker.txt"), "real");
+
+      const fsLocal = require("node:fs") as typeof import("node:fs");
+      // "junction" on Windows so the test works without admin / Developer
+      // Mode; lstatSync still reports isSymbolicLink()===true for junctions,
+      // which is what the algorithm-under-test depends on.
+      const symlinkType = process.platform === "win32" ? "junction" : "dir";
+      fsLocal.symlinkSync(realDir, linkPath, symlinkType);
+
+      const lst = fsLocal.lstatSync(linkPath);
+      expect(lst.isSymbolicLink()).toBe(true);
+      expect(lst.isDirectory()).toBe(false);
+      expect(fsLocal.statSync(linkPath).isDirectory()).toBe(true);
+
+      const real = fsLocal.realpathSync(linkPath);
+      expect(real).not.toBe(linkPath);
+      expect(real).toBe(fsLocal.realpathSync(realDir));
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -6313,3 +6313,99 @@ describe("ctx_index: root-level symlink defense in directory dispatch", () => {
     }
   });
 });
+
+describe("ctx_fetch_and_index: response body size cap", () => {
+  // ctx_fetch_and_index spawns a subprocess that fetches a URL, writes the
+  // response body to a tmpfile, exits, and the parent reads the file back
+  // into the long-running MCP server's heap via readFileSync. Without a
+  // cap, an unexpectedly large endpoint (or a slowloris that keeps
+  // appending chunks until the subprocess is killed) can either OOM the
+  // subprocess or, worse, propagate a multi-GB response into the parent
+  // heap and crash the MCP server. Cap to 50 MB on both ends.
+
+  const SERVER_SOURCE = readFileSync(
+    resolve(__dirname, "../../src/server.ts"),
+    "utf-8",
+  );
+
+  test("subprocess buildFetchCode caps response via Content-Length and post-text length", () => {
+    expect(SERVER_SOURCE).toContain("const MAX_FETCH_BYTES = 50 * 1024 * 1024;");
+    expect(SERVER_SOURCE).toContain("async function safeText(resp)");
+    // The three response paths (JSON, HTML, default) all route through safeText
+    // instead of resp.text() directly.
+    const buildFetchSrc = SERVER_SOURCE.slice(
+      SERVER_SOURCE.indexOf("export function buildFetchCode"),
+      SERVER_SOURCE.indexOf("// fetch_and_index helpers"),
+    );
+    expect(buildFetchSrc.length).toBeGreaterThan(0);
+    expect(buildFetchSrc.match(/await safeText\(resp\)/g)?.length).toBeGreaterThanOrEqual(3);
+    // The pre-fix call sites (one per content-type branch) routed through
+    // `await resp.text()` directly. Now only one such call survives,
+    // inside safeText itself. Count exactly one.
+    const directCalls = buildFetchSrc.match(/await resp\.text\(\)/g) ?? [];
+    expect(directCalls.length).toBe(1);
+  });
+
+  test("parent-side fetchOneUrl stat-gates outputPath before readFileSync", () => {
+    const fetchOneUrlSrc = SERVER_SOURCE.slice(
+      SERVER_SOURCE.indexOf("async function fetchOneUrl"),
+      SERVER_SOURCE.indexOf("async function fetchOneUrl") + 6000,
+    );
+    expect(fetchOneUrlSrc).toContain("MAX_FETCH_OUTPUT_BYTES = 50 * 1024 * 1024");
+    expect(fetchOneUrlSrc).toMatch(/statSync\(outputPath\)\.size/);
+    expect(fetchOneUrlSrc).toMatch(/fileSize > MAX_FETCH_OUTPUT_BYTES/);
+  });
+});
+
+describe("getStatsFilePath: sanitize CLAUDE_SESSION_ID before path.join", () => {
+  // CLAUDE_SESSION_ID flows from the hosting process straight into a
+  // path.join, and path.join collapses ".." segments. CLAUDE_SESSION_ID=
+  // "../../evil" would write "stats-evil.json" two levels above statsDir.
+  // The env var is not under direct MCP-tool-caller control, but in CI /
+  // multi-tenant contexts where the host env is partly influenceable this
+  // is an arbitrary-write primitive. Reject any session id whose
+  // characters aren't [A-Za-z0-9._-] and fall back to pid-based id.
+
+  const SERVER_SOURCE = readFileSync(
+    resolve(__dirname, "../../src/server.ts"),
+    "utf-8",
+  );
+
+  test("sanitizeSessionId exists and is called from getStatsFilePath", () => {
+    expect(SERVER_SOURCE).toMatch(/const SESSION_ID_RE = \/\^\[A-Za-z0-9\._-\]\+\$\//);
+    expect(SERVER_SOURCE).toContain("function sanitizeSessionId(raw: string): string {");
+    const getStatsSlice = SERVER_SOURCE.slice(
+      SERVER_SOURCE.indexOf("function getStatsFilePath"),
+      SERVER_SOURCE.indexOf("function getStatsFilePath") + 600,
+    );
+    expect(getStatsSlice).toMatch(/sanitizeSessionId\(raw\)/);
+    // The pre-fix direct splice of the env var into the join is gone.
+    expect(getStatsSlice).not.toMatch(
+      /join\(statsDir, `stats-\$\{process\.env\.CLAUDE_SESSION_ID/,
+    );
+  });
+
+  test("algorithm: sanitizer rejects traversal characters and falls back to pid", () => {
+    // Mirror the production sanitizer in isolation. The malicious shapes
+    // must all fall through to the pid-based id; the legitimate UUID-ish
+    // shape passes through unchanged.
+    const SESSION_ID_RE = /^[A-Za-z0-9._-]+$/;
+    const sanitize = (raw: string): string =>
+      SESSION_ID_RE.test(raw) ? raw : `pid-${process.ppid}`;
+
+    expect(sanitize("../../evil")).toMatch(/^pid-\d+$/);
+    expect(sanitize("/etc/passwd")).toMatch(/^pid-\d+$/);
+    expect(sanitize("a/b")).toMatch(/^pid-\d+$/);
+    expect(sanitize("a\\b")).toMatch(/^pid-\d+$/);
+    expect(sanitize("..\\..")).toMatch(/^pid-\d+$/);
+    expect(sanitize("")).toMatch(/^pid-\d+$/);
+
+    // Legitimate ids pass through.
+    expect(sanitize("session-abc123")).toBe("session-abc123");
+    expect(sanitize("pid-12345")).toBe("pid-12345");
+    expect(sanitize("550e8400-e29b-41d4-a716-446655440000")).toBe(
+      "550e8400-e29b-41d4-a716-446655440000",
+    );
+    expect(sanitize("MyHost_2024.01")).toBe("MyHost_2024.01");
+  });
+});

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -7,13 +7,30 @@
 
 import { describe, test, assert } from "vitest";
 import { spawn, execSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { startLifecycleGuard, makeDefaultIsParentAlive } from "../src/lifecycle.js";
 
-const TSX_PATH = execSync("which tsx", { encoding: "utf-8" }).trim();
+// Resolve the tsx binary. Prefer the local devDep so the test doesn't depend
+// on a global tsx install or on Git Bash's `which` being on PATH; the PATH
+// probe is a fallback for environments where node_modules/.bin isn't
+// populated. Windows ships tsx as tsx.cmd and uses `where`; everywhere else
+// it's `tsx` with `which`.
+function resolveTsxPath(): string {
+  const isWindows = process.platform === "win32";
+  const localBin = join(
+    process.cwd(),
+    "node_modules",
+    ".bin",
+    isWindows ? "tsx.cmd" : "tsx",
+  );
+  if (existsSync(localBin)) return localBin;
+  const probe = isWindows ? "where tsx" : "which tsx";
+  return execSync(probe, { encoding: "utf-8" }).trim().split(/\r?\n/)[0];
+}
+const TSX_PATH = resolveTsxPath();
 const PROJECT_ROOT = process.cwd();
 // file:// URL form so the spawned ESM module can import lifecycle.ts by
 // absolute path regardless of where the script itself lives.

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -7,16 +7,36 @@
 
 import { describe, test, assert } from "vitest";
 import { spawn, execSync } from "node:child_process";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
 import { startLifecycleGuard, makeDefaultIsParentAlive } from "../src/lifecycle.js";
 
 const TSX_PATH = execSync("which tsx", { encoding: "utf-8" }).trim();
+const PROJECT_ROOT = process.cwd();
+// file:// URL form so the spawned ESM module can import lifecycle.ts by
+// absolute path regardless of where the script itself lives.
+const LIFECYCLE_SRC_URL = pathToFileURL(
+  join(PROJECT_ROOT, "src", "lifecycle.ts"),
+).href;
 
-function spawnGuardChild(exitCode: number): { child: ReturnType<typeof spawn>; ready: Promise<void> } {
-  const script = join(process.cwd(), `_lifecycle_test_${exitCode}.ts`);
+// Sandboxed write target. Pre-fix this wrote _lifecycle_test_*.ts directly
+// to process.cwd() (the project root) and only cleaned up on the child's
+// `close` event. A hang or hard crash left the temp scripts in the repo
+// (not gitignored). Use a per-test mkdtempSync directory under tmpdir
+// instead so partial state can't escape the sandbox even when the child
+// dies without firing its close handler. The vitest worker tears down its
+// per-test environment when the run ends, so worst case the dir lingers
+// only for the lifetime of the run.
+function spawnGuardChild(exitCode: number): {
+  child: ReturnType<typeof spawn>;
+  ready: Promise<void>;
+} {
+  const scratchDir = mkdtempSync(join(tmpdir(), "ctx-lifecycle-test-"));
+  const script = join(scratchDir, `guard_${exitCode}.ts`);
   writeFileSync(script, `
-import { startLifecycleGuard } from "./src/lifecycle.ts";
+import { startLifecycleGuard } from ${JSON.stringify(LIFECYCLE_SRC_URL)};
 startLifecycleGuard({
   checkIntervalMs: 60000,
   onShutdown: () => process.exit(${exitCode}),
@@ -25,10 +45,12 @@ process.stdout.write("READY");
 setInterval(() => {}, 1000);
 `);
   const child = spawn(TSX_PATH, [script], {
-    cwd: process.cwd(),
+    cwd: PROJECT_ROOT,
     stdio: ["pipe", "pipe", "pipe"],
   });
-  child.on("close", () => { try { unlinkSync(script); } catch {} });
+  child.on("close", () => {
+    try { rmSync(scratchDir, { recursive: true, force: true }); } catch {}
+  });
   const ready = new Promise<void>((resolve) => {
     child.stdout!.on("data", (chunk: Buffer) => {
       if (chunk.toString().includes("READY")) resolve();

--- a/tests/util/heal-installed-plugins.test.ts
+++ b/tests/util/heal-installed-plugins.test.ts
@@ -954,4 +954,55 @@ describe("healClaudeJsonMcpArgs", () => {
     expect(result.healed).toEqual([]);
     expect(readFileSync(dotClaudeJsonPath, "utf-8")).toBe(original);
   });
+
+  it("rejects suffixes that escape newPluginRoot via .. traversal", () => {
+    // ~/.claude.json is locally user-writable, same trust boundary as
+    // installed_plugins.json. A crafted arg whose suffix slice contains
+    // literal ".." string characters (not path.join-normalized at write
+    // time) would otherwise let resolve(newPluginRoot, suffix) normalize
+    // the traversal to a path outside the cache hierarchy. The healer
+    // then writes that attacker-chosen .mjs path back into ~/.claude.json
+    // as the new MCP spawn target. The post-resolve startsWith guard
+    // rejects the mutation; the arg is left untouched.
+    const tmp = makeTmp("ctx-claude-json-traversal-");
+    const cacheParent = join(tmp, ".claude", "plugins", "cache", "context-mode", "context-mode");
+    const oldPluginRoot = join(cacheParent, "1.0.0");
+    const newPluginRoot = join(cacheParent, "1.0.1");
+    mkdirSync(oldPluginRoot, { recursive: true });
+    mkdirSync(newPluginRoot, { recursive: true });
+
+    // String concatenation preserves the literal ".." characters in the
+    // stored arg, which is what the threat model requires. join() would
+    // normalize at construction time and defuse the attack before it
+    // reaches the healer, so don't use join() here.
+    const traversalArg = oldPluginRoot + "/../../../evil/start.mjs";
+    const deeperTraversalArg = oldPluginRoot + "/subdir/../../../../../evil.mjs";
+    const legitimateOldArg = join(oldPluginRoot, "start.mjs");
+
+    const dotClaudeJsonPath = join(tmp, ".claude.json");
+    const original = JSON.stringify({
+      mcpServers: {
+        traversal_suffix: { args: [traversalArg] },
+        deeper_traversal: { args: [deeperTraversalArg] },
+        legitimate_old: { args: [legitimateOldArg] },
+      },
+    }, null, 2);
+    writeFileSync(dotClaudeJsonPath, original);
+
+    const result = healClaudeJsonMcpArgs({
+      dotClaudeJsonPath,
+      pluginCacheParent: cacheParent,
+      newPluginRoot,
+    });
+
+    expect(result.healed).toEqual(["claude-json-mcp-args"]);
+    const updated = JSON.parse(readFileSync(dotClaudeJsonPath, "utf-8"));
+    // The legitimate entry was rewritten in place.
+    expect(updated.mcpServers.legitimate_old.args[0]).toBe(join(newPluginRoot, "start.mjs"));
+    // The two traversal entries must NOT have been rewritten; the original
+    // attacker strings stay in place rather than getting normalized to a
+    // .mjs path outside newPluginRoot.
+    expect(updated.mcpServers.traversal_suffix.args[0]).toBe(traversalArg);
+    expect(updated.mcpServers.deeper_traversal.args[0]).toBe(deeperTraversalArg);
+  });
 });


### PR DESCRIPTION
## Summary

Deep security audit across the in-scope codebase. Nine fixes (plus one test-only slice widening) covering exploitable supply-chain / local-trust-boundary paths, an info-disclosure DoS surface, and destructive-test hygiene.

### Containment guards (the big block of work)

- `bf4c948` -- `/ctx-upgrade` swap loop in both `cli.ts` and `server.ts` (the inline-fallback variant) iterated `pkg.files[]` from the freshly cloned upstream `package.json` and handed each entry to `rmSync` + `cpSync` with no `startsWith(pluginRoot)` containment. A compromised upstream tag shipping `files: ["../../.ssh/authorized_keys"]` would rm and overwrite arbitrary files under the user's UID. Mirrors the lexical guard pattern that `hooks/heal-partial-install.mjs` already uses for its own `files[]` expansion.

- `e7d5599` -- `cli.ts` reads `~/.claude/plugins/installed_plugins.json` in two hot spots (`upgrade()` skills cpSync and `statuslineForward()` dynamic-import). The same field already had a `startsWith(cacheRoot + sep)` guard in `server.ts:790` (`healCacheMidSession`); this just propagates it to the more sensitive call sites. statusline re-fires several times per second, so a malicious `installPath` planted in the registry by a co-resident plugin or postinstall would otherwise hand the attacker durable RCE under the user account.

- `dff7bac` -- closing adversarial sweep caught that the lexical guards above (and the swap-loop guard in `bf4c948`) are bypassable via a planted symlink AT `cacheRoot/<owner>/<plugin>/<version>` because `path.resolve` is purely lexical and doesn't dereference symlinks. Adds a `realpathSync` re-check after the lexical gate for the installPath sites and an `lstatSync`-backed `cpSync({filter})` for the swap loop so neither a symlink anchor at the registry path nor a committed symlink inside the cloned source tree can sneak past.

- `b01278d` -- `ctx_insight` accepted `sessionDir` / `contentDir` MCP overrides that flowed verbatim into `INSIGHT_SESSION_DIR` / `INSIGHT_CONTENT_DIR` on the spawned dashboard subprocess. Without containment, a prompt-injected MCP caller passing `sessionDir="~/.ssh"` turns the dashboard into a confused-deputy enumerator over the user's filesystem (and, for hex-named SQLite files, can delete rows via `/api/content`). Gates explicit overrides to the adapter config root (`dirname(dirname(getSessionDir()))`).

- `760d476` -- `healClaudeJsonMcpArgs` rewrote `mcpServers.args[]` in `~/.claude.json` by slicing the arg, then `resolve(newPluginRoot, suffix)`. The slice is a literal substring; `..` characters embedded in the original arg survive into `suffix`, and `resolve` normalizes them when it builds `newArg`. A crafted `~/.claude.json` could trick the heal into rewriting MCP spawn args at attacker-chosen paths. Adds a post-resolve `startsWith` guard.

- `25606f2` -- `ctx_index`'s directory-dispatch branch used `statSync` rather than `lstatSync`, so a path like `/tmp/link` with `link -> /etc` was reported as a directory and walked into `/etc`. The deny-glob check at the head of the handler ran against `/tmp/link`, not the symlink target, so users whose deny globs included `/etc` but not `/tmp` would still see `/etc` content land in the FTS5 store. Switches to `lstatSync` + `realpathSync` + re-applied deny check.

### Info-disclosure / DoS

- `3568d9a` -- bundles two `src/server.ts` fixes. `ctx_fetch_and_index` had no size cap on either the subprocess fetch or the parent's `readFileSync(outputPath)`, so a malicious URL returning multi-GB content could OOM the long-running MCP server. Adds a 50 MB cap on both ends. Same commit sanitizes `CLAUDE_SESSION_ID` before splicing it into a `path.join`-based stats filename, so a host-controlled `CLAUDE_SESSION_ID="../../evil"` can no longer write outside `statsDir`.

### Destructive-test hygiene (matches PR #702 pattern)

- `c8a5728` -- `tests/lifecycle.test.ts` wrote `_lifecycle_test_*.ts` to `process.cwd()` (the project root, not gitignored) and `tests/adapters/cursor.test.ts` mkdir'd, wrote, and `rmSync(force:true)`'d `.cursor/mcp.json` against `process.cwd()`, silently clobbering the contributor's real `.cursor/mcp.json` on `npm test`. Both blocks now sandbox the writes inside per-test `mkdtempSync` directories (and chdir for the cursor case so the adapter still finds the test fixture).

### Test-only follow-up

- `123b21b` -- three pre-existing tests in `tests/core/cli.test.ts` sliced `cli.ts` source by fixed-width windows that the new containment comments + checks pushed assertions out of. Widened the slices to end-of-file; the textual landmarks (`sweepStaleMcpJson`, `process.exit(0)`) still anchor the regex assertions, so the wider slices don't weaken anything.

### Out-of-scope (deferred to follow-up if you want them)

- `F02` SSRF defaults: working as designed (loopback / RFC1918 reachable unless `CTX_FETCH_STRICT=1`); could be surfaced in `ctx_doctor`.
- `F08`: `...process.env` spread into the npm install subprocess on `/ctx-upgrade` still propagates `CLAUDE_*` env into transitive postinstall scripts.
- `F27`: ~20 `writeFileSync` call sites on critical config files don't use `tmp + rename`. Reliability concern, not exploitable.
- `F28`: same-uid `chmod` TOCTOU in `hooks/cache-heal-utils.mjs`.
- `CONTEXT_MODE_SECURITY_BUNDLE_PATH` env-controlled dynamic import in `hooks/core/routing.mjs:364`. Documented as a test seam; env is parent-process-controlled (same trust as the user). Fixing strictly would break legitimate test fixtures in tmpdir.

## Test plan

- [ ] `node node_modules/.bin/tsc --noEmit` is clean.
- [ ] `vitest run tests/core/cli.test.ts` -- 173 / 173 pass.
- [ ] `vitest run tests/util/heal-installed-plugins.test.ts` -- 33 / 33 pass.
- [ ] `vitest run tests/adapters/cursor.test.ts` -- 39 / 39 pass.
- [ ] `vitest run tests/core/server.test.ts` -- 463 / 463 pass when run unsandboxed (the in-sandbox EROFS failures are pre-existing in any executor / turndown / projectRoot test that needs `mkdtempSync("/tmp/.ctx-mode-")`).
- [ ] Manual /ctx-upgrade smoke on a fresh install (legitimate path) -- the cosmetic regression for users whose `~/.claude` itself is a symlink is documented in the `dff7bac` commit message and is not a security regression.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>