### PR TITLE
feat(ctx-upgrade): improve upgrade process version detection

### DIFF
--- a/skills/ctx-upgrade/SKILL.md
+++ b/skills/ctx-upgrade/SKILL.md
@@ -24,7 +24,7 @@ Pull latest from GitHub and reinstall the plugin.
    - [x] Doctor: all checks PASS
    ```
    Use `[x]` for success, `[ ]` for failure. Show actual version numbers.
-4. Tell the user to **restart their session** to pick up the new version.
+4. If the output shows a new version was installed, tell the user to **restart their session** to pick up the new version. If it says "Already on latest", no restart is needed.
 5. **Fallback** (only if MCP tool call fails): Derive the **plugin root** from this skill's base directory (go up 2 levels — remove `/skills/ctx-upgrade`), then run with Bash:
    ```
    CLI="<PLUGIN_ROOT>/cli.bundle.mjs"; [ ! -f "$CLI" ] && CLI="<PLUGIN_ROOT>/build/cli.js"; node "$CLI" upgrade

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1068,6 +1068,7 @@ async function upgrade(opts?: { platform?: string }) {
 
   let pluginRoot = getPluginRoot();
   const changes: string[] = [];
+  let didBumpVersion = false;
   const s = p.spinner();
 
   // Step 0: Sync the marketplace clone (#418).
@@ -1531,6 +1532,7 @@ async function upgrade(opts?: { platform?: string }) {
       } catch { /* best effort — registry may not exist or be malformed */ }
 
       changes.push(`Updated v${localVersion} → v${newVersion}`);
+      didBumpVersion = true;
       p.log.success(
         color.green("Plugin reinstalled from GitHub!") +
           color.dim(` — v${newVersion}`),
@@ -1635,13 +1637,15 @@ async function upgrade(opts?: { platform?: string }) {
   }
 
   // Restart notice — new MCP tools require MCP server restart
-  const restartHint = adapter.name === "Claude Code"
-    ? "/reload-plugins, new terminal, or restart session"
-    : "new terminal or restart session";
-  p.log.warn(
-    color.yellow("Restart for new MCP tools to take effect.") +
-      color.dim(` (${restartHint})`),
-  );
+  if (didBumpVersion) {
+    const restartHint = adapter.name === "Claude Code"
+      ? "/reload-plugins, new terminal, or restart session"
+      : "new terminal or restart session";
+    p.log.warn(
+      color.yellow("Restart for new MCP tools to take effect.") +
+        color.dim(` (${restartHint})`),
+    );
+  }
 
   // Step 7: Run doctor
   p.log.step("Running doctor to verify...");

--- a/src/server.ts
+++ b/src/server.ts
@@ -3867,7 +3867,8 @@ server.registerTool(
       "  - [x] Hooks configured",
       "  - [x] Doctor: all checks PASS",
       "  ```",
-      "- Tell the user to restart their session to pick up the new version.",
+      "- If the output says a new version was installed, tell the user to restart their session to pick up the new version.",
+      "- If the output says \"Already on latest\", no restart is needed.",
     ].join("\n");
 
     return trackResponse("ctx_upgrade", {


### PR DESCRIPTION

## What / Why / How

- Only show restart notice when a new version was actually installed
- Update documentation to clarify restart condition based on version output
- Add version tracking to prevent unnecessary restart prompts

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [x] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
