### PR TITLE
Codex/fix windows plugin symlink docs

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -252,6 +252,18 @@ context-mode hook codex stop
   at `%USERPROFILE%\.codex\local-marketplaces\context-mode` with
   `source_type = "local"` and retry the install.
 
+  After installation succeeds, verify that Codex hooks are enabled in
+  `%USERPROFILE%\.codex\config.toml`:
+
+  ```toml
+  [features]
+  hooks = true
+  ```
+
+  Some Codex builds may also require `plugin_hooks = true`. Without hook support,
+  the MCP tools can still work, but automatic session capture and persistent
+  memory may not record events.
+
 ---
 
 ### Qwen Code

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -232,6 +232,25 @@ context-mode hook codex stop
 - Codex emits structured tool names such as `Bash` and `apply_patch`; context-mode only normalizes legacy shell aliases.
 - updatedInput and updatedMCPToolOutput are in the schema but NOT implemented
 - Default hook timeout: 600 seconds
+- Codex plugin marketplace installs on Windows can fail with `missing plugin.json` if
+  Git checks out `plugins/context-mode` as a regular file containing `..` instead of
+  a directory symlink. The Codex marketplace manifest points at
+  `./plugins/context-mode` because Codex currently rejects the repository root
+  (`"./"`) as an empty local plugin source path. If this happens, use a local
+  marketplace wrapper or Windows junction so `plugins/context-mode` resolves to
+  the repository root and contains `.codex-plugin/plugin.json`.
+
+  Example local workaround:
+
+  ```cmd
+  mkdir "%USERPROFILE%\.codex\local-marketplaces\context-mode\.agents\plugins"
+  mkdir "%USERPROFILE%\.codex\local-marketplaces\context-mode\plugins"
+  mklink /J "%USERPROFILE%\.codex\local-marketplaces\context-mode\plugins\context-mode" "%USERPROFILE%\.codex\.tmp\marketplaces\context-mode"
+  ```
+
+  Then point `[marketplaces.context-mode]` in `%USERPROFILE%\.codex\config.toml`
+  at `%USERPROFILE%\.codex\local-marketplaces\context-mode` with
+  `source_type = "local"` and retry the install.
 
 ---
 


### PR DESCRIPTION
## What / Why / How

Documents a Windows-specific Codex plugin marketplace install failure.

On Windows, Git may check out `plugins/context-mode` as a regular file containing `..` instead of a directory symlink. When Codex resolves the marketplace manifest path `./plugins/context-mode`, it sees a file rather than the plugin root and installation fails with `missing plugin.json`.

This PR adds a Codex CLI caveat to `docs/platform-support.md` and documents a local marketplace + Windows junction workaround that makes `plugins/context-mode` resolve to the repository root containing `.codex-plugin/plugin.json`.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Docs-only change.

Locally reproduced the Codex plugin install failure on Windows where install failed with `missing plugin.json`, then verified the documented local marketplace + junction workaround allowed installation to complete.

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>