### PR TITLE
feat(cli): add indexing and search commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,13 @@ All checks should show `[x]`. The doctor validates runtimes, hooks, FTS5, and pl
 |---|---|
 | `/context-mode:ctx-stats` | Context savings — per-tool breakdown, tokens consumed, savings ratio. |
 | `/context-mode:ctx-doctor` | Diagnostics — runtimes, hooks, FTS5, plugin registration, versions. |
+| `/context-mode:ctx-index` | Index a local file or directory into the persistent FTS5 knowledge base. |
+| `/context-mode:ctx-search` | Search previously indexed content. |
 | `/context-mode:ctx-upgrade` | Pull latest, rebuild, migrate cache, fix hooks. |
 | `/context-mode:ctx-purge` | Permanently delete all indexed content from the knowledge base. |
 | `/context-mode:ctx-insight` | Personal analytics dashboard — 90 metrics, 37 insight patterns, 4 composite scores (productivity, quality, delegation, context health) across 23 event categories. Opens a local web UI. |
 
-> **Note:** Slash commands are a Claude Code plugin feature. On other platforms, type `ctx stats`, `ctx doctor`, `ctx upgrade`, or `ctx insight` in the chat — the model calls the MCP tool automatically. See [Utility Commands](#utility-commands).
+> **Note:** Slash commands are a Claude Code plugin feature. On other platforms, type `ctx stats`, `ctx doctor`, `ctx index`, `ctx search`, `ctx upgrade`, or `ctx insight` in the chat — the model calls the MCP tool automatically. See [Utility Commands](#utility-commands).
 
 **Status line (optional):** Claude Code's plugin manifest cannot declare a status line, so this is a one-time manual edit to `~/.claude/settings.json`:
 
@@ -1252,6 +1254,8 @@ See [`docs/platform-support.md`](docs/platform-support.md) for the full capabili
 ```
 ctx stats       → context savings, call counts, session report
 ctx doctor      → diagnose runtimes, hooks, FTS5, versions
+ctx index       → index a local file or directory for later search
+ctx search      → search previously indexed content
 ctx upgrade     → update from GitHub, rebuild, reconfigure hooks
 ctx purge       → permanently delete all indexed content from the knowledge base
 ctx insight     → personal analytics dashboard (opens local web UI)
@@ -1261,6 +1265,8 @@ ctx insight     → personal analytics dashboard (opens local web UI)
 
 ```bash
 context-mode doctor
+context-mode index . --source project:my-app
+context-mode search "authentication middleware" --source project:my-app
 context-mode upgrade
 context-mode insight          # opens analytics dashboard in browser
 bash scripts/ctx-debug.sh    # full diagnostic report for bug reports
@@ -1268,7 +1274,7 @@ bash scripts/ctx-debug.sh    # full diagnostic report for bug reports
 
 The debug script collects OS info, runtime versions, better-sqlite3 status, adapter detection, config files (redacted), hook validation, FTS5/SQLite test, executor test, process check, session databases, and environment variables into a single pasteable markdown report.
 
-Works on **all platforms**. On Claude Code, slash commands (`/ctx-stats`, `/ctx-doctor`, `/ctx-upgrade`, `/ctx-purge`, `/ctx-insight`) are also available.
+Works on **all platforms**. On Claude Code, slash commands (`/ctx-stats`, `/ctx-doctor`, `/ctx-index`, `/ctx-search`, `/ctx-upgrade`, `/ctx-purge`, `/ctx-insight`) are also available.
 
 ## Benchmarks
 

--- a/skills/ctx-index/SKILL.md
+++ b/skills/ctx-index/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ctx-index
+description: |
+  Index a local file or directory into context-mode's persistent FTS5 knowledge base
+  so future ctx_search calls can retrieve focused snippets without rereading raw files.
+  Trigger: /context-mode:ctx-index
+user-invocable: true
+---
+
+# Context Mode Index
+
+Index local project content for later search.
+
+## Instructions
+
+1. Prefer the `ctx_index` MCP tool when it is available.
+2. Ask for a path only if the user did not provide one and the current project root is ambiguous.
+3. Use `path`, not large inline `content`, so file bytes do not enter the conversation.
+4. For repository indexing, pass conservative bounds and a clear source label:
+
+```javascript
+ctx_index({
+  path: ".",
+  source: "project:<name>",
+  maxDepth: 5,
+  maxFiles: 200
+})
+```
+
+5. If MCP tools are unavailable, fall back to the CLI:
+
+```bash
+context-mode index . --source project:<name>
+```
+
+6. Report the indexed source label, file count or section count, and the matching search command:
+
+```javascript
+ctx_search({ source: "project:<name>", queries: ["..."] })
+```
+
+## Safety
+
+- Do not index dependency directories, build outputs, secrets, or generated artifacts.
+- Prefer `--exclude` or `exclude` for project-specific noisy paths.
+- For broad repos, ask the user before raising `maxFiles` above 500.

--- a/skills/ctx-search/SKILL.md
+++ b/skills/ctx-search/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: ctx-search
+description: |
+  Search context-mode's persistent FTS5 knowledge base for previously indexed
+  local project content, documentation, or session memory.
+  Trigger: /context-mode:ctx-search
+user-invocable: true
+---
+
+# Context Mode Search
+
+Search indexed content without rereading raw sources into conversation context.
+
+## Instructions
+
+1. Prefer the `ctx_search` MCP tool when it is available.
+2. Batch all related questions in one `queries` array.
+3. Scope with `source` when the user names a project or indexed label.
+4. Use short, specific queries of two to four technical terms.
+
+```javascript
+ctx_search({
+  source: "project:<name>",
+  queries: ["authentication middleware", "token refresh"],
+  limit: 5
+})
+```
+
+5. If MCP tools are unavailable, fall back to the CLI:
+
+```bash
+context-mode search "authentication middleware" --source project:<name> --limit 5
+```
+
+6. If the index is empty, tell the user to run `/context-mode:ctx-index` or `context-mode index <path>` first.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,9 +17,9 @@
 import * as p from "@clack/prompts";
 import color from "picocolors";
 import { execFileSync, execSync, execFile as nodeExecFile, type ExecSyncOptions } from "node:child_process";
-import { readFileSync, writeFileSync, cpSync, accessSync, existsSync, readdirSync, rmSync, closeSync, openSync, chmodSync, mkdirSync, lstatSync, realpathSync, constants } from "node:fs";
+import { readFileSync, writeFileSync, cpSync, accessSync, existsSync, readdirSync, rmSync, closeSync, openSync, chmodSync, mkdirSync, lstatSync, realpathSync, statSync, constants } from "node:fs";
 import { request as httpsRequest } from "node:https";
-import { resolve, dirname, join, sep } from "node:path";
+import { resolve, dirname, join, sep, basename, isAbsolute } from "node:path";
 import { tmpdir, devNull, homedir } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -39,6 +39,8 @@ import {
   StorageDirectoryError,
   type ResolvedStorageDir,
 } from "./session/db.js";
+import { ContentStore } from "./store.js";
+import { readToolDenyPatterns, evaluateFilePath } from "./security.js";
 // v1.0.128 — Issue #559 sibling MCP kill helpers (see PR-559-560-FIX-DESIGN.md).
 import { discoverSiblingMcpPids, killSiblingMcpServers } from "./util/sibling-mcp.js";
 // v1.0.119 — Issue #523 Layer 5 heal: post-bump assertion on .claude-plugin/plugin.json
@@ -157,10 +159,29 @@ function printHelp(): void {
   console.log([
     "Usage:",
     "  context-mode                         Start MCP server (stdio)",
+    "  context-mode index <path>            Index a file or directory into the FTS5 knowledge base",
+    "  context-mode search <query...>       Search the current project's FTS5 knowledge base",
     "  context-mode doctor                  Diagnose runtime issues, hooks, FTS5, version",
     "  context-mode upgrade                 Fix hooks, permissions, and settings",
     "  context-mode hook <platform> <event> Dispatch a configured hook script",
     "  context-mode statusline              Print Claude Code status line",
+    "",
+    "Index options:",
+    "  --source <label>                     Source label (default: project:<directory-name> or path)",
+    "  --project <path>                     Project identity for the content DB (default: indexed dir or cwd)",
+    "  --max-depth <n>                      Directory recursion depth (default: 5)",
+    "  --max-files <n>                      Directory file cap (default: 200)",
+    "  --ext <.ts,.md>                      Comma-separated extension allowlist",
+    "  --include <glob>                     Directory include pattern (repeatable)",
+    "  --exclude <glob>                     Directory exclude pattern (repeatable)",
+    "  --no-gitignore                       Do not apply .gitignore during directory walks",
+    "  --follow-symlinks                    Follow directory symlinks inside the root",
+    "",
+    "Search options:",
+    "  --project <path>                     Project identity for the content DB (default: cwd)",
+    "  --source <label>                     Filter to a source label (partial match)",
+    "  --limit <n>                          Results to show (default: 3)",
+    "  --type <code|prose>                  Filter by content type",
     "",
     "Environment:",
     "  CONTEXT_MODE_DIR=/absolute/path      Override sessions/content storage root; empty is ignored, non-empty must be absolute",
@@ -169,6 +190,10 @@ function printHelp(): void {
 
 if (args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
   printHelp();
+} else if (args[0] === "index") {
+  indexCommand(args.slice(1)).then((code) => process.exit(code));
+} else if (args[0] === "search") {
+  searchCommand(args.slice(1)).then((code) => process.exit(code));
 } else if (args[0] === "doctor") {
   doctor().then((code) => process.exit(code));
 } else if (args[0] === "upgrade") {
@@ -354,6 +379,223 @@ async function fetchLatestVersion(): Promise<string> {
 
 function describeStorageSource(dir: ResolvedStorageDir): string {
   return dir.envVar ? dir.envVar : "adapter default";
+}
+
+interface ParsedFlags {
+  positional: string[];
+  flags: Record<string, string | boolean | string[]>;
+}
+
+function parseFlags(argv: string[]): ParsedFlags {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean | string[]> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (!arg.startsWith("--") || arg === "--") {
+      positional.push(arg);
+      continue;
+    }
+
+    const raw = arg.slice(2);
+    const eq = raw.indexOf("=");
+    const key = eq >= 0 ? raw.slice(0, eq) : raw;
+    const inlineValue = eq >= 0 ? raw.slice(eq + 1) : undefined;
+    const next = argv[i + 1];
+    const value =
+      inlineValue !== undefined
+        ? inlineValue
+        : next && !next.startsWith("--")
+          ? (i++, next)
+          : true;
+
+    if (key === "include" || key === "exclude") {
+      const prev = flags[key];
+      flags[key] = Array.isArray(prev) ? [...prev, String(value)] : [String(value)];
+    } else {
+      flags[key] = value;
+    }
+  }
+
+  return { positional, flags };
+}
+
+function stringFlag(flags: ParsedFlags["flags"], key: string): string | undefined {
+  const v = flags[key];
+  if (typeof v === "string" && v.length > 0) return v;
+  return undefined;
+}
+
+function boolFlag(flags: ParsedFlags["flags"], key: string): boolean {
+  return flags[key] === true || flags[key] === "true";
+}
+
+function stringListFlag(flags: ParsedFlags["flags"], key: string): string[] | undefined {
+  const v = flags[key];
+  if (Array.isArray(v)) return v.filter(Boolean);
+  if (typeof v === "string" && v.length > 0) return [v];
+  return undefined;
+}
+
+function numberFlag(flags: ParsedFlags["flags"], key: string, opts: { min?: number } = {}): number | undefined {
+  const raw = stringFlag(flags, key);
+  if (!raw) return undefined;
+  const n = Number(raw);
+  const min = opts.min ?? 1;
+  if (!Number.isInteger(n) || n < min) throw new Error(`--${key} must be an integer >= ${min}`);
+  return n;
+}
+
+function extFlag(flags: ParsedFlags["flags"]): string[] | undefined {
+  const raw = stringFlag(flags, "ext") ?? stringFlag(flags, "extensions");
+  if (!raw) return undefined;
+  const exts = raw
+    .split(",")
+    .map((x) => x.trim())
+    .filter(Boolean)
+    .map((x) => (x.startsWith(".") ? x : `.${x}`));
+  return exts.length > 0 ? exts : undefined;
+}
+
+function resolveCliProjectDir(projectFlag: string | undefined, fallback: string): string {
+  if (projectFlag) return resolve(projectFlag);
+  return resolve(fallback);
+}
+
+async function openCliContentStore(projectDir: string): Promise<{ store: ContentStore; dbPath: string; contentDir: string }> {
+  const adapter = await getAdapter(detectPlatform().platform);
+  const contentStorage = resolveContentStorageDir(() => adapter.getSessionDir());
+  const contentDir = ensureWritableStorageDir(contentStorage);
+  const { resolveContentStorePath } = await import("./session/db.js");
+  const dbPath = resolveContentStorePath({ projectDir, contentDir });
+  return { store: new ContentStore(dbPath), dbPath, contentDir };
+}
+
+function defaultSourceForPath(absPath: string): string {
+  try {
+    if (statSync(absPath).isDirectory()) return `project:${basename(absPath) || absPath}`;
+  } catch { /* path errors are reported by the index command */ }
+  return absPath;
+}
+
+function assertReadAllowed(path: string, projectDir: string): void {
+  const denyGlobs = readToolDenyPatterns("Read", projectDir);
+  const denied = evaluateFilePath(path, denyGlobs, process.platform === "win32", projectDir);
+  if (denied.denied) {
+    throw new Error(`Read denied by policy: ${path}`);
+  }
+}
+
+async function indexCommand(argv: string[]): Promise<number> {
+  try {
+    const parsed = parseFlags(argv);
+    const target = parsed.positional[0];
+    if (!target || target === "-h" || target === "--help") {
+      console.log("Usage: context-mode index <path> [--source label] [--project path] [--max-files n] [--max-depth n] [--ext .ts,.md]");
+      return target ? 0 : 1;
+    }
+
+    const absPath = isAbsolute(target) ? resolve(target) : resolve(process.cwd(), target);
+    if (!existsSync(absPath)) throw new Error(`Path does not exist: ${absPath}`);
+
+    const st = statSync(absPath);
+    const projectDir = resolveCliProjectDir(
+      stringFlag(parsed.flags, "project"),
+      st.isDirectory() ? absPath : dirname(absPath),
+    );
+    const source = stringFlag(parsed.flags, "source") ?? defaultSourceForPath(absPath);
+    const { store, dbPath } = await openCliContentStore(projectDir);
+
+    try {
+      assertReadAllowed(absPath, projectDir);
+      if (st.isDirectory()) {
+        const denyGlobs = readToolDenyPatterns("Read", projectDir);
+        const result = store.indexDirectory({
+          path: absPath,
+          source,
+          include: stringListFlag(parsed.flags, "include"),
+          exclude: stringListFlag(parsed.flags, "exclude"),
+          maxDepth: numberFlag(parsed.flags, "max-depth", { min: 0 }),
+          maxFiles: numberFlag(parsed.flags, "max-files"),
+          extensions: extFlag(parsed.flags),
+          respectGitignore: !boolFlag(parsed.flags, "no-gitignore"),
+          followSymlinks: boolFlag(parsed.flags, "follow-symlinks"),
+          perFileDeny: (filePath) => {
+            try {
+              return evaluateFilePath(filePath, denyGlobs, process.platform === "win32", projectDir).denied;
+            } catch {
+              return false;
+            }
+          },
+        });
+        const cap = result.capped ? ` (cap reached at ${result.filesIndexed} files)` : "";
+        const denied = result.denied > 0 ? `; ${result.denied} denied` : "";
+        const failed = result.failed > 0 ? `; ${result.failed} failed` : "";
+        console.log(`Indexed ${result.filesIndexed} files (${result.totalChunks} sections) from ${absPath}${cap}${denied}${failed}`);
+      } else {
+        const result = store.index({ path: absPath, source });
+        console.log(`Indexed ${result.totalChunks} sections (${result.codeChunks} with code) from ${absPath}`);
+      }
+      console.log(`Source: ${source}`);
+      console.log(`Project: ${projectDir}`);
+      console.log(`DB: ${dbPath}`);
+      return 0;
+    } finally {
+      store.close();
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`context-mode index: ${message}`);
+    return 1;
+  }
+}
+
+async function searchCommand(argv: string[]): Promise<number> {
+  try {
+    const parsed = parseFlags(argv);
+    const query = parsed.positional.join(" ").trim();
+    if (!query || query === "-h" || query === "--help") {
+      console.log("Usage: context-mode search <query...> [--source label] [--project path] [--limit n] [--type code|prose]");
+      return query ? 0 : 1;
+    }
+
+    const projectDir = resolveCliProjectDir(stringFlag(parsed.flags, "project"), process.cwd());
+    const { store, dbPath } = await openCliContentStore(projectDir);
+    try {
+      const limit = numberFlag(parsed.flags, "limit") ?? 3;
+      const type = stringFlag(parsed.flags, "type");
+      if (type && type !== "code" && type !== "prose") throw new Error("--type must be code or prose");
+
+      const results = store.searchWithFallback(
+        query,
+        limit,
+        stringFlag(parsed.flags, "source"),
+        type as "code" | "prose" | undefined,
+      );
+      if (results.length === 0) {
+        console.log(`No matches for: ${query}`);
+        console.log(`Project: ${projectDir}`);
+        console.log(`DB: ${dbPath}`);
+        return 0;
+      }
+      for (const [i, r] of results.entries()) {
+        const content = r.content.replace(/\s+/g, " ").trim();
+        const snippet = content.length > 500 ? `${content.slice(0, 500)}...` : content;
+        console.log(`## ${i + 1}. ${r.title}`);
+        console.log(`Source: ${r.source}`);
+        console.log(`Type: ${r.contentType}`);
+        console.log(snippet);
+        console.log("");
+      }
+      return 0;
+    } finally {
+      store.close();
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`context-mode search: ${message}`);
+    return 1;
+  }
 }
 
 function logStorageDir(dir: ResolvedStorageDir): number {

--- a/tests/core/cli.test.ts
+++ b/tests/core/cli.test.ts
@@ -84,6 +84,16 @@ describe("cli.bundle.mjs — marketplace install support", () => {
     expect(src).toMatch(/items\s*=\s*\[[\s\S]*?"cli\.bundle\.mjs"/);
   });
 
+  it("cli.ts exposes index/search commands for terminal knowledge-base access", () => {
+    const src = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
+    expect(src).toContain("context-mode index <path>");
+    expect(src).toContain("context-mode search <query...>");
+    expect(src).toContain('args[0] === "index"');
+    expect(src).toContain('args[0] === "search"');
+    expect(src).toContain("resolveContentStorePath");
+    expect(src).toContain("searchWithFallback");
+  });
+
   it("cli.ts upgrade doctor call prefers cli.bundle.mjs with fallback", () => {
     const src = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf-8");
     expect(src).toContain("cli.bundle.mjs");
@@ -134,6 +144,17 @@ describe("cli.bundle.mjs — marketplace install support", () => {
     expect(skill).toContain("cli.bundle.mjs");
     expect(skill).toContain("build/cli.js");
     expect(skill).toMatch(/CLI=.*cli\.bundle\.mjs.*\[ ! -f.*\].*build\/cli\.js/);
+  });
+
+  it("ctx-index and ctx-search skills expose slash-style triggers", () => {
+    const indexSkill = readFileSync(resolve(ROOT, "skills", "ctx-index", "SKILL.md"), "utf-8");
+    const searchSkill = readFileSync(resolve(ROOT, "skills", "ctx-search", "SKILL.md"), "utf-8");
+    expect(indexSkill).toContain("Trigger: /context-mode:ctx-index");
+    expect(indexSkill).toContain("user-invocable: true");
+    expect(indexSkill).toContain("context-mode index");
+    expect(searchSkill).toContain("Trigger: /context-mode:ctx-search");
+    expect(searchSkill).toContain("user-invocable: true");
+    expect(searchSkill).toContain("context-mode search");
   });
 
   // ── .gitignore ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds terminal and slash-style entry points for pre-warming and querying context-mode's persistent FTS5 knowledge base.

- add `context-mode index <path>` for indexing local files/directories into the per-project content DB
- add `context-mode search <query...>` for querying indexed content from the terminal
- add user-invocable `/context-mode:ctx-index` and `/context-mode:ctx-search` skills
- document the new slash, chat utility, and terminal commands
- add focused CLI surface regression tests

## Why

`ctx_index(path)` already supports indexing file and directory content through MCP, but there was no deterministic terminal entry point for pre-filling the SQLite/FTS5 store before or outside an agent session. This makes the workflow discoverable and automatable while keeping raw project bytes out of chat context.

## Validation

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run tests/core/cli.test.ts --reporter=dot`
- smoke test: `context-mode index README.md --project . --source smoke:readme`, then `context-mode search "context savings" --project . --source smoke:readme --limit 1`
- `git diff --check`