### PR TITLE
fix(opencode): convert Zod v3 schemas to v4 for in-process plugin host

### DIFF
--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -407,20 +407,10 @@ async function createContextModePlugin(ctx: PluginContext) {
             ? (inputSchema._def.shape as () => unknown)()
             : {};
 
-      // Both KiloCode and recent OpenCode releases bundle Zod v4 in their
-      // host runtime. When they receive a tool definition whose `args`
-      // contain Zod v3 schemas (with `_def` but no `_zod.def`), they crash
-      // with `TypeError: undefined is not an object (evaluating 'n._zod.def')`
-      // during the first message handling. The KiloCode-only gate was
-      // introduced in v1.0.142 (#632) under the assumption that OpenCode
-      // would stay on Zod v3 — that assumption no longer holds for OpenCode
-      // ≥ ~1.14.x, which now bundles Zod v4 inside its bun-compiled binary.
-      // Converting v3 → v4 for both platforms is safe: the resulting v4
-      // schemas retain `_def` for legacy callers and add the `_zod.def`
-      // payload that v4 hosts require.
-      const argsForHost = platform === "kilo" || platform === "opencode"
-        ? zod3ShapeToV4(shape as Record<string, unknown>)
-        : shape as Record<string, unknown>;
+      // Both KiloCode and recent OpenCode bundle Zod v4 in-host; v3 schemas
+      // crash with `n._zod.def` undefined. Gate widened from kilo-only (#632)
+      // because every consumer of this file is an OpenCode-family host.
+      const argsForHost = zod3ShapeToV4(shape as Record<string, unknown>);
 
       tools[registered.name] = {
         description: String(config.description ?? ""),

--- a/src/adapters/opencode/plugin.ts
+++ b/src/adapters/opencode/plugin.ts
@@ -407,7 +407,18 @@ async function createContextModePlugin(ctx: PluginContext) {
             ? (inputSchema._def.shape as () => unknown)()
             : {};
 
-      const argsForHost = platform === "kilo"
+      // Both KiloCode and recent OpenCode releases bundle Zod v4 in their
+      // host runtime. When they receive a tool definition whose `args`
+      // contain Zod v3 schemas (with `_def` but no `_zod.def`), they crash
+      // with `TypeError: undefined is not an object (evaluating 'n._zod.def')`
+      // during the first message handling. The KiloCode-only gate was
+      // introduced in v1.0.142 (#632) under the assumption that OpenCode
+      // would stay on Zod v3 — that assumption no longer holds for OpenCode
+      // ≥ ~1.14.x, which now bundles Zod v4 inside its bun-compiled binary.
+      // Converting v3 → v4 for both platforms is safe: the resulting v4
+      // schemas retain `_def` for legacy callers and add the `_zod.def`
+      // payload that v4 hosts require.
+      const argsForHost = platform === "kilo" || platform === "opencode"
         ? zod3ShapeToV4(shape as Record<string, unknown>)
         : shape as Record<string, unknown>;
 

--- a/src/adapters/opencode/zod3tov4.ts
+++ b/src/adapters/opencode/zod3tov4.ts
@@ -1,13 +1,14 @@
 /**
- * Zod 3 → Zod 4 shape conversion (KiloCode only).
+ * Zod 3 → Zod 4 shape conversion for in-process plugin hosts that bundle Zod v4.
  *
- * KiloCode's runtime bundles Zod v4 internally. When it receives plugin tool
- * definitions whose `args` contain Zod v3 schemas (with `_def` but no `_zod`),
- * it crashes with `undefined is not an object (evaluating 'n._zod.def')`.
+ * KiloCode (since its inception) and recent OpenCode releases (≥ ~1.14.x)
+ * bundle Zod v4 internally. When they receive plugin tool definitions whose
+ * `args` contain Zod v3 schemas (with `_def` but no `_zod.def`), they crash
+ * with `TypeError: undefined is not an object (evaluating 'n._zod.def')`.
  *
- * This module converts Zod 3 schema shapes into Zod 4 equivalents so KiloCode
- * can process them natively. Only called when `platform === "kilo"`.
- * OpenCode uses Zod 3 natively and receives the original shapes unchanged.
+ * This module converts Zod 3 schema shapes into Zod 4 equivalents so both
+ * hosts can process them natively. Called when `platform === "kilo"` or
+ * `platform === "opencode"`.
  */
 import z from 'zod/v4';
 

--- a/src/adapters/opencode/zod3tov4.ts
+++ b/src/adapters/opencode/zod3tov4.ts
@@ -7,8 +7,7 @@
  * with `TypeError: undefined is not an object (evaluating 'n._zod.def')`.
  *
  * This module converts Zod 3 schema shapes into Zod 4 equivalents so both
- * hosts can process them natively. Called when `platform === "kilo"` or
- * `platform === "opencode"`.
+ * hosts can process them natively.
  */
 import z from 'zod/v4';
 
@@ -121,7 +120,7 @@ function zod3ToV4(v: unknown, depth = 0): z.ZodType {
       break;
 
     default:
-      // Never leak raw Zod 3 schemas back to KiloCode.
+      // Never leak raw Zod 3 schemas back to a v4 host.
       result = z.unknown();
       break;
   }

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -103,52 +103,40 @@ describe("ContextModePlugin", () => {
       ]);
     });
 
-    it("converts tool args to Zod v4 when platform is kilo (#_zod.def fix)", async () => {
-      const prevKiloPid = process.env.KILO_PID;
-      process.env.KILO_PID = String(process.pid);
-      try {
-        const plugin = await createTestPlugin(join(tempDir, "kilo-zod-v4-args"));
-        expect(plugin).toHaveProperty("tool");
-        expect(Object.keys(plugin.tool ?? {}).length).toBeGreaterThan(0);
-
-        for (const [toolName, toolDef] of Object.entries(plugin.tool ?? {})) {
-          const args = (toolDef as any).args as Record<string, unknown>;
-          for (const [argName, argSchema] of Object.entries(args)) {
-            expect(
-              (argSchema as any)._zod,
-              `tool ${toolName} arg ${argName} missing _zod (Zod v4 marker)`,
-            ).toBeDefined();
-          }
-        }
-      } finally {
-        if (prevKiloPid !== undefined) process.env.KILO_PID = prevKiloPid;
+    // Both KiloCode and recent OpenCode (≥ ~1.14.x) bundle Zod v4 in their
+    // bun-compiled host runtime. Pre-fix, raw Zod v3 schemas crashed the host
+    // on first message with `TypeError: undefined is not an object
+    // (evaluating 'n._zod.def')`. Invariant: every arg schema handed to the
+    // host must carry the `_zod` v4 marker. Asserted on both platforms.
+    it.each([
+      { platform: "kilo" as const, dir: "kilo-zod-v4-args", setEnv: true },
+      { platform: "opencode" as const, dir: "opencode-zod-v4-args", setEnv: false },
+    ])(
+      "converts tool args to Zod v4 when platform is $platform (#_zod.def fix)",
+      async ({ dir, setEnv }) => {
+        const prevKiloPid = process.env.KILO_PID;
+        if (setEnv) process.env.KILO_PID = String(process.pid);
         else delete process.env.KILO_PID;
-      }
-    });
+        try {
+          const plugin = await createTestPlugin(join(tempDir, dir));
+          expect(plugin).toHaveProperty("tool");
+          expect(Object.keys(plugin.tool ?? {}).length).toBeGreaterThan(0);
 
-    // Mirror of the KiloCode test above, but for the default OpenCode platform.
-    // Recent OpenCode releases (≥ ~1.14.x) bundle Zod v4 in their bun-compiled
-    // binary. Before this fix, registering tool args as raw Zod v3 schemas
-    // caused OpenCode to crash on the first message with:
-    //   TypeError: undefined is not an object (evaluating 'n._zod.def')
-    // Reproduces the same invariant the KiloCode test enforces: every arg
-    // schema handed to the host must carry the `_zod` v4 marker.
-    it("converts tool args to Zod v4 when platform is opencode (#_zod.def fix)", async () => {
-      // No KILO_PID is set — getPlatform() falls back to "opencode" (default).
-      const plugin = await createTestPlugin(join(tempDir, "opencode-zod-v4-args"));
-      expect(plugin).toHaveProperty("tool");
-      expect(Object.keys(plugin.tool ?? {}).length).toBeGreaterThan(0);
-
-      for (const [toolName, toolDef] of Object.entries(plugin.tool ?? {})) {
-        const args = (toolDef as any).args as Record<string, unknown>;
-        for (const [argName, argSchema] of Object.entries(args)) {
-          expect(
-            (argSchema as any)._zod,
-            `tool ${toolName} arg ${argName} missing _zod (Zod v4 marker)`,
-          ).toBeDefined();
+          for (const [toolName, toolDef] of Object.entries(plugin.tool ?? {})) {
+            const args = (toolDef as any).args as Record<string, unknown>;
+            for (const [argName, argSchema] of Object.entries(args)) {
+              expect(
+                (argSchema as any)._zod,
+                `tool ${toolName} arg ${argName} missing _zod (Zod v4 marker)`,
+              ).toBeDefined();
+            }
+          }
+        } finally {
+          if (prevKiloPid !== undefined) process.env.KILO_PID = prevKiloPid;
+          else delete process.env.KILO_PID;
         }
-      }
-    });
+      },
+    );
 
     it("ctx_stats native plugin tool executes without an MCP child (#574 smoke)", async () => {
       const projectDir = join(tempDir, "factory-native-tool-exec");

--- a/tests/opencode-plugin.test.ts
+++ b/tests/opencode-plugin.test.ts
@@ -126,6 +126,30 @@ describe("ContextModePlugin", () => {
       }
     });
 
+    // Mirror of the KiloCode test above, but for the default OpenCode platform.
+    // Recent OpenCode releases (≥ ~1.14.x) bundle Zod v4 in their bun-compiled
+    // binary. Before this fix, registering tool args as raw Zod v3 schemas
+    // caused OpenCode to crash on the first message with:
+    //   TypeError: undefined is not an object (evaluating 'n._zod.def')
+    // Reproduces the same invariant the KiloCode test enforces: every arg
+    // schema handed to the host must carry the `_zod` v4 marker.
+    it("converts tool args to Zod v4 when platform is opencode (#_zod.def fix)", async () => {
+      // No KILO_PID is set — getPlatform() falls back to "opencode" (default).
+      const plugin = await createTestPlugin(join(tempDir, "opencode-zod-v4-args"));
+      expect(plugin).toHaveProperty("tool");
+      expect(Object.keys(plugin.tool ?? {}).length).toBeGreaterThan(0);
+
+      for (const [toolName, toolDef] of Object.entries(plugin.tool ?? {})) {
+        const args = (toolDef as any).args as Record<string, unknown>;
+        for (const [argName, argSchema] of Object.entries(args)) {
+          expect(
+            (argSchema as any)._zod,
+            `tool ${toolName} arg ${argName} missing _zod (Zod v4 marker)`,
+          ).toBeDefined();
+        }
+      }
+    });
+
     it("ctx_stats native plugin tool executes without an MCP child (#574 smoke)", async () => {
       const projectDir = join(tempDir, "factory-native-tool-exec");
       const plugin = await createTestPlugin(projectDir);


### PR DESCRIPTION
## Summary

Recent OpenCode releases (≥ ~1.14.x) bundle Zod v4 in their bun-compiled binary. The existing in-process plugin path registers tool args as raw Zod v3 schemas, which now crashes the OpenCode host on the **first message** with:

```
TypeError: undefined is not an object (evaluating 'n._zod.def')
    at process (/$bunfs/root/chunk-w7ehg0hg.js:22:198266)
    at process (/$bunfs/root/chunk-w7ehg0hg.js:22:201152)
    at Bv (/$bunfs/root/chunk-w7ehg0hg.js:24:2057)
    at <anonymous> (/$bunfs/root/chunk-8xcga49m.js:2059:1004)
    at ~effect/Effect/successCont (/$bunfs/root/chunk-812qsrfz.js:25:7738)
    at runLoop (/$bunfs/root/chunk-812qsrfz.js:25:2045)
    ...
```

The crash is the exact same pattern that #632 fixed for KiloCode in v1.0.142: a Zod v4 host accessing `_zod.def` on a schema built with Zod v3 (which only exposes `_def`).

## Root cause

The v1.0.142 release notes explicitly scoped the v3→v4 conversion layer to KiloCode only, with this note:

> Adds transparent conversion for all Zod types (objects, arrays, unions, optionals, nullables, defaults, effects) scoped to KiloCode only; **OpenCode continues using native Zod v3.**

That assumption no longer holds. OpenCode's in-process plugin host is now on Zod v4, so the same crash class now reproduces on OpenCode with no plugins-side change.

## Fix

Extend the existing KiloCode-only gate to also cover OpenCode. No converter logic changes — `zod3ShapeToV4` already handles objects, arrays, unions, optionals, nullables, defaults, effects.

```diff
- const argsForHost = platform === "kilo"
+ const argsForHost = platform === "kilo" || platform === "opencode"
    ? zod3ShapeToV4(shape as Record<string, unknown>)
    : shape as Record<string, unknown>;
```

The execute path is unchanged (still calls `inputSchema.parse(args)` on the original v3 schema), so #621 preprocessing semantics are preserved.

Updated the `zod3tov4.ts` module header comment to reflect the wider scope (no longer "KiloCode only").

## Reproduction (pre-fix)

1. `npm i -g context-mode@1.0.151`
2. `brew install opencode` (1.14.40 reproduces; older brew bottles likely affected since the OpenCode zod v4 cutover)
3. `~/.config/opencode/opencode.json`:
   ```json
   { "$schema": "https://opencode.ai/config.json", "plugin": ["context-mode"] }
   ```
4. `opencode`, send any prompt → TypeError above on every message.

Workaround (no PR): remove from `plugin` array, register context-mode as an out-of-process `mcp` server — tools work but **PreToolUse routing / SessionStart hooks are lost**, defeating the in-process plugin's whole purpose.

## Tests

Added `tests/opencode-plugin.test.ts` test "converts tool args to Zod v4 when platform is opencode (#_zod.def fix)" — mirror of the existing KiloCode test (#632 line 106), but without setting `KILO_PID`. Asserts every registered tool arg carries the `_zod` v4 marker on the default OpenCode platform.

Validation:

```
bun run typecheck                                            # clean
bun run vitest run tests/opencode-plugin.test.ts \
    tests/adapters/opencode.test.ts \
    tests/adapters/zod3tov4.test.ts
                                                             # 120/120 passed
```

## Affected platforms

- [x] OpenCode
- [ ] (no change for any other adapter)

## Checklist

- [x] Tests added (TDD-equivalent: test fails on `main` without the gate change, passes with it)
- [x] `bun run typecheck` clean
- [x] No converter logic change — reuses #632's proven conversion
- [x] PR against `next`