### PR TITLE
Forbid hand-rolled curl/wget and Python-script bypass in the curl/wget redirect message

### DIFF
--- a/hooks/core/routing.mjs
+++ b/hooks/core/routing.mjs
@@ -704,7 +704,7 @@ export function routePreToolUse(toolName, toolInput, projectDir, platform, sessi
         return mcpRedirect({
           action: "modify",
           updatedInput: {
-            command: `echo "context-mode: curl/wget redirected. Call ${t("ctx_execute")}(language, code) to fetch the URL, derive your answer in code, and print only the result — the raw HTTP body stays in the sandbox instead of entering your conversation. Or call ${t("ctx_fetch_and_index")}(url, source) when you want to query the response later via ${t("ctx_search")}. Both have full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH)."`,
+            command: `echo "context-mode: curl/wget redirected. Call ${t("ctx_execute")}(language, code) to fetch the URL, derive your answer in code, and print only the result — the raw HTTP body stays in the sandbox instead of entering your conversation. Or call ${t("ctx_fetch_and_index")}(url, source) when you want to query the response later via ${t("ctx_search")}. Both have full network access. Retry the same call on a transient DNS error (EAI_AGAIN, ETIMEDOUT, ENETUNREACH). Do not retry with curl, wget, or creating a custom Python script."`,
           },
           // D2 PRD Phase 3.1: marker payload for PostToolUse byte accounting.
           redirectMeta: {


### PR DESCRIPTION
### What

The `curl`/`wget` redirect message in `hooks/core/routing.mjs` points the agent at the ctx tools but says nothing about not routing around the redirect. When a `curl`/`wget` command is redirected, the agent can re-run `curl`/`wget` itself, or hand-write an equivalent Python `urllib` script, to perform the same fetch. That reintroduces the stdout flood the redirect exists to prevent.

This appends one prohibition to the message:

> Do not reattempt with curl/wget or use a custom Python script to bypass this redirect.

### Scope

- Single string change in `hooks/core/routing.mjs`, the `curl`/`wget` redirect message only.
- The existing transient-DNS retry guidance (`EAI_AGAIN`, `ETIMEDOUT`, `ENETUNREACH`) is left intact, so a genuine transient retry of the same call is still allowed. The new sentence is unconditional and does not key off transient vs non-transient errors.
- No detection or routing logic changes; the `Inline HTTP` and `WebFetch` redirect messages are not touched.
