### PR TITLE
feat: detect and prioritize project-local venv python runtimes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -425,7 +425,11 @@ async function doctor(): Promise<number> {
   let runtimes: ReturnType<typeof detectRuntimes>;
   let available: string[];
   try {
-    runtimes = detectRuntimes();
+    // Pass cwd so detectVenvPython() picks up .venv/bin/python in the
+    // user's project. Without this, doctor's PolyglotExecutor (below)
+    // receives a runtime map with the global python rather than the
+    // activated/local one.
+    runtimes = detectRuntimes(process.cwd());
     available = getAvailableLanguages(runtimes);
   } catch {
     s.stop("Diagnostics partial");

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -157,7 +157,7 @@ export class PolyglotExecutor {
     } else {
       this.#projectRootResolver = () => process.cwd();
     }
-    this.#runtimes = opts?.runtimes ?? detectRuntimes();
+    this.#runtimes = opts?.runtimes ?? detectRuntimes(this.#projectRoot);
   }
 
   get #projectRoot(): string {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -89,6 +89,14 @@ function commandExists(cmd: string): boolean {
  * exit 0 before declaring the runtime available (#455).
  */
 function runnableExists(cmd: string): boolean {
+  // Defense-in-depth (#455 fb4bc5ad): reject Windows MS Store App Execution
+  // Alias stubs even when the caller passes an absolute path. The stubs are
+  // 0-byte reparse points under %LOCALAPPDATA%\Microsoft\WindowsApps\ that
+  // existsSync() reports as true — without this guard an absolute-path probe
+  // would skip the stub filter and rely solely on the slow --version timeout.
+  if (isWindows && /\\Microsoft\\WindowsApps\\/i.test(cmd)) {
+    return false;
+  }
   const isDirectFile = existsSync(cmd);
   if (!isDirectFile) {
     if (isWindows) {
@@ -233,8 +241,26 @@ function getVersion(cmd: string, args: string[] = ["--version"]): string {
 }
 
 function detectVenvPython(projectRoot?: string): string | null {
-  const roots = [projectRoot, process.cwd()].filter((r): r is string => typeof r === "string" && r !== "");
   const isWin = process.platform === "win32";
+
+  // 1. $VIRTUAL_ENV — canonical activated-venv signal. Covers poetry, uv,
+  //    pyenv-virtualenv, conda, ~/.virtualenvs/* and any non-standard layout
+  //    the user has activated. Trust the env var over a disk scan because the
+  //    venv binary may live outside the project tree (e.g. ~/.cache/pypoetry).
+  //    Complements #22 (3e059bd5) which already passes VIRTUAL_ENV through to
+  //    child processes — here we also use it to pick the parent's interpreter.
+  const activeVenv = process.env.VIRTUAL_ENV;
+  if (activeVenv) {
+    const activatedPython = isWin
+      ? resolve(activeVenv, "Scripts", "python.exe")
+      : resolve(activeVenv, "bin", "python");
+    if (existsSync(activatedPython) && runnableExists(activatedPython)) {
+      return activatedPython;
+    }
+  }
+
+  // 2. Disk scan under projectRoot / cwd for the conventional .venv | venv layout.
+  const roots = [projectRoot, process.cwd()].filter((r): r is string => typeof r === "string" && r !== "");
   const subPaths = isWin
     ? [join(".venv", "Scripts", "python.exe"), join("venv", "Scripts", "python.exe")]
     : [join(".venv", "bin", "python"), join("venv", "bin", "python")];

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,5 +1,6 @@
 import { execFileSync, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
 
 /**
  * Allowlist for SHELL env override. Only POSIX shells + Windows shells permit
@@ -88,19 +89,22 @@ function commandExists(cmd: string): boolean {
  * exit 0 before declaring the runtime available (#455).
  */
 function runnableExists(cmd: string): boolean {
-  if (isWindows) {
-    // Reject if every `where` hit lives under Microsoft\WindowsApps (Store stubs).
-    try {
-      const out = execSync(`where ${cmd}`, { encoding: "utf-8", stdio: "pipe" });
-      const hits = out.trim().split(/\r?\n/).map(p => p.trim()).filter(Boolean);
-      if (hits.length === 0) return false;
-      const realHits = hits.filter(p => !/\\Microsoft\\WindowsApps\\/i.test(p));
-      if (realHits.length === 0) return false;
-    } catch {
+  const isDirectFile = existsSync(cmd);
+  if (!isDirectFile) {
+    if (isWindows) {
+      // Reject if every `where` hit lives under Microsoft\WindowsApps (Store stubs).
+      try {
+        const out = execSync(`where ${cmd}`, { encoding: "utf-8", stdio: "pipe" });
+        const hits = out.trim().split(/\r?\n/).map(p => p.trim()).filter(Boolean);
+        if (hits.length === 0) return false;
+        const realHits = hits.filter(p => !/\\Microsoft\\WindowsApps\\/i.test(p));
+        if (realHits.length === 0) return false;
+      } catch {
+        return false;
+      }
+    } else if (!commandExists(cmd)) {
       return false;
     }
-  } else if (!commandExists(cmd)) {
-    return false;
   }
   // Probe with --version. On Windows, allow 5s for cold-start (MS Store stub
   // fallthrough can be slow). On POSIX, 1500ms is plenty for a real binary
@@ -228,7 +232,25 @@ function getVersion(cmd: string, args: string[] = ["--version"]): string {
   }
 }
 
-export function detectRuntimes(): RuntimeMap {
+function detectVenvPython(projectRoot?: string): string | null {
+  const roots = [projectRoot, process.cwd()].filter((r): r is string => typeof r === "string" && r !== "");
+  const isWin = process.platform === "win32";
+  const subPaths = isWin
+    ? [join(".venv", "Scripts", "python.exe"), join("venv", "Scripts", "python.exe")]
+    : [join(".venv", "bin", "python"), join("venv", "bin", "python")];
+
+  for (const root of roots) {
+    for (const subPath of subPaths) {
+      const fullPath = resolve(root, subPath);
+      if (existsSync(fullPath) && runnableExists(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+  return null;
+}
+
+export function detectRuntimes(projectRoot?: string): RuntimeMap {
   const hasBun = bunExists();
   const bun = hasBun ? bunCommand() : null;
 
@@ -248,6 +270,7 @@ export function detectRuntimes(): RuntimeMap {
     !(isWin && isWindowsWslBash(userShell))
     ? userShell
     : null;
+  const venvPython = detectVenvPython(projectRoot);
 
   return {
     javascript: bun ?? process.execPath,
@@ -258,13 +281,13 @@ export function detectRuntimes(): RuntimeMap {
         : commandExists("ts-node")
           ? "ts-node"
           : null,
-    python: runnableExists("python3")
+    python: venvPython ?? (runnableExists("python3")
       ? "python3"
       : runnableExists("python")
         ? "python"
         : runnableExists("py")
           ? "py"
-          : null,
+          : null),
     shell: shellOverride ?? (isWin
       ? (resolveWindowsBash() ?? (commandExists("sh") ? "sh" : commandExists("powershell") ? "powershell" : "cmd.exe"))
       : commandExists("bash") ? "bash" : "sh"),

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,7 +87,12 @@ if (process.env.CONTEXT_MODE_EMBEDDED_PLUGIN_TOOLS !== "1") {
   });
 }
 
-const runtimes = detectRuntimes();
+// Pass the resolved project directory so detectVenvPython() can find
+// .venv/bin/python at boot. getProjectDir is hoisted from its function
+// declaration below (line ~537). Without projectRoot the venv check
+// falls back to process.cwd(), which for MCP servers spawned by editors
+// is rarely the user's actual project root.
+const runtimes = detectRuntimes(getProjectDir());
 const available = getAvailableLanguages(runtimes);
 export const server = new McpServer({
   name: "context-mode",

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -744,3 +744,182 @@ describe("buildCommand shell variants", () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────
+// PR #726 — project-local venv python detection
+//
+// detectVenvPython() resolves the Python interpreter in this order:
+//   1. $VIRTUAL_ENV/bin/python  (POSIX) | $VIRTUAL_ENV\Scripts\python.exe (Win)
+//   2. <projectRoot>/.venv/bin/python | venv/bin/python (POSIX equivalents on Win)
+//   3. <cwd>/.venv/bin/python | venv/bin/python
+//   4. PATH lookup for python3 → python → py
+//
+// Tests mock node:fs.existsSync and node:child_process.execFileSync/execSync
+// so they run identically across macOS / Linux / Windows CI without touching
+// the real disk. process.platform is stubbed to validate the path-separator
+// branch for each OS.
+// ─────────────────────────────────────────────────────────
+describe("detectVenvPython — project-local venv prioritization (#726)", () => {
+  const ORIG_VIRTUAL_ENV = process.env.VIRTUAL_ENV;
+  const ORIG_PLATFORM = process.platform;
+
+  beforeEach(() => {
+    delete process.env.VIRTUAL_ENV;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:child_process");
+    if (ORIG_VIRTUAL_ENV === undefined) {
+      delete process.env.VIRTUAL_ENV;
+    } else {
+      process.env.VIRTUAL_ENV = ORIG_VIRTUAL_ENV;
+    }
+    Object.defineProperty(process, "platform", { value: ORIG_PLATFORM, configurable: true });
+  });
+
+  /** Mock node:fs.existsSync to return true ONLY for the paths in `present`,
+   *  AND mock node:child_process so --version probes for those paths succeed.
+   *  This combination makes runnableExists() return true for our venv binary
+   *  without touching the real filesystem.
+   */
+  function mockFsAndProbes(present: string[]) {
+    const presentSet = new Set(present);
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (p: string) => presentSet.has(p),
+      };
+    });
+    const execFileSync = vi.fn((cmd: string, args: string[]) => {
+      if (args && args[0] === "--version" && presentSet.has(cmd)) {
+        return Buffer.from("Python 3.11.4\n");
+      }
+      throw new Error(`probe failed: ${cmd}`);
+    });
+    const execSync = vi.fn((cmd: string) => {
+      // POSIX `command -v <x>` lookups — fail everything so PATH-fallback
+      // can't accidentally satisfy the test.
+      if (/^command -v\s/.test(cmd)) throw new Error("not in PATH");
+      // Windows `where <x>` lookups — fail everything for the same reason.
+      if (/^where\s/.test(cmd)) throw new Error("not in PATH");
+      // Windows `"<cmd>" --version` probe.
+      const probe = cmd.match(/^"([^"]+)"\s+--version$/);
+      if (probe && presentSet.has(probe[1])) {
+        return Buffer.from("Python 3.11.4\n");
+      }
+      throw new Error(`unmocked execSync: ${cmd}`);
+    });
+    vi.doMock("node:child_process", () => ({ execFileSync, execSync }));
+  }
+
+  test("(a) POSIX: finds <projectRoot>/.venv/bin/python", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const projectRoot = "/home/user/project";
+    const venvPy = `${projectRoot}/.venv/bin/python`;
+    mockFsAndProbes([venvPy]);
+
+    const { detectRuntimes } = await import("../src/runtime.js");
+    const r = detectRuntimes(projectRoot);
+
+    expect(r.python).toBe(venvPy);
+  });
+
+  test("(b) Windows: finds <projectRoot>\\.venv\\Scripts\\python.exe", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    // Use a POSIX-shaped absolute root so node:path.resolve on the host
+    // test runner produces a stable string we can match. The branch under
+    // test is the Windows subPaths array (Scripts\\python.exe), which the
+    // process.platform stub selects regardless of host OS.
+    const projectRoot = "/fake/win-project";
+    const { join, resolve } = await import("node:path");
+    const venvPy = resolve(projectRoot, join(".venv", "Scripts", "python.exe"));
+    mockFsAndProbes([venvPy]);
+
+    const { detectRuntimes } = await import("../src/runtime.js");
+    const r = detectRuntimes(projectRoot);
+
+    expect(r.python).toBe(venvPy);
+    // Verify the Windows subPath was used (not the POSIX bin/python).
+    expect(venvPy).toContain("Scripts");
+    expect(venvPy).toContain("python.exe");
+  });
+
+  test("(c) $VIRTUAL_ENV precedence over disk scan (covers poetry/uv/pyenv-virtualenv)", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const projectRoot = "/home/user/project";
+    const projectVenv = `${projectRoot}/.venv/bin/python`;
+    const activatedVenv = "/home/user/.cache/pypoetry/virtualenvs/myproj-py3.11/bin/python";
+    process.env.VIRTUAL_ENV = "/home/user/.cache/pypoetry/virtualenvs/myproj-py3.11";
+    // BOTH exist — activated venv must win.
+    mockFsAndProbes([projectVenv, activatedVenv]);
+
+    const { detectRuntimes } = await import("../src/runtime.js");
+    const r = detectRuntimes(projectRoot);
+
+    expect(r.python).toBe(activatedVenv);
+  });
+
+  test("(d) orphan-exe fallthrough — existsSync true but --version fails → fall through to PATH", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const projectRoot = "/home/user/project";
+    const venvPy = `${projectRoot}/.venv/bin/python`;
+    // .venv/bin/python exists on disk but the binary is broken (e.g. recreated
+    // interpreter has wrong dynamic linker after a system upgrade). It must NOT
+    // be selected — detectRuntimes must fall through to PATH-based python3.
+    const presentSet = new Set([venvPy]);
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return { ...actual, existsSync: (p: string) => presentSet.has(p) };
+    });
+    const execFileSync = vi.fn((cmd: string, args: string[]) => {
+      if (args && args[0] === "--version") {
+        if (cmd === venvPy) throw new Error("orphan venv: bad interpreter");
+        if (cmd === "python3") return Buffer.from("Python 3.11.4\n");
+      }
+      throw new Error(`probe failed: ${cmd}`);
+    });
+    const execSync = vi.fn((cmd: string) => {
+      if (cmd === "command -v python3") return Buffer.from("/usr/bin/python3\n");
+      if (/^command -v\s/.test(cmd)) throw new Error("not in PATH");
+      throw new Error(`unmocked execSync: ${cmd}`);
+    });
+    vi.doMock("node:child_process", () => ({ execFileSync, execSync }));
+
+    const { detectRuntimes } = await import("../src/runtime.js");
+    const r = detectRuntimes(projectRoot);
+
+    expect(r.python).toBe("python3");
+  });
+
+  test("(e) dead symlink fallthrough — existsSync false → skip venv, use PATH", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const projectRoot = "/home/user/project";
+    // Dead symlink: existsSync follows symlinks → returns false for broken targets.
+    // No fs entries are "present" → venv check returns null → fall through to python3.
+    const presentSet = new Set<string>();
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return { ...actual, existsSync: (p: string) => presentSet.has(p) };
+    });
+    const execFileSync = vi.fn((cmd: string, args: string[]) => {
+      if (args && args[0] === "--version" && cmd === "python3") {
+        return Buffer.from("Python 3.11.4\n");
+      }
+      throw new Error(`probe failed: ${cmd}`);
+    });
+    const execSync = vi.fn((cmd: string) => {
+      if (cmd === "command -v python3") return Buffer.from("/usr/bin/python3\n");
+      if (/^command -v\s/.test(cmd)) throw new Error("not in PATH");
+      throw new Error(`unmocked execSync: ${cmd}`);
+    });
+    vi.doMock("node:child_process", () => ({ execFileSync, execSync }));
+
+    const { detectRuntimes } = await import("../src/runtime.js");
+    const r = detectRuntimes(projectRoot);
+
+    expect(r.python).toBe("python3");
+  });
+});


### PR DESCRIPTION
This PR modifies the executor and runtime detection of context-mode to scan for and prioritize project-local virtual environments (\.venv\ or \env\) when executing Python code. It also updates instruction templates to recommend Python standard library over JavaScript for better conciseness and token efficiency.