### PR TITLE
Fix mobile overflow on Insights persona cards

### DIFF
--- a/web/insights.html
+++ b/web/insights.html
@@ -63,7 +63,8 @@ body{font-family:var(--sans);color:var(--text-2);background:var(--bg);-webkit-fo
 ::selection{background:var(--accent-light);color:var(--accent-dark)}
 a{color:var(--accent);text-decoration:none}
 a:hover{text-decoration:underline}
-code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(--accent-dark);padding:2px 7px;border-radius:4px;font-weight:500}
+code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(--accent-dark);padding:2px 7px;border-radius:4px;font-weight:500;overflow-wrap:anywhere;word-break:normal}
+pre code{overflow-wrap:normal;word-break:normal;white-space:pre}
 
 /* ── Layout primitives — wider than typical narrow column ── */
 .wrap{max-width:1280px;margin:0 auto;padding:0 32px}
@@ -118,7 +119,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(
 .cta.pri{background:var(--text);color:#fff}.cta.pri:hover{background:var(--accent-dark);text-decoration:none}
 .cta.sec{color:var(--text-2);border-color:var(--border);background:#fff}.cta.sec:hover{border-color:var(--accent);color:var(--accent);text-decoration:none}
 .hero-tags{display:flex;gap:10px;flex-wrap:wrap;margin-top:20px}
-.hero-tags a{font-family:var(--mono);font-size:12px;font-weight:500;padding:5px 12px;border-radius:4px;transition:.15s}
+.hero-tags a{min-width:0;max-width:100%;font-family:var(--mono);font-size:12px;font-weight:500;padding:5px 12px;border-radius:4px;transition:.15s;overflow-wrap:anywhere}
 .hero-tags .t-oss{color:var(--accent-dark);background:var(--accent-light)}
 .hero-tags .t-mcp{color:var(--green);background:var(--green-light)}
 
@@ -144,8 +145,8 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(
 .pain .fact strong{color:var(--text);font-weight:600}
 
 /* ── Solution architecture (asymmetric) ── */
-.arch-wrap{display:grid;grid-template-columns:1.1fr 1fr;gap:48px;align-items:start;margin-top:36px}
-@media(max-width:900px){.arch-wrap{grid-template-columns:1fr}}
+.arch-wrap{display:grid;grid-template-columns:minmax(0,1.1fr) minmax(0,1fr);gap:48px;align-items:start;margin-top:36px}
+@media(max-width:900px){.arch-wrap{grid-template-columns:minmax(0,1fr)}}
 .arch-flow{background:var(--bg-alt);border:1px solid var(--border-light);border-radius:10px;padding:32px;font-family:var(--mono);font-size:13.5px;line-height:1.95;color:var(--text-2)}
 .arch-flow .step{display:flex;gap:14px;padding:8px 0;align-items:start}
 .arch-flow .step:not(:last-child){border-bottom:1px dashed var(--border-light)}
@@ -154,27 +155,27 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(
 .arch-flow .det{color:var(--text-3);flex:1;font-family:var(--sans);font-size:13px}
 
 /* ── Persona card (wider, magazine-style) ── */
-.personas{display:grid;grid-template-columns:repeat(2,1fr);gap:24px;margin-top:32px}
-@media(max-width:900px){.personas{grid-template-columns:1fr}}
+.personas{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:24px;margin-top:32px}
+@media(max-width:900px){.personas{grid-template-columns:minmax(0,1fr)}}
 /* persona cards — shadcn philosophy: subtle border, soft shadow on hover, no decorative side strip */
-.persona{border:1px solid var(--border);border-radius:12px;padding:28px;background:#fff;transition:box-shadow .2s,border-color .2s}
+.persona{min-width:0;border:1px solid var(--border);border-radius:12px;padding:28px;background:#fff;transition:box-shadow .2s,border-color .2s}
 .persona:hover{box-shadow:0 4px 16px rgba(15,20,25,.04);border-color:var(--border)}
 .persona-head{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px;margin-bottom:20px;padding-bottom:16px;border-bottom:1px solid var(--border-light)}
 .persona-name{font-family:var(--sans);font-size:1.1rem;font-weight:600;color:var(--text);line-height:1.2;letter-spacing:-.01em}
 .persona-role{font-family:var(--mono);font-size:10.5px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-3);background:var(--bg-alt);padding:4px 10px;border-radius:4px;border:1px solid var(--border-light)}
 .persona-ask{font-family:var(--sans);color:var(--text);font-size:1rem;font-weight:500;line-height:1.55;margin-bottom:18px;letter-spacing:-.005em}
-.persona-ask::before{content:'"';color:var(--text-4);font-weight:600;margin-right:2px}
-.persona-ask::after{content:'"';color:var(--text-4);font-weight:600;margin-left:2px}
-.persona-call{font-family:var(--mono);font-size:12.5px;background:var(--bg-alt);color:var(--accent-dark);padding:10px 14px;border-radius:6px;display:block;margin-bottom:16px;overflow-x:auto;white-space:pre;border:1px solid var(--border-light)}
+.persona-ask::before,.persona-ask::after{content:none}
+.persona-call{max-width:100%;font-family:var(--mono);font-size:12.5px;background:var(--bg-alt);color:var(--accent-dark);padding:10px 14px;border-radius:6px;display:block;margin-bottom:16px;overflow-x:auto;white-space:pre;border:1px solid var(--border-light);overflow-wrap:normal;word-break:normal}
 .persona-ret{font-size:14.5px;color:var(--text-2);line-height:1.7;margin-bottom:16px}
 .persona-ret strong{color:var(--text);font-weight:600}
 .persona-act{font-size:13.5px;color:var(--text);font-weight:500;display:flex;align-items:center;gap:8px;padding-top:16px;border-top:1px solid var(--border-light)}
+@media(max-width:600px){.persona{padding:24px 20px}.persona-call{white-space:pre-wrap;overflow-x:auto;overflow-wrap:anywhere;word-break:normal}}
 
 /* ── MCP-first feature section (the agentic emphasis) ── */
-.mcp-feature{background:linear-gradient(135deg,var(--night) 0%,var(--night-2) 100%);color:#fff;border-radius:16px;padding:56px;margin:48px 0;position:relative;overflow:hidden}
+.mcp-feature{min-width:0;background:linear-gradient(135deg,var(--night) 0%,var(--night-2) 100%);color:#fff;border-radius:16px;padding:56px;margin:48px 0;position:relative;overflow:hidden}
 .mcp-feature::before{content:'';position:absolute;top:-50%;right:-20%;width:600px;height:600px;background:radial-gradient(circle,rgba(75,123,236,.18) 0%,transparent 70%);pointer-events:none}
 .mcp-feature::after{content:'';position:absolute;bottom:-30%;left:-10%;width:400px;height:400px;background:radial-gradient(circle,rgba(13,124,74,.15) 0%,transparent 70%);pointer-events:none}
-.mcp-inner{position:relative;z-index:1}
+.mcp-inner{min-width:0;position:relative;z-index:1}
 .mcp-head{max-width:820px;margin-bottom:40px}
 @media(max-width:900px){.mcp-feature{padding:36px 24px}.mcp-head{margin-bottom:28px}}
 .mcp-kicker{font-family:var(--mono);font-size:11px;font-weight:600;color:#4b7bec;background:rgba(75,123,236,.18);padding:5px 12px;border-radius:4px;letter-spacing:.08em;text-transform:uppercase;display:inline-block;margin-bottom:18px}
@@ -183,10 +184,10 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(
 .mcp-body{font-size:16px;color:#cbd5e1;line-height:1.8;margin-bottom:14px}
 .mcp-body:last-of-type{margin-bottom:0}
 .mcp-body strong{color:#fff;font-weight:600}
-.mcp-demos-grid{position:relative;z-index:1;display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:40px 0 44px}
-@media(max-width:1100px){.mcp-demos-grid{grid-template-columns:repeat(2,1fr)}}
-@media(max-width:700px){.mcp-demos-grid{grid-template-columns:1fr;gap:14px;margin:28px 0 32px}}
-.mcp-demo-card{background:#0a0e14;border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:22px 22px 24px;display:flex;flex-direction:column;min-height:340px;transition:border-color .2s ease}
+.mcp-demos-grid{position:relative;z-index:1;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:18px;margin:40px 0 44px}
+@media(max-width:1100px){.mcp-demos-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+@media(max-width:700px){.mcp-demos-grid{grid-template-columns:minmax(0,1fr);gap:14px;margin:28px 0 32px}}
+.mcp-demo-card{min-width:0;background:#0a0e14;border:1px solid rgba(255,255,255,.08);border-radius:10px;padding:22px 22px 24px;display:flex;flex-direction:column;min-height:340px;transition:border-color .2s ease}
 .mcp-demo-card:hover{border-color:rgba(163,191,255,.22)}
 .mcp-demo-card .persona-tag{font-family:var(--mono);font-size:10.5px;font-weight:600;letter-spacing:.1em;text-transform:uppercase;color:#a3bfff;background:rgba(75,123,236,.14);border:1px solid rgba(163,191,255,.22);padding:4px 10px;border-radius:4px;display:inline-block;align-self:flex-start;margin-bottom:14px}
 .mcp-demo-card .persona-tag.t-em{color:#7dd3fc;background:rgba(56,189,248,.12);border-color:rgba(125,211,252,.22)}
@@ -194,7 +195,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(
 .mcp-demo-card .persona-tag.t-ciso{color:#fda4af;background:rgba(244,63,94,.12);border-color:rgba(253,164,175,.22)}
 .mcp-demo-card .persona-tag.t-finops{color:#fcd34d;background:rgba(245,158,11,.12);border-color:rgba(252,211,77,.22)}
 .mcp-demo-card .persona-tag.t-devops{color:#c4b5fd;background:rgba(139,92,246,.12);border-color:rgba(196,181,253,.22)}
-.mcp-demo{background:transparent;border:0;border-radius:0;padding:0;font-family:var(--mono);font-size:12.5px;line-height:1.7;color:#cbd5e1;overflow-x:auto;white-space:pre-wrap;word-break:break-word;margin:0}
+.mcp-demo{min-width:0;background:transparent;border:0;border-radius:0;padding:0;font-family:var(--mono);font-size:12.5px;line-height:1.7;color:#cbd5e1;overflow-x:auto;white-space:pre-wrap;word-break:break-word;margin:0}
 .mcp-demo .you{color:#fff}
 .mcp-demo .ai{color:#94a3b8}
 .mcp-demo .tool-call{color:#4b7bec;font-weight:500}
@@ -202,11 +203,12 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(
 .mcp-demo .comment{color:#475569;font-style:italic}
 .mcp-demo .value{color:#5eead4;font-weight:500;display:block;font-size:13.5px;line-height:1.7}
 .mcp-demo .value::before{content:'▸ ';color:#5eead4;font-weight:600;margin-right:2px}
-.mcp-tools-wrap{position:relative;z-index:1}
+.mcp-tools-wrap{min-width:0;position:relative;z-index:1}
 .mcp-tools-label{font-family:var(--mono);font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:#94a3b8;margin-bottom:14px}
-.mcp-tools-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
-@media(max-width:900px){.mcp-tools-grid{grid-template-columns:repeat(2,1fr)}}
-.mcp-tool{background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:6px;padding:12px 14px}
+.mcp-tools-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px}
+@media(max-width:900px){.mcp-tools-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
+@media(max-width:560px){.mcp-tools-grid{grid-template-columns:minmax(0,1fr)}}
+.mcp-tool{min-width:0;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08);border-radius:6px;padding:12px 14px}
 .mcp-tool .n{font-family:var(--mono);font-size:12.5px;font-weight:600;color:#a3bfff}
 .mcp-tool .d{font-size:11.5px;color:#94a3b8;margin-top:3px;line-height:1.4}
 


### PR DESCRIPTION
## Summary

- constrain the Insights persona and MCP grids with `minmax(0, 1fr)` / `min-width: 0` so long code-like tokens cannot force mobile page overflow
- remove duplicated CSS-generated quote marks from persona questions
- wrap persona tool calls on narrow mobile while preserving desktop formatting

## Root cause

The live `/` route is served from `web/insights.html`. On mobile, `.personas` switched to one `1fr` column, but grid items kept their default `min-width: auto`. Long `white-space: pre` tool calls and inline pattern IDs therefore contributed their min-content width to the grid item, expanding the first persona card beyond the viewport.

## Validation

- Reproduced on `https://context-mode.com` at 390px: document width expanded to 570px and the first persona card expanded to 538px.
- Verified the patched `web/insights.html` with Playwright at 320, 375, 390, and 430px.
- In all patched viewports, `documentElement.scrollWidth` and `body.scrollWidth` matched the viewport width, and the persona grid/card/tool-call widths stayed inside the card bounds.
- `git diff --check`
