### PR TITLE
fix(test): override codexHome in project-dir-strict fallback test

### DIFF
--- a/tests/integration/project-dir-strict.test.ts
+++ b/tests/integration/project-dir-strict.test.ts
@@ -110,6 +110,7 @@ describe("server getProjectDir wiring — strictPlatform for all adapters (issue
         cwd: "/anchor/cwd",
         pwd: "/Users/x/from-shell",
         strictPlatform: platform,
+        codexHome: "/nonexistent-empty-codex-home",
       });
       // No own workspace var matches (we set leaks, not the platform's own
       // value). PWD is the next tier. PI / OMP have own vars set in the


### PR DESCRIPTION
This PR overrides `codexHome` to a nonexistent path in the `project-dir-strict` integration test fallback case. This prevents the test from reading the developer's real `~/.codex` directory (which might contain recent session logs), causing the PWD fallback assertion to fail. All 4069 tests pass successfully.