### PR TITLE
Guard Codex plugin install paths

### DIFF
--- a/src/util/project-dir.ts
+++ b/src/util/project-dir.ts
@@ -53,17 +53,18 @@ const LEGACY_NON_STRICT_CANDIDATES: readonly string[] = [
  */
 
 /**
- * Detect whether a path lives inside the Claude Code plugin install tree —
- * specifically `<home>/.claude/plugins/cache/<plugin>/<plugin>/<version>/`
- * or the marketplace mirror `<home>/.claude/plugins/marketplaces/...`.
+ * Detect whether a path lives inside an agent plugin install tree —
+ * specifically `<home>/.claude/plugins/cache/<plugin>/<plugin>/<version>/`,
+ * `<home>/.codex/plugins/cache/<plugin>/<plugin>/<version>/`, or the
+ * marketplace mirror under `<home>/.{claude,codex}/plugins/marketplaces/...`.
  *
  * Cross-OS: matches both POSIX (`/`) and Windows (`\`) path separators.
- * Independent of `home` location — we only care about the `.claude/plugins/`
+ * Independent of `home` location — we only care about the agent plugin
  * suffix pattern.
  */
 export function isPluginInstallPath(p: string): boolean {
   if (!p) return false;
-  return /[/\\]\.claude[/\\]plugins[/\\](cache|marketplaces)[/\\]/.test(p);
+  return /[/\\]\.(claude|codex)[/\\]plugins[/\\](cache|marketplaces)[/\\]/.test(p);
 }
 
 /**
@@ -157,24 +158,26 @@ export function resolveProjectDirFromTranscript(opts: {
  * session log when the spawned MCP child inherits a non-project cwd
  * (e.g. $HOME when Codex was launched from anywhere outside the project).
  *
- * Codex writes its session transcripts to
- * `${CODEX_HOME ?? ~/.codex}/sessions/<uuid>.jsonl`. The first line is a
- * `SessionMeta` JSON struct whose `meta.cwd` field carries the literal
- * project directory the CLI was launched from (see refs/platforms/codex/
- * codex-rs SessionMeta). Codex publishes NO workspace env var to its child
- * MCP processes — so unlike Claude/Pi/Cursor, we have no env signal at all.
- * The session log is the strongest available signal.
+ * Codex writes its session transcripts to either
+ * `${CODEX_HOME ?? ~/.codex}/sessions/<uuid>.jsonl` (CLI) or a dated desktop
+ * layout such as
+ * `${CODEX_HOME ?? ~/.codex}/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+ * The cwd appears on `meta.cwd` for the CLI shape and on
+ * `payload.cwd` in `type: "session_meta"` records for Codex Desktop. Codex
+ * publishes NO workspace env var to its child MCP processes — so unlike
+ * Claude/Pi/Cursor, we have no env signal at all. The session log is the
+ * strongest available signal.
  *
  * Mirror of `resolveProjectDirFromTranscript` for Claude Code; differences:
- *   • Sessions live flat in `${codexHome}/sessions/*.jsonl` (no per-project
- *     encoded subdir like Claude's `~/.claude/projects/<encoded>/`).
- *   • The cwd is on `meta.cwd` (nested), not top-level `cwd`.
+ *   • Sessions may live flat or in a dated hierarchy (no per-project encoded
+ *     subdir like Claude's `~/.claude/projects/<encoded>/`).
+ *   • The cwd is nested on `meta.cwd` or `payload.cwd`, not top-level `cwd`.
  *
  * Returns `null` when:
  *   • `codexHome` or its `sessions/` subdir does not exist.
- *   • No `.jsonl` files exist or none has a parseable `meta.cwd` string.
+ *   • No `.jsonl` files exist or none has a parseable cwd string.
  *   • The newest log is older than `transcriptMaxAgeMs` (multi-window guard).
- *   • The resolved `meta.cwd` points at a plugin install path (poisoned).
+ *   • The resolved cwd points at a plugin install path (poisoned).
  */
 export function resolveCodexSessionCwd(opts?: {
   /** Defaults to `process.env.CODEX_HOME ?? path.join(os.homedir(), ".codex")`. */
@@ -193,17 +196,33 @@ export function resolveCodexSessionCwd(opts?: {
   const sessionsDir = path.join(codexHome, "sessions");
   if (!fs.existsSync(sessionsDir)) return null;
 
+  const MAX_SCAN_DEPTH = 4; // sessions/YYYY/MM/DD/<file>.jsonl plus one spare.
+  const MAX_SCAN_ENTRIES = 10_000;
+  let visitedEntries = 0;
   let bestPath: string | undefined;
   let bestMtime = 0;
-  try {
-    for (const f of fs.readdirSync(sessionsDir)) {
-      if (!f.endsWith(".jsonl")) continue;
-      const fp = path.join(sessionsDir, f);
-      try {
-        const m = fs.statSync(fp).mtimeMs;
-        if (m > bestMtime) { bestMtime = m; bestPath = fp; }
-      } catch { /* skip */ }
+  const visit = (dir: string, depth: number) => {
+    if (visitedEntries >= MAX_SCAN_ENTRIES) return;
+    let entries: string[];
+    try { entries = fs.readdirSync(dir); } catch { return; }
+    entries.sort().reverse();
+    for (const entry of entries) {
+      if (visitedEntries >= MAX_SCAN_ENTRIES) return;
+      visitedEntries++;
+      const fp = path.join(dir, entry);
+      let stat;
+      try { stat = fs.statSync(fp); } catch { continue; }
+      if (stat.isDirectory()) {
+        if (depth < MAX_SCAN_DEPTH) visit(fp, depth + 1);
+        continue;
+      }
+      if (!stat.isFile() || !entry.endsWith(".jsonl")) continue;
+      const m = stat.mtimeMs;
+      if (m > bestMtime) { bestMtime = m; bestPath = fp; }
     }
+  };
+  try {
+    visit(sessionsDir, 0);
   } catch { return null; }
 
   if (!bestPath) return null;
@@ -212,27 +231,35 @@ export function resolveCodexSessionCwd(opts?: {
     if (nowMs - bestMtime > opts.transcriptMaxAgeMs) return null;
   }
 
-  // Read first ~8KB; the SessionMeta JSON is line 1 and small. Stream-cap
-  // mirrors `resolveProjectDirFromTranscript` for memory safety on long logs.
+  // Read a bounded head chunk. Codex Desktop's first session_meta line can be
+  // larger than Claude/Codex CLI metadata because it includes dynamic tool and
+  // instruction fields, but the full transcript can still be tens of MB.
   try {
     const fd = fs.openSync(bestPath, "r");
     try {
-      const buf = Buffer.alloc(8192);
+      const buf = Buffer.alloc(1024 * 1024);
       const bytes = fs.readSync(fd, buf, 0, buf.length, 0);
       const text = buf.subarray(0, bytes).toString("utf-8");
-      const firstLine = text.split("\n", 1)[0];
-      if (!firstLine || !firstLine.trim()) return null;
-      try {
-        const obj = JSON.parse(firstLine) as { meta?: { cwd?: unknown } };
-        const cwd = obj?.meta?.cwd;
-        if (typeof cwd !== "string" || cwd.length === 0) return null;
-        if (isPluginInstallPath(cwd)) return null;
-        return cwd;
-      } catch { return null; /* malformed first line */ }
+      for (const line of text.split("\n").slice(0, 10)) {
+        if (!line.trim()) continue;
+        try {
+          const obj = JSON.parse(line) as {
+            type?: unknown;
+            meta?: { cwd?: unknown };
+            payload?: { cwd?: unknown };
+          };
+          const cwd = obj?.meta?.cwd ??
+            (obj?.type === "session_meta" ? obj?.payload?.cwd : undefined);
+          if (typeof cwd !== "string" || cwd.length === 0) continue;
+          if (isPluginInstallPath(cwd)) return null;
+          return cwd;
+        } catch { return null; /* malformed session metadata line */ }
+      }
     } finally {
       fs.closeSync(fd);
     }
   } catch { return null; /* file vanished mid-read */ }
+  return null;
 }
 
 /**

--- a/start.mjs
+++ b/start.mjs
@@ -36,7 +36,7 @@ function resolveClaudeConfigDir() {
 // the env auto-set in that case; getProjectDir() defends a second time inside
 // server.ts via resolveProjectDir(). See src/util/project-dir.ts.
 const isPluginInstallPath = (p) =>
-  /[/\\]\.claude[/\\]plugins[/\\](cache|marketplaces)[/\\]/.test(p);
+  /[/\\]\.(claude|codex)[/\\]plugins[/\\](cache|marketplaces)[/\\]/.test(p);
 const safeOriginalCwd = isPluginInstallPath(originalCwd) ? null : originalCwd;
 
 if (!process.env.CLAUDE_PROJECT_DIR && safeOriginalCwd) {

--- a/tests/util/codex-session-cwd-resolution.test.ts
+++ b/tests/util/codex-session-cwd-resolution.test.ts
@@ -59,11 +59,68 @@ function writeSession(
   return file;
 }
 
+function writeDesktopSession(
+  codexHome: string,
+  name: string,
+  cwd: string,
+  mtime?: Date,
+  extraPayload?: Record<string, unknown>,
+): string {
+  const sessionsDir = join(codexHome, "sessions", "2026", "05", "28");
+  mkdirSync(sessionsDir, { recursive: true });
+  const file = join(sessionsDir, `${name}.jsonl`);
+  const lines = [
+    JSON.stringify({ type: "session_meta", payload: { cwd, ...extraPayload } }),
+    JSON.stringify({ type: "turn_context", payload: { cwd } }),
+  ];
+  writeFileSync(file, lines.join("\n") + "\n");
+  if (mtime) utimesSync(file, mtime, mtime);
+  return file;
+}
+
 describe("resolveCodexSessionCwd", () => {
   it("returns meta.cwd from the most-recently-modified session.jsonl", () => {
     const codexHome = makeCodexHome();
     writeSession(codexHome, "old-uuid", "/project/old", new Date(Date.now() - 60_000));
     writeSession(codexHome, "new-uuid", "/project/new", new Date());
+
+    expect(resolveCodexSessionCwd({ codexHome })).toBe("/project/new");
+  });
+
+  it("returns payload.cwd from Codex Desktop's dated rollout session layout", () => {
+    const codexHome = makeCodexHome();
+    writeDesktopSession(
+      codexHome,
+      "rollout-2026-05-28T12-00-00-000Z",
+      "/Users/x/Work/Dev/ucw",
+      new Date(),
+    );
+
+    expect(resolveCodexSessionCwd({ codexHome })).toBe("/Users/x/Work/Dev/ucw");
+  });
+
+  it("handles Codex Desktop session_meta lines larger than the old 8KB head read", () => {
+    const codexHome = makeCodexHome();
+    writeDesktopSession(
+      codexHome,
+      "rollout-large-meta",
+      "/project/large-meta",
+      new Date(),
+      { dynamic_tools: "x".repeat(16_000) },
+    );
+
+    expect(resolveCodexSessionCwd({ codexHome })).toBe("/project/large-meta");
+  });
+
+  it("prefers the most-recently-modified Codex Desktop session recursively", () => {
+    const codexHome = makeCodexHome();
+    writeDesktopSession(
+      codexHome,
+      "rollout-old",
+      "/project/old",
+      new Date(Date.now() - 60_000),
+    );
+    writeDesktopSession(codexHome, "rollout-new", "/project/new", new Date());
 
     expect(resolveCodexSessionCwd({ codexHome })).toBe("/project/new");
   });
@@ -100,6 +157,26 @@ describe("resolveCodexSessionCwd", () => {
       codexHome,
       "poisoned",
       "/Users/x/.claude/plugins/cache/context-mode/context-mode/1.0.148",
+    );
+    expect(resolveCodexSessionCwd({ codexHome })).toBeNull();
+  });
+
+  it("rejects when meta.cwd points to Codex plugin install path (isPluginInstallPath)", () => {
+    const codexHome = makeCodexHome();
+    writeSession(
+      codexHome,
+      "poisoned-codex",
+      "/Users/x/.codex/plugins/cache/context-mode/context-mode/1.0.151",
+    );
+    expect(resolveCodexSessionCwd({ codexHome })).toBeNull();
+  });
+
+  it("rejects when Codex Desktop payload.cwd points to Codex plugin install path", () => {
+    const codexHome = makeCodexHome();
+    writeDesktopSession(
+      codexHome,
+      "rollout-poisoned",
+      "/Users/x/.codex/plugins/cache/context-mode/context-mode/1.0.151",
     );
     expect(resolveCodexSessionCwd({ codexHome })).toBeNull();
   });
@@ -172,6 +249,20 @@ describe("resolveProjectDir({strictPlatform: 'codex'})", () => {
       codexHome,
     });
     expect(result).toBe("/project/from-session");
+  });
+
+  it("falls back to Codex Desktop session log before poisoned plugin cwd", () => {
+    const codexHome = makeCodexHome();
+    writeDesktopSession(codexHome, "rollout-active", "/project/from-desktop", new Date());
+
+    const result = resolveProjectDir({
+      env: {},
+      cwd: "/Users/x/.codex/plugins/cache/context-mode/context-mode/1.0.151",
+      pwd: undefined,
+      strictPlatform: "codex",
+      codexHome,
+    });
+    expect(result).toBe("/project/from-desktop");
   });
 
   it("falls through to PWD when no env and no session log", () => {

--- a/tests/util/project-dir.test.ts
+++ b/tests/util/project-dir.test.ts
@@ -65,14 +65,18 @@ describe("isPluginInstallPath", () => {
   it("matches macOS / Linux plugin cache paths", () => {
     expect(isPluginInstallPath("/Users/x/.claude/plugins/cache/context-mode/context-mode/1.0.112")).toBe(true);
     expect(isPluginInstallPath("/home/x/.claude/plugins/cache/foo/foo/1.0.0")).toBe(true);
+    expect(isPluginInstallPath("/Users/x/.codex/plugins/cache/context-mode/context-mode/1.0.151")).toBe(true);
+    expect(isPluginInstallPath("/home/x/.codex/plugins/cache/foo/foo/1.0.0")).toBe(true);
   });
 
   it("matches plugin marketplace paths", () => {
     expect(isPluginInstallPath("/Users/x/.claude/plugins/marketplaces/context-mode")).toBe(true);
+    expect(isPluginInstallPath("/Users/x/.codex/plugins/marketplaces/context-mode")).toBe(true);
   });
 
   it("matches Windows plugin cache paths (backslash + drive letter)", () => {
     expect(isPluginInstallPath("C:\\Users\\x\\.claude\\plugins\\cache\\foo\\foo\\1.0.0")).toBe(true);
+    expect(isPluginInstallPath("C:\\Users\\x\\.codex\\plugins\\cache\\foo\\foo\\1.0.0")).toBe(true);
   });
 
   it("returns false for ordinary project paths", () => {
@@ -116,6 +120,18 @@ describe("resolveProjectDir", () => {
       pwd: "/Users/x/Server/realproj",
     });
     expect(result).toBe("/Users/x/Server/realproj"); // PWD wins, skipping poisoned env + plugin cwd
+  });
+
+  it("rejects Codex plugin path env vars and falls through to the next source", () => {
+    const result = resolveProjectDir({
+      env: {
+        CLAUDE_PROJECT_DIR: "/Users/x/.codex/plugins/cache/context-mode/context-mode/1.0.151",
+        CONTEXT_MODE_PROJECT_DIR: "/Users/x/.codex/plugins/cache/context-mode/context-mode/1.0.151",
+      },
+      cwd: "/Users/x/.codex/plugins/cache/context-mode/context-mode/1.0.151",
+      pwd: "/Users/x/Work/Dev/ucw",
+    });
+    expect(result).toBe("/Users/x/Work/Dev/ucw");
   });
 
   it("uses cwd as last resort when env + PWD are missing or all poisoned", () => {

--- a/tests/util/start-mjs-no-poison.test.ts
+++ b/tests/util/start-mjs-no-poison.test.ts
@@ -18,7 +18,7 @@ function runStartMjsBootstrap(opts: {
 }): { CLAUDE_PROJECT_DIR: string | undefined; CONTEXT_MODE_PROJECT_DIR: string | undefined } {
   const code = `
     const isPluginInstallPath = (p) =>
-      /[/\\\\]\\.claude[/\\\\]plugins[/\\\\](cache|marketplaces)[/\\\\]/.test(p);
+      /[/\\\\]\\.(claude|codex)[/\\\\]plugins[/\\\\](cache|marketplaces)[/\\\\]/.test(p);
     const originalCwd = process.cwd();
     const safeOriginalCwd = isPluginInstallPath(originalCwd) ? null : originalCwd;
     if (!process.env.CLAUDE_PROJECT_DIR && safeOriginalCwd) {
@@ -51,6 +51,13 @@ describe("start.mjs env bootstrap — plugin path no-poison", () => {
     mkdirSync(pluginPath, { recursive: true });
     return pluginPath;
   };
+  const makeCodexPluginDir = () => {
+    const root = mkdtempSync(join(tmpdir(), "ctx-fake-plugin-"));
+    cleanup.push(root);
+    const pluginPath = join(root, ".codex", "plugins", "cache", "context-mode", "context-mode", "1.0.151");
+    mkdirSync(pluginPath, { recursive: true });
+    return pluginPath;
+  };
   const makeProjectDir = () => {
     const dir = mkdtempSync(join(tmpdir(), "ctx-fake-project-"));
     cleanup.push(dir);
@@ -68,6 +75,13 @@ describe("start.mjs env bootstrap — plugin path no-poison", () => {
 
   it("does NOT set CLAUDE_PROJECT_DIR or CONTEXT_MODE_PROJECT_DIR when cwd is plugin install path", () => {
     const pluginPath = makePluginDir();
+    const result = runStartMjsBootstrap({ cwd: pluginPath });
+    expect(result.CLAUDE_PROJECT_DIR).toBeUndefined();
+    expect(result.CONTEXT_MODE_PROJECT_DIR).toBeUndefined();
+  });
+
+  it("does NOT set CLAUDE_PROJECT_DIR or CONTEXT_MODE_PROJECT_DIR when cwd is Codex plugin install path", () => {
+    const pluginPath = makeCodexPluginDir();
     const result = runStartMjsBootstrap({ cwd: pluginPath });
     expect(result.CLAUDE_PROJECT_DIR).toBeUndefined();
     expect(result.CONTEXT_MODE_PROJECT_DIR).toBeUndefined();
@@ -91,4 +105,3 @@ describe("start.mjs env bootstrap — plugin path no-poison", () => {
     expect(result.CLAUDE_PROJECT_DIR).toBe("/Users/x/preset/proj");
   });
 });
-


### PR DESCRIPTION
## What / Why / How

In Codex Desktop, the context-mode MCP server can start with `process.cwd()` set to the Codex plugin cache/install directory, for example `<home>/.codex/plugins/cache/context-mode/context-mode/1.0.151`. The plugin-install-path guard only recognized `.claude/plugins/...`, so `start.mjs` could seed `CLAUDE_PROJECT_DIR` / `CONTEXT_MODE_PROJECT_DIR` from the Codex plugin cache path and `resolveProjectDir()` / `resolveCodexSessionCwd()` could accept the same poisoned path.

Observed repro: the active repo was a separate user project, but the first `ctx_batch_execute` returned issue #1 and files from `mksglu/context-mode` because the MCP cwd was the Codex plugin cache path. Those results were then attributed under the active project label.

This fixes the Codex Desktop path end to end:

- Widen shared plugin-install-path detection from `.claude/plugins/(cache|marketplaces)/...` to `.(claude|codex)/plugins/(cache|marketplaces)/...`.
- Update the duplicated `start.mjs` bootstrap guard.
- Teach `resolveCodexSessionCwd()` to scan Codex Desktop's dated transcript layout, `sessions/YYYY/MM/DD/rollout-*.jsonl`, and read `payload.cwd` from `type: "session_meta"` records while preserving the existing flat `sessions/<uuid>.jsonl` + `meta.cwd` path.
- Read a bounded larger transcript head chunk so large Codex Desktop `session_meta` records are not parsed while truncated.

Refs #434, #545, #663, #521, #561.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [x] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- `npm run build`
- `npm run typecheck`
- `./node_modules/.bin/vitest run tests/util/project-dir.test.ts tests/util/codex-session-cwd-resolution.test.ts tests/util/start-mjs-no-poison.test.ts`
- Direct local smoke: `resolveCodexSessionCwd()` now resolves the current Codex Desktop dated transcript cwd from `<home>/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`.
- `npm test` in Codex Desktop env: failed because ambient `CODEX_*` env made existing platform-detection tests resolve `codex`; unrelated to this change.
- `env -u CODEX_CI -u CODEX_INTERNAL_ORIGINATOR_OVERRIDE -u CODEX_SHELL -u CODEX_THREAD_ID -u LC_ALL -u LC_CTYPE LANG=en_US.UTF-8 npm test`: 149/150 files passed, remaining failure was existing macOS locale expectation in `tests/session/detect-locale-esm.test.ts` (`expected en-US@rg=rozzzz`, received `en-US`).

## Checklist

- [x] Tests added/updated (TDD: red -> green)
- [ ] `npm test` passes
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md)
- [x] No Windows path regressions (forward slashes only)
- [x] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

The guard keeps the existing separator-flexible regex and adds Windows `.codex\plugins\cache...` coverage. The Codex session scan is bounded by depth and entry count, and reads only a bounded transcript head chunk.

</details>