### PR TITLE
Discourage hand-rolled bypass in the curl/wget redirect message

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -704,7 +704,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         return mcpRedirect({
           action: "modify",
           updatedInput: {
-            command: `echo "context-mode: curl/wget redirected. Call ${t("ctx_execute")}(language, code) to fetch the URL, derive your answer in code, and print only the result — the raw HTTP body stays in the sandbox instead of entering your conversation. Or call ${t("ctx_fetch_and_index")}(url, source) when you want to query the response later via ${t("ctx_search")}. Both have full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
+            command: `echo "context-mode: curl/wget redirected. Call ${t("ctx_execute")}(language, code) to fetch the URL, derive your answer in code, and print only the result — the raw HTTP body stays in the sandbox instead of entering your conversation. Or call ${t("ctx_fetch_and_index")}(url, source) when you want to query the response later via ${t("ctx_search")}. Both have full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH). When the redirect is because of output volume rather than a transient error, do not work around it with a hand-written curl, wget, or custom script. The tools above have full network access."`,
           },
           // D2 PRD Phase 3.1: marker payload for PostToolUse byte accounting.
           redirectMeta: {


### PR DESCRIPTION
### What

When a `curl`/`wget` command is redirected for output volume, the redirect message in `hooks/core/routing.mjs` points the agent at `ctx_execute` / `ctx_fetch_and_index`. In practice the agent sometimes bypasses the redirect by hand-writing an equivalent `curl`/`wget` or a one-off script (for example a Python `urllib` snippet) instead of using the ctx tools, which reintroduces exactly the stdout flood the redirect is meant to prevent.

This appends one sentence to that message: when the redirect is because of output volume rather than a transient error, do not work around it with a hand-written `curl`, `wget`, or custom script.

### Scope

- Single source change in `hooks/core/routing.mjs`; the message is defined once and shared by the adapters.
- The existing transient-DNS retry guidance (`EAI_AGAIN`, `ETIMEDOUT`, `ENETUNREACH`) is left intact, so a genuine transient retry is still allowed.
