### PR TITLE
fix(codex): set platform env for plugin MCP server

### DIFF
--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -4,6 +4,9 @@
       "command": "node",
       "args": ["./start.mjs"],
       "cwd": ".",
+      "env": {
+        "CONTEXT_MODE_PLATFORM": "codex"
+      },
       "default_tools_approval_mode": "approve"
     }
   }

--- a/README.md
+++ b/README.md
@@ -586,6 +586,9 @@ The Codex plugin manifest provides MCP via `.codex-plugin/mcp.json`, skills via
 
    [mcp_servers.context-mode]
    command = "context-mode"
+
+   [mcp_servers.context-mode.env]
+   CONTEXT_MODE_PLATFORM = "codex"
    ```
 
 3. Create `$CODEX_HOME/hooks.json` (or `~/.codex/hooks.json` when `CODEX_HOME` is unset):

--- a/tests/plugins/codex-manifest.test.ts
+++ b/tests/plugins/codex-manifest.test.ts
@@ -66,6 +66,15 @@ describe(".codex-plugin/mcp.json", () => {
     expect(entry.cwd).toBe(".");
   });
 
+  it("sets CONTEXT_MODE_PLATFORM=codex for the MCP server process", () => {
+    // Codex hook wrappers already set this before loading shared hook code.
+    // The MCP server needs the same signal so storage and doctor output do
+    // not fall back to ~/.claude on machines that have both agents installed.
+    const servers = mcp.mcpServers as Record<string, { env?: Record<string, string> }>;
+    const entry = servers["context-mode"];
+    expect(entry.env?.CONTEXT_MODE_PLATFORM).toBe("codex");
+  });
+
   it("does NOT use `${CODEX_PLUGIN_ROOT}` placeholders (no var expansion happens)", () => {
     const raw = readFileSync(resolve(REPO_ROOT, ".codex-plugin/mcp.json"), "utf8");
     expect(raw).not.toMatch(/\$\{[^}]*PLUGIN_ROOT[^}]*\}/);


### PR DESCRIPTION
## Summary
- set `CONTEXT_MODE_PLATFORM=codex` in the Codex plugin MCP manifest
- document the same env for the manual Codex fallback config
- add a manifest regression test so the Codex MCP server stays aligned with hook wrappers

## Why
On Windows machines with both Claude Code and Codex installed, context-mode can otherwise fall through config-dir detection and pick `claude-code` because `~/.claude` exists before `~/.codex`. The Codex hook wrappers already set `CONTEXT_MODE_PLATFORM=codex`; this makes the plugin MCP server get the same platform signal.

This keeps Codex plugin storage and doctor output under `~/.codex/context-mode` instead of accidentally falling back to Claude storage before client/platform metadata is available.

## Validation
- `npx vitest run tests/plugins/codex-manifest.test.ts --reporter=dot`
- `npx vitest run tests/core/cli.test.ts tests/plugins/codex-manifest.test.ts tests/adapters/detect.test.ts --reporter=dot`
- `npx vitest run tests/core/server.test.ts -t "getDefaultSessionDir|ctx_doctor reports storage|Storage sessions" --reporter=dot`
- `npm run typecheck`
- `git diff --check`

Manual Codex check on Windows:
- Codex CLI: `codex-cli 0.133.0`
- installed a temporary local Codex marketplace/plugin containing the updated `.codex-plugin/mcp.json`
- `codex mcp get context-mode-env-test` showed `CONTEXT_MODE_PLATFORM` attached to the MCP server env, confirming Codex consumes this manifest field in the actual plugin registration path