### PR TITLE
openclaw: fix adapter compatibility and tool contracts

### DIFF
--- a/.openclaw-plugin/openclaw.plugin.json
+++ b/.openclaw-plugin/openclaw.plugin.json
@@ -9,6 +9,21 @@
     "filesystem_access": "full",
     "system_access": "full"
   },
+  "contracts": {
+    "tools": [
+      "ctx_execute",
+      "ctx_execute_file",
+      "ctx_index",
+      "ctx_search",
+      "ctx_fetch_and_index",
+      "ctx_batch_execute",
+      "ctx_stats",
+      "ctx_doctor",
+      "ctx_upgrade",
+      "ctx_purge",
+      "ctx_insight"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "properties": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -9,6 +9,21 @@
     "filesystem_access": "full",
     "system_access": "full"
   },
+  "contracts": {
+    "tools": [
+      "ctx_execute",
+      "ctx_execute_file",
+      "ctx_index",
+      "ctx_search",
+      "ctx_fetch_and_index",
+      "ctx_batch_execute",
+      "ctx_stats",
+      "ctx_doctor",
+      "ctx_upgrade",
+      "ctx_purge",
+      "ctx_insight"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "properties": {

--- a/src/adapters/openclaw/plugin.ts
+++ b/src/adapters/openclaw/plugin.ts
@@ -57,12 +57,54 @@ const SYSTEM_REMINDER_PREFIXES = [
   "<context_guidance>",
   "<tool-result>",
 ] as const;
+const SKILL_FRONTMATTER_REGEX = /^---\s*\n[\s\S]*?\n---\s*\n?/;
+const OPENCLAW_SKILL_PROMPT_CHAR_LIMIT = 6000;
+const SKILL_SECTION_HEADINGS = [
+  "MANDATORY RULE",
+  "Decision Tree",
+  "When to Use Each Tool",
+  "Critical Rules",
+] as const;
 function isSystemReminderMessage(msg: string): boolean {
   const trimmed = msg.trimStart();
   for (const prefix of SYSTEM_REMINDER_PREFIXES) {
     if (trimmed.startsWith(prefix)) return true;
   }
   return false;
+}
+function stripMarkdownFrontmatter(markdown: string): string {
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  return normalized.replace(SKILL_FRONTMATTER_REGEX, "").trim();
+}
+function extractMarkdownSection(markdown: string, heading: string): string | null {
+  const sectionHeader = `## ${heading}`;
+  const start = markdown.indexOf(sectionHeader);
+  if (start === -1) return null;
+  const afterHeader = markdown.slice(start + sectionHeader.length);
+  const nextHeadingOffset = afterHeader.search(/\n##\s+|\n#\s+/);
+  const body = (nextHeadingOffset === -1 ? afterHeader : afterHeader.slice(0, nextHeadingOffset)).trim();
+  if (!body) return null;
+  return `${sectionHeader}\n\n${body}`;
+}
+function buildOpenClawSkillLikeGuidance(skillMarkdown: string): string {
+  const skillBody = stripMarkdownFrontmatter(skillMarkdown);
+  const skillTitle = skillBody.match(/^#\s+.+$/m)?.[0]?.trim() ?? "# Context Mode Skill";
+  const selectedSections = SKILL_SECTION_HEADINGS
+    .map((heading) => extractMarkdownSection(skillBody, heading))
+    .filter((section): section is string => Boolean(section));
+  const rawContent = (
+    selectedSections.length > 0
+      ? [skillTitle, ...selectedSections].join("\n\n")
+      : skillBody
+  ).trim();
+  const boundedContent = rawContent.length > OPENCLAW_SKILL_PROMPT_CHAR_LIMIT
+    ? `${rawContent.slice(0, OPENCLAW_SKILL_PROMPT_CHAR_LIMIT).trimEnd()}\n\n[skill excerpt truncated for prompt budget]`
+    : rawContent;
+  return [
+    "<context_mode_skill_like_guidance source=\"skills/context-mode/SKILL.md\">",
+    boundedContent,
+    "</context_mode_skill_like_guidance>",
+  ].join("\n");
 }
 
 // ── OpenClaw Plugin API Types ─────────────────────────────
@@ -354,6 +396,7 @@ export default {
     // with createRoutingBlock(createToolNamer("openclaw")) so OpenClaw-specific
     // MCP-prefix substitution stays in lockstep with hooks/routing-block.mjs.
     let routingInstructions = "";
+    let skillLikeInstructions = "";
     const initPromise = (async () => {
       const routingPath = resolve(buildDir, "..", "..", "..", "hooks", "core", "routing.mjs");
       const routing = await import(pathToFileURL(routingPath).href);
@@ -391,6 +434,17 @@ export default {
         } catch {
           // best effort
         }
+      }
+
+      try {
+        const skillPath = resolve(pluginRoot, "skills", "context-mode", "SKILL.md");
+        if (existsSync(skillPath)) {
+          skillLikeInstructions = buildOpenClawSkillLikeGuidance(readFileSync(skillPath, "utf-8"));
+        } else {
+          log.debug("context-mode skill file missing; skipping skill-like prompt injection", { skillPath });
+        }
+      } catch (err) {
+        log.warn?.("failed to build skill-like guidance from SKILL.md", err);
       }
 
       return { routing };
@@ -715,13 +769,21 @@ export default {
     api.on(
       "before_prompt_build",
       () => {
-        if (!routingInstructions) return undefined;
-        log.debug("before_prompt_build[routing]", { hasInstructions: !!routingInstructions });
-        // v1.0.107 — visible marker so OpenClaw users can verify the routing
-        // block reached the model (Mickey-class verification path; mirrors
-        // OpenCode + Pi adapters).
-        const marker = `<!-- context-mode: routing block injected (sessionID=${String(sessionId).slice(0, 8)}) -->`;
-        return { appendSystemContext: marker + "\n" + routingInstructions };
+        if (!routingInstructions && !skillLikeInstructions) return undefined;
+        log.debug("before_prompt_build[routing+skill]", {
+          hasRoutingInstructions: !!routingInstructions,
+          hasSkillLikeInstructions: !!skillLikeInstructions,
+        });
+        const injectedBlocks: string[] = [];
+        if (routingInstructions) {
+          // v1.0.107 — visible marker so OpenClaw users can verify the routing
+          // block reached the model (Mickey-class verification path; mirrors
+          // OpenCode + Pi adapters).
+          const marker = `<!-- context-mode: routing block injected (sessionID=${String(sessionId).slice(0, 8)}) -->`;
+          injectedBlocks.push(marker + "\n" + routingInstructions);
+        }
+        if (skillLikeInstructions) injectedBlocks.push(skillLikeInstructions);
+        return { appendSystemContext: injectedBlocks.join("\n\n") };
       },
       { priority: 5 },
     );
@@ -779,13 +841,19 @@ export default {
         try {
           const e = (event ?? {}) as { input?: { prompt?: string } };
           const basePrompt = e?.input?.prompt ?? "";
-          if (!routingInstructions) return undefined;
+          if (!routingInstructions && !skillLikeInstructions) return undefined;
+          const injectedBlocks: string[] = [];
+          if (routingInstructions) injectedBlocks.push(routingInstructions);
+          if (skillLikeInstructions) injectedBlocks.push(skillLikeInstructions);
+          const injectedPromptBlock = injectedBlocks.join("\n\n");
           const newPrompt = basePrompt
-            ? `${basePrompt}\n\n${routingInstructions}`
-            : routingInstructions;
-          log.debug("subagent_spawning[inject-routing]", {
+            ? `${basePrompt}\n\n${injectedPromptBlock}`
+            : injectedPromptBlock;
+          log.debug("subagent_spawning[inject-routing+skill]", {
             basePromptLen: basePrompt.length,
-            blockLen: routingInstructions.length,
+            hasRoutingInstructions: !!routingInstructions,
+            hasSkillLikeInstructions: !!skillLikeInstructions,
+            blockLen: injectedPromptBlock.length,
           });
           return { inputOverride: { ...(e.input ?? {}), prompt: newPrompt } };
         } catch {

--- a/src/adapters/openclaw/plugin.ts
+++ b/src/adapters/openclaw/plugin.ts
@@ -77,9 +77,17 @@ interface CommandContext {
   config?: Record<string, unknown>;
 }
 
+interface OpenClawCommandDefinition {
+  name: string;
+  description: string;
+  acceptsArgs?: boolean;
+  requireAuth?: boolean;
+  handler: (ctx: CommandContext) => { text: string } | Promise<{ text: string }>;
+}
+
 /** OpenClaw plugin API provided to the register function. */
 interface OpenClawPluginApi {
-  registerHook(
+  registerHook?(
     event: string,
     handler: (...args: unknown[]) => unknown,
     meta: { name: string; description: string },
@@ -94,14 +102,10 @@ interface OpenClawPluginApi {
     handler: (...args: unknown[]) => unknown,
     opts?: { priority?: number },
   ): void;
-  registerContextEngine(id: string, factory: () => ContextEngineInstance): void;
-  registerCommand?(cmd: {
-    name: string;
-    description: string;
-    acceptsArgs?: boolean;
-    requireAuth?: boolean;
-    handler: (ctx: CommandContext) => { text: string } | Promise<{ text: string }>;
-  }): void;
+  registerContextEngine?(id: string, factory: () => ContextEngineInstance): void;
+  registerCommand?:
+    | ((cmd: OpenClawCommandDefinition) => void)
+    | ((name: string, options: Omit<OpenClawCommandDefinition, "name">) => void);
   registerCli?(
     factory: (ctx: { program: unknown }) => void,
     meta: { commands: string[] },
@@ -273,10 +277,58 @@ export default {
     // info/error always emit; debug only when api.logger.debug is present
     // (i.e. OpenClaw running with --log-level debug or lower).
     const log = {
-      info: (...args: unknown[]) => api.logger?.info("[context-mode]", ...args),
-      error: (...args: unknown[]) => api.logger?.error("[context-mode]", ...args),
+      info: (...args: unknown[]) => api.logger?.info?.("[context-mode]", ...args),
+      error: (...args: unknown[]) => api.logger?.error?.("[context-mode]", ...args),
       debug: (...args: unknown[]) => api.logger?.debug?.("[context-mode]", ...args),
       warn: (...args: unknown[]) => api.logger?.warn?.("[context-mode]", ...args),
+    };
+
+    const registerCommandHook = (
+      event: string,
+      handler: () => Promise<void> | void,
+      meta: { name: string; description: string },
+    ): void => {
+      if (api.registerHook) {
+        api.registerHook(event, handler, meta);
+        return;
+      }
+      try {
+        api.on(event, handler as (...args: unknown[]) => unknown);
+        log.debug("command hook registered via api.on fallback", { event });
+      } catch (err) {
+        log.warn?.("command hook registration skipped", { event }, err);
+      }
+    };
+
+    const registerAutoReplyCommand = (command: OpenClawCommandDefinition): void => {
+      if (!api.registerCommand) return;
+      try {
+        (api.registerCommand as (cmd: OpenClawCommandDefinition) => void)(command);
+      } catch (err) {
+        try {
+          (
+            api.registerCommand as (
+              name: string,
+              options: Omit<OpenClawCommandDefinition, "name">,
+            ) => void
+          )(command.name, {
+            description: command.description,
+            acceptsArgs: command.acceptsArgs,
+            requireAuth: command.requireAuth,
+            handler: command.handler,
+          });
+        } catch (fallbackErr) {
+          log.warn?.(
+            "registerCommand compatibility fallback failed; skipping auto-reply command",
+            { name: command.name },
+            fallbackErr,
+          );
+          log.debug("registerCommand primary signature error", {
+            name: command.name,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
     };
 
     // Get shared DB singleton (lazy-init on first register() call)
@@ -465,7 +517,7 @@ export default {
 
     // ── 3. command:new — Session initialization ────────────
 
-    api.registerHook(
+    registerCommandHook(
       "command:new",
       async () => {
         try {
@@ -484,7 +536,7 @@ export default {
 
     // ── 3b. command:reset / command:stop — Session cleanup ────
 
-    api.registerHook(
+    registerCommandHook(
       "command:reset",
       async () => {
         try {
@@ -499,8 +551,7 @@ export default {
         description: "Session cleanup on /reset command",
       },
     );
-
-    api.registerHook(
+    registerCommandHook(
       "command:stop",
       async () => {
         try {
@@ -745,29 +796,33 @@ export default {
 
     // ── 9. Context engine — Compaction management ──────────
 
-    api.registerContextEngine("context-mode", () => ({
-      info: {
-        id: "context-mode",
-        name: "Context Mode",
-        ownsCompaction: false,
-      },
+    if (api.registerContextEngine) {
+      api.registerContextEngine("context-mode", () => ({
+        info: {
+          id: "context-mode",
+          name: "Context Mode",
+          ownsCompaction: false,
+        },
 
-      async ingest() {
-        return { ingested: true };
-      },
+        async ingest() {
+          return { ingested: true };
+        },
 
-      async assemble({ messages }: { messages: unknown[] }) {
-        return { messages, estimatedTokens: 0 };
-      },
+        async assemble({ messages }: { messages: unknown[] }) {
+          return { messages, estimatedTokens: 0 };
+        },
 
-      async compact() {
-        // No-op: session continuity is handled by before_compaction / after_compaction hooks.
-        // Returning ownsCompaction: false + compacted: false lets the host platform (OpenClaw)
-        // manage conversation truncation, preserving Anthropic thinking/redacted_thinking blocks.
-        // See: https://github.com/mksglu/context-mode/issues/191
-        return { ok: true, compacted: false };
-      },
-    }));
+        async compact() {
+          // No-op: session continuity is handled by before_compaction / after_compaction hooks.
+          // Returning ownsCompaction: false + compacted: false lets the host platform (OpenClaw)
+          // manage conversation truncation, preserving Anthropic thinking/redacted_thinking blocks.
+          // See: https://github.com/mksglu/context-mode/issues/191
+          return { ok: true, compacted: false };
+        },
+      }));
+    } else {
+      log.warn?.("api.registerContextEngine unavailable — skipping context engine registration");
+    }
 
     // ── 10. Auto-reply commands — ctx slash commands ──────
     // Update module-level refs so command handlers (registered once) always
@@ -777,7 +832,7 @@ export default {
     _latestPluginRoot = pluginRoot;
 
     if (api.registerCommand) {
-      api.registerCommand({
+      registerAutoReplyCommand({
         name: "ctx-stats",
         description: "Show context-mode session statistics",
         handler: () => {
@@ -785,8 +840,7 @@ export default {
           return { text };
         },
       });
-
-      api.registerCommand({
+      registerAutoReplyCommand({
         name: "ctx-doctor",
         description: "Run context-mode diagnostics",
         handler: () => {
@@ -808,7 +862,7 @@ export default {
         },
       });
 
-      api.registerCommand({
+      registerAutoReplyCommand({
         name: "ctx-upgrade",
         description: "Upgrade context-mode to the latest version",
         handler: () => {

--- a/src/adapters/openclaw/plugin.ts
+++ b/src/adapters/openclaw/plugin.ts
@@ -145,9 +145,7 @@ interface OpenClawPluginApi {
     opts?: { priority?: number },
   ): void;
   registerContextEngine?(id: string, factory: () => ContextEngineInstance): void;
-  registerCommand?:
-    | ((cmd: OpenClawCommandDefinition) => void)
-    | ((name: string, options: Omit<OpenClawCommandDefinition, "name">) => void);
+  registerCommand?: (cmd: OpenClawCommandDefinition) => void;
   registerCli?(
     factory: (ctx: { program: unknown }) => void,
     meta: { commands: string[] },
@@ -345,31 +343,13 @@ export default {
     const registerAutoReplyCommand = (command: OpenClawCommandDefinition): void => {
       if (!api.registerCommand) return;
       try {
-        (api.registerCommand as (cmd: OpenClawCommandDefinition) => void)(command);
+        api.registerCommand(command);
       } catch (err) {
-        try {
-          (
-            api.registerCommand as (
-              name: string,
-              options: Omit<OpenClawCommandDefinition, "name">,
-            ) => void
-          )(command.name, {
-            description: command.description,
-            acceptsArgs: command.acceptsArgs,
-            requireAuth: command.requireAuth,
-            handler: command.handler,
-          });
-        } catch (fallbackErr) {
-          log.warn?.(
-            "registerCommand compatibility fallback failed; skipping auto-reply command",
-            { name: command.name },
-            fallbackErr,
-          );
-          log.debug("registerCommand primary signature error", {
-            name: command.name,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
+        log.warn?.(
+          "registerCommand failed; skipping auto-reply command",
+          { name: command.name },
+          err,
+        );
       }
     };
 

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "222.5k+",
+  "message": "226.7k+",
   "color": "brightgreen",
-  "npm": "192.4k+",
-  "marketplace": "30k+"
+  "npm": "197k+",
+  "marketplace": "29.6k+"
 }

--- a/tests/plugins/openclaw.test.ts
+++ b/tests/plugins/openclaw.test.ts
@@ -525,6 +525,17 @@ describe("OpenClawPlugin", () => {
       expect(result.appendSystemContext).toContain("context-mode");
     });
 
+    it("injects skill-like guidance derived from skills/context-mode/SKILL.md", async () => {
+      const mock = await createTestPlugin(join(tempDir, "prompt-skill-like"));
+      await flushInit(mock);
+      const promptHook = mock.lifecycle.find(
+        (l) => l.event === "before_prompt_build" && l.opts?.priority === 5,
+      );
+      const result = promptHook!.handler() as { appendSystemContext?: string };
+      expect(result?.appendSystemContext).toContain("<context_mode_skill_like_guidance");
+      expect(result?.appendSystemContext).toContain("Default to context-mode for ALL commands.");
+    });
+
     it("has priority 5", async () => {
       const mock = await createTestPlugin(join(tempDir, "prompt-priority"));
       const promptHook = mock.lifecycle.find(
@@ -671,6 +682,7 @@ describe("OpenClawPlugin", () => {
       expect(out?.inputOverride?.prompt).toBeDefined();
       expect(out!.inputOverride!.prompt!).toContain("Investigate the failing test.");
       expect(out!.inputOverride!.prompt!).toContain("<context_window_protection>");
+      expect(out!.inputOverride!.prompt!).toContain("<context_mode_skill_like_guidance");
     });
 
     it("falls back gracefully when input.prompt is missing", async () => {
@@ -681,6 +693,7 @@ describe("OpenClawPlugin", () => {
         | { inputOverride?: { prompt?: string } }
         | undefined;
       expect(out?.inputOverride?.prompt).toContain("<context_window_protection>");
+      expect(out?.inputOverride?.prompt).toContain("<context_mode_skill_like_guidance");
     });
   });
 

--- a/tests/plugins/openclaw.test.ts
+++ b/tests/plugins/openclaw.test.ts
@@ -53,7 +53,7 @@ interface MockContextEngine {
 function createMockApiWithoutRegisterHook() {
   const lifecycle: MockLifecycleEntry[] = [];
   const tools: MockToolEntry[] = [];
-  const commands: MockV2CommandEntry[] = [];
+  const commands: MockCommandEntry[] = [];
   const warnings: unknown[][] = [];
 
   return {
@@ -69,19 +69,16 @@ function createMockApiWithoutRegisterHook() {
       ) {
         lifecycle.push({ event, handler, opts });
       },
-      registerCommand(name: unknown, options: unknown) {
+      registerCommand(command: unknown) {
         if (
-          typeof name !== "string" ||
-          !options ||
-          typeof options !== "object" ||
-          typeof (options as { handler?: unknown }).handler !== "function"
+          !command ||
+          typeof command !== "object" ||
+          typeof (command as { name?: unknown }).name !== "string" ||
+          typeof (command as { handler?: unknown }).handler !== "function"
         ) {
-          throw new TypeError("registerCommand(name, options) expected");
+          throw new TypeError("registerCommand(command) expected");
         }
-        commands.push({
-          name,
-          options: options as MockV2CommandEntry["options"],
-        });
+        commands.push(command as MockCommandEntry);
       },
       registerTool(
         tool: Omit<MockToolEntry, "optional">,
@@ -111,11 +108,6 @@ interface MockToolEntry {
   execute: (id: string, params: Record<string, unknown>) =>
     Promise<{ content: Array<{ type: "text"; text: string }> }>;
   optional?: boolean;
-}
-
-interface MockV2CommandEntry {
-  name: string;
-  options: { description?: string; handler: (...args: unknown[]) => unknown };
 }
 
 function createMockApiFull() {

--- a/tests/plugins/openclaw.test.ts
+++ b/tests/plugins/openclaw.test.ts
@@ -50,6 +50,52 @@ interface MockContextEngine {
   };
 }
 
+function createMockApiWithoutRegisterHook() {
+  const lifecycle: MockLifecycleEntry[] = [];
+  const tools: MockToolEntry[] = [];
+  const commands: MockV2CommandEntry[] = [];
+  const warnings: unknown[][] = [];
+
+  return {
+    lifecycle,
+    tools,
+    commands,
+    warnings,
+    api: {
+      on(
+        event: string,
+        handler: (...args: unknown[]) => unknown,
+        opts?: { priority?: number },
+      ) {
+        lifecycle.push({ event, handler, opts });
+      },
+      registerCommand(name: unknown, options: unknown) {
+        if (
+          typeof name !== "string" ||
+          !options ||
+          typeof options !== "object" ||
+          typeof (options as { handler?: unknown }).handler !== "function"
+        ) {
+          throw new TypeError("registerCommand(name, options) expected");
+        }
+        commands.push({
+          name,
+          options: options as MockV2CommandEntry["options"],
+        });
+      },
+      registerTool(
+        tool: Omit<MockToolEntry, "optional">,
+        opts?: { optional?: boolean },
+      ) {
+        tools.push({ ...tool, optional: opts?.optional });
+      },
+      logger: {
+        warn: (...args: unknown[]) => warnings.push(args),
+      },
+    },
+  };
+}
+
 interface MockCommandEntry {
   name: string;
   description: string;
@@ -65,6 +111,11 @@ interface MockToolEntry {
   execute: (id: string, params: Record<string, unknown>) =>
     Promise<{ content: Array<{ type: "text"; text: string }> }>;
   optional?: boolean;
+}
+
+interface MockV2CommandEntry {
+  name: string;
+  options: { description?: string; handler: (...args: unknown[]) => unknown };
 }
 
 function createMockApiFull() {
@@ -264,6 +315,22 @@ describe("OpenClawPlugin", () => {
         expect(hook.meta.name).toMatch(/^context-mode\./);
         expect(hook.meta.description.length).toBeGreaterThan(0);
       }
+    });
+
+    it("degrades gracefully when registerHook and registerContextEngine are unavailable", async () => {
+      const { default: plugin } = await import("../../src/adapters/openclaw/plugin.js");
+      const mock = createMockApiWithoutRegisterHook();
+
+      expect(() => plugin.register(mock.api as unknown as Parameters<typeof plugin.register>[0]))
+        .not.toThrow();
+      expect(mock.tools.length).toBeGreaterThan(0);
+      expect(mock.commands.map((c) => c.name)).toEqual(
+        expect.arrayContaining(["ctx-stats", "ctx-doctor", "ctx-upgrade"]),
+      );
+      const lifecycleNames = mock.lifecycle.map((h) => h.event);
+      expect(lifecycleNames).toContain("before_tool_call");
+      expect(lifecycleNames).toContain("command:new");
+      expect(mock.warnings.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## Summary
- add OpenClaw API compatibility handling for missing hook/context-engine APIs and command registration signatures
- declare plugin `contracts.tools` in both OpenClaw plugin manifests so runtime tool registration passes contract checks

## Validation
- npm --prefix /home/cronus/repos/mcp/context-mode run build
- bash /home/cronus/repos/mcp/context-mode/scripts/test-openclaw-e2e.sh
- openclaw plugins doctor