### PR TITLE
fix(routing): bootstrap deferred ctx_* tools in subagent prompts (#724)

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -822,7 +822,15 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
     const fieldName = ["prompt", "request", "objective", "question", "query", "task"].find(f => f in toolInput) ?? "prompt";
     const prompt = toolInput[fieldName] ?? "";
 
-    const subagentBlock = createRoutingBlock(t, { includeCommands: false });
+    // Claude Code surfaces ctx_* as DEFERRED tools (schemas loaded via ToolSearch).
+    // Without a bootstrap step the subagent is told to use ctx_* tools it cannot yet
+    // invoke and stalls (see #724). Prepend the ToolSearch bootstrap for claude-code
+    // (the default when platform is unset). Other platforms don't defer, so skip it.
+    const isClaudeCode = !platform || platform === "claude-code";
+    const subagentBlock = createRoutingBlock(t, {
+      includeCommands: false,
+      toolSearchBootstrap: isClaudeCode,
+    });
 
     const updatedInput =
       subagentType === "Bash"

--- a/hooks/routing-block.mjs
+++ b/hooks/routing-block.mjs
@@ -14,13 +14,19 @@ import { createToolNamer } from "./core/tool-naming.mjs";
 // ── Factory functions ─────────────────────────────────────
 
 export function createRoutingBlock(t, options = {}) {
-  const { includeCommands = true } = options;
+  const { includeCommands = true, toolSearchBootstrap = false } = options;
   return `
 <context_window_protection>
   <priority_instructions>
     Every byte a tool returns enters your conversation memory and costs reasoning capacity for the rest of the session. The context-mode tools let you do the work in a sandbox and surface only the derived answer — the raw bytes stay out. Think-in-Code: program the analysis, do not compute it by reading raw data into your conversation.
   </priority_instructions>
-
+${toolSearchBootstrap ? `
+  <deferred_tool_bootstrap>
+    The context-mode tools below may be DEFERRED in your harness — their schemas are not loaded yet, so calling them directly fails (e.g. "tool not found" / InputValidationError). Load them ONCE before your first ctx_* call:
+    ToolSearch(query: "select:${t("ctx_batch_execute")},${t("ctx_search")},${t("ctx_execute")},${t("ctx_execute_file")},${t("ctx_fetch_and_index")}")
+    After that they are callable. If any ctx_* call fails as not-found, ToolSearch it and retry — do NOT fall back to Bash/Read just because the schema was not loaded yet.
+  </deferred_tool_bootstrap>
+` : ''}
   <tool_selection_hierarchy>
     0. MEMORY: ${t("ctx_search")}(sort: "timeline")
        - On resume or compaction, query prior decisions, errors, plans, user prompts before asking the user — auto-captured session memory is searchable.

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "226.7k+",
+  "message": "226.6k+",
   "color": "brightgreen",
   "npm": "197k+",
-  "marketplace": "29.6k+"
+  "marketplace": "29.5k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "226.6k+",
+  "message": "230.7k+",
   "color": "brightgreen",
-  "npm": "197k+",
+  "npm": "201.1k+",
   "marketplace": "29.5k+"
 }

--- a/tests/core/routing.test.ts
+++ b/tests/core/routing.test.ts
@@ -7,9 +7,14 @@ import {
 import { createRoutingBlock } from "../../hooks/routing-block.mjs";
 import { createToolNamer } from "../../hooks/core/tool-naming.mjs";
 
-// Subagent routing uses createRoutingBlock(t, { includeCommands: false })
+// Subagent routing uses createRoutingBlock(t, { includeCommands: false }).
+// For claude-code (incl. the default when platform is unset) it also enables the
+// ToolSearch bootstrap so deferred ctx_* tools are loadable by the subagent (#724).
 const _t = createToolNamer("claude-code");
-const SUBAGENT_BLOCK = createRoutingBlock(_t, { includeCommands: false });
+const SUBAGENT_BLOCK = createRoutingBlock(_t, {
+  includeCommands: false,
+  toolSearchBootstrap: true,
+});
 
 describe("Routing: Subagents (Agent only — Task removed per #241)", () => {
   it("Agent tool injects routing block into prompt field", () => {
@@ -64,6 +69,21 @@ describe("Routing: Subagents (Agent only — Task removed per #241)", () => {
     expect(prompt).toContain("label");
     expect(prompt).toContain("descriptive");
     expect(prompt).toContain("FTS5 chunk title");
+  });
+
+  it("Agent block includes the ToolSearch bootstrap for deferred ctx_* tools on claude-code (#724)", () => {
+    const decision = routePreToolUse("Agent", { prompt: "test" }, "/test", "claude-code");
+    const prompt = decision.updatedInput.prompt;
+    expect(prompt).toContain("deferred_tool_bootstrap");
+    expect(prompt).toContain("ToolSearch");
+    expect(prompt).toContain("select:mcp__plugin_context-mode_context-mode__ctx_batch_execute");
+  });
+
+  it("Agent block omits the ToolSearch bootstrap on platforms without deferred tools (#724)", () => {
+    const decision = routePreToolUse("Agent", { prompt: "test" }, "/test", "codex");
+    const prompt = decision.updatedInput.prompt;
+    expect(prompt).not.toContain("deferred_tool_bootstrap");
+    expect(prompt).not.toContain("ToolSearch");
   });
 
   it("Task tool is NOT routed — returns null (passthrough) (#241)", () => {


### PR DESCRIPTION
Fixes #724.

## Problem

The `Agent` PreToolUse hook appends the routing block to every subagent prompt,
instructing it to use the `ctx_*` MCP tools and **not** Bash/Read. But in Claude
Code those `ctx_*` tools are **deferred** — their schemas must be loaded via
`ToolSearch` before they can be called. The injected block never tells the
subagent to do that, so a narrow subagent (e.g. the built-in `Explore` type)
is told to use a tool it cannot yet invoke and stalls — observed multi-minute
hangs with near-zero output (one ran ~63 min).

A controlled probe confirmed the mechanism: a `general-purpose` subagent (which
carries `ToolSearch`) loaded the schema and ran `ctx_batch_execute` in ~1–2s with
no cold-start; the only thing separating success from a stall was the missing
`ToolSearch` bootstrap step. (Cold-start and SQLite/FTS5 lock contention were
ruled out.)

## Fix

Make the subagent routing block self-bootstrapping. `createRoutingBlock` gains an
opt-in `toolSearchBootstrap` option (default `false`, so the main-session block
and all other callers are unchanged). When enabled, it prepends a
`<deferred_tool_bootstrap>` section telling the subagent to `ToolSearch` the
`ctx_*` schemas before first use and not to fall back to Bash/Read just because a
first call failed as not-found.

The `Agent` branch in `routing.mjs` enables it **only for claude-code** (the
default when `platform` is unset); other platforms don't defer tools, so they're
untouched.

## Changes

- `hooks/routing-block.mjs` — add `toolSearchBootstrap` option + the
  `<deferred_tool_bootstrap>` section (uses the platform tool-namer for correct
  names).
- `hooks/core/routing.mjs` — `Agent` branch passes `toolSearchBootstrap` gated on
  claude-code.
- `tests/core/routing.test.ts` — update the shared `SUBAGENT_BLOCK` constant and
  add two cases (bootstrap present for claude-code, absent for `codex`).

## Testing

- `npx vitest run tests/core/routing.test.ts` → 29/29 pass.
- Default-off option; `ROUTING_BLOCK` (main session) and non-claude-code platforms
  are byte-for-byte unchanged.

## Alternative / follow-up

A complementary option (not done here, to keep the change minimal) is to skip the
injection entirely for read-only subagent types like `Explore`, since they're
designed around Grep/Read. Happy to add that if you'd prefer it.
