### PR TITLE
fix(store): cap plain-text chunks at the byte limit like markdown chunking

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -150,7 +150,7 @@ function maxEditDistance(wordLength: number): number {
 // Oversized chunks (e.g., a 50KB section between two headings) hurt BM25
 // length normalization and produce unwieldy search results. Split at paragraph
 // boundaries when a chunk exceeds this cap.
-const MAX_CHUNK_BYTES = 4096;
+export const MAX_CHUNK_BYTES = 4096;
 
 // ─────────────────────────────────────────────────────────
 // ContentStore
@@ -1747,6 +1747,7 @@ export class ContentStore {
   #chunkPlainText(
     text: string,
     linesPerChunk: number,
+    maxChunkBytes: number = MAX_CHUNK_BYTES,
   ): Array<{ title: string; content: string }> {
     // Try blank-line splitting first for naturally-sectioned output
     const sections = text.split(/\n\s*\n/);
@@ -1769,12 +1770,15 @@ export class ContentStore {
 
     const lines = text.split("\n");
 
-    // Small enough for a single chunk
+    // Small enough for a single chunk by line count — but still enforce the byte
+    // cap, otherwise a few very long lines produce one oversized chunk that bloats
+    // the FTS5 content DB and times out subsequent queries (#781).
     if (lines.length <= linesPerChunk) {
-      return [{ title: "Output", content: text }];
+      return this.#capPlainTextByBytes(text, "Output", maxChunkBytes);
     }
 
-    // Fixed-size line groups with 2-line overlap
+    // Fixed-size line groups with 2-line overlap. Each group is additionally
+    // sub-split by bytes so a slice containing long lines stays under the cap (#781).
     const chunks: Array<{ title: string; content: string }> = [];
     const overlap = 2;
     const step = Math.max(linesPerChunk - overlap, 1);
@@ -1785,13 +1789,79 @@ export class ContentStore {
       const startLine = i + 1;
       const endLine = Math.min(i + slice.length, lines.length);
       const firstLine = slice[0]?.trim().slice(0, 80);
-      chunks.push({
-        title: firstLine || `Lines ${startLine}-${endLine}`,
-        content: slice.join("\n"),
-      });
+      const title = firstLine || `Lines ${startLine}-${endLine}`;
+      chunks.push(
+        ...this.#capPlainTextByBytes(slice.join("\n"), title, maxChunkBytes),
+      );
     }
 
     return chunks;
+  }
+
+  /**
+   * Split plain-text content into pieces that never exceed `maxChunkBytes`.
+   * Prefers line boundaries; a single line longer than the cap is hard-split on
+   * UTF-8 character boundaries so multi-byte sequences are never severed. Mirrors
+   * the byte-cap guarantee `#chunkMarkdown` already provides for markdown (#781).
+   */
+  #capPlainTextByBytes(
+    content: string,
+    title: string,
+    maxChunkBytes: number,
+  ): Array<{ title: string; content: string }> {
+    if (Buffer.byteLength(content) <= maxChunkBytes) {
+      return content.length > 0 ? [{ title, content }] : [];
+    }
+
+    const parts: string[] = [];
+    let current = "";
+    let currentBytes = 0;
+
+    const pushCurrent = () => {
+      if (current.length > 0) {
+        parts.push(current);
+        current = "";
+        currentBytes = 0;
+      }
+    };
+
+    const lines = content.split("\n");
+    for (let li = 0; li < lines.length; li++) {
+      // Re-attach the newline to every line except the last so joined parts
+      // round-trip to the original content.
+      const line = li < lines.length - 1 ? `${lines[li]}\n` : lines[li];
+      const lineBytes = Buffer.byteLength(line);
+
+      if (lineBytes <= maxChunkBytes) {
+        if (currentBytes > 0 && currentBytes + lineBytes > maxChunkBytes) {
+          pushCurrent();
+        }
+        current += line;
+        currentBytes += lineBytes;
+        continue;
+      }
+
+      // A single line is itself over the cap — flush, then hard-split it on
+      // character boundaries so no UTF-8 code point is cut in half.
+      pushCurrent();
+      for (const ch of line) {
+        const chBytes = Buffer.byteLength(ch);
+        if (currentBytes > 0 && currentBytes + chBytes > maxChunkBytes) {
+          pushCurrent();
+        }
+        current += ch;
+        currentBytes += chBytes;
+      }
+    }
+    pushCurrent();
+
+    const numbered = parts.length > 1;
+    return parts
+      .map((part, idx) => ({
+        title: numbered ? `${title} (${idx + 1})` : title,
+        content: part,
+      }))
+      .filter((c) => c.content.length > 0);
   }
 
   #walkJSON(

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -12,7 +12,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
-import { ContentStore, cleanupStaleDBs } from "../src/store.js";
+import { ContentStore, cleanupStaleDBs, MAX_CHUNK_BYTES } from "../src/store.js";
 import {
   withRetry,
   closeDB,
@@ -2110,5 +2110,48 @@ describe("ctx_index TOCTOU symlink swap (#442 round-3)", () => {
     } finally {
       try { fsSync.unlinkSync(safePath); } catch { /* ignore */ }
     }
+  });
+});
+
+describe("Plain-text chunk byte cap (#781)", () => {
+  // A few very long lines: line count stays under the default linesPerChunk (20),
+  // so the buggy plain-text path returned the whole blob as ONE uncapped chunk.
+  // Each line is built from ordinary words (not one mega-token) so FTS5 tokenizes
+  // normally, and carries a unique `marker<i>` so search can locate its chunk.
+  const LINE_COUNT = 8;
+  const WORDS_PER_LINE = 2000; // ~ "lorem " * 2000 ≈ 12 KB/line, well above MAX_CHUNK_BYTES
+
+  function buildFewLongLines(): string {
+    const filler = "lorem ".repeat(WORDS_PER_LINE).trim();
+    const lines: string[] = [];
+    for (let i = 0; i < LINE_COUNT; i++) {
+      lines.push(`marker${i} ${filler}`);
+    }
+    return lines.join("\n");
+  }
+
+  test("indexPlainText splits oversized output instead of one giant chunk", () => {
+    const store = createStore();
+    const result = store.indexPlainText(buildFewLongLines(), "big-plain");
+    assert.ok(
+      result.totalChunks > 1,
+      `oversized plain-text output must be split into multiple chunks, got ${result.totalChunks}`,
+    );
+    store.close();
+  });
+
+  test("no indexed plain-text chunk exceeds MAX_CHUNK_BYTES", () => {
+    const store = createStore();
+    store.indexPlainText(buildFewLongLines(), "big-plain");
+    for (let i = 0; i < LINE_COUNT; i++) {
+      const hits = store.search(`marker${i}`, 1);
+      assert.ok(hits.length > 0, `marker${i} should be searchable`);
+      const bytes = Buffer.byteLength(hits[0].content);
+      assert.ok(
+        bytes <= MAX_CHUNK_BYTES,
+        `chunk for marker${i} is ${bytes} bytes, exceeds cap ${MAX_CHUNK_BYTES}`,
+      );
+    }
+    store.close();
   });
 });


### PR DESCRIPTION
## What

`#chunkPlainText` now enforces `MAX_CHUNK_BYTES` on every path, matching the byte cap `#chunkMarkdown` already guarantees. A new `#capPlainTextByBytes` helper sub-splits oversized output by line, falling back to UTF-8 character boundaries when a single line exceeds the cap.

Fix #781

## Why

`#chunkPlainText` (the path `indexPlainText` uses for command/tool output) had no byte cap:

- when the line count was `<= linesPerChunk` it returned the **entire blob as one chunk**;
- otherwise it grouped lines by count with **no byte check**, so a few very long lines still produced an oversized chunk.

A broad `rg`/`grep` dump, large JSON, or few-newline log auto-indexed via `ctx_batch_execute` therefore produced a single ~104 MB chunk in the field, bloating a content DB to ~605 MB and timing out subsequent `ctx_search` / `ctx_doctor` calls at 120 s.

## Coverage added

`tests/store.test.ts` — `describe("Plain-text chunk byte cap (#781)")`:
- a few very long lines (under `linesPerChunk`) are split into multiple chunks instead of one;
- every indexed plain-text chunk stays `<= MAX_CHUNK_BYTES`, verified through the public `indexPlainText` + `search` API.

Both tests fail on `next` without the fix (RED: one chunk of 96063 bytes), pass with it (GREEN).

## Test plan

- `npx vitest run tests/store.test.ts -t "byte cap"` — RED before fix, GREEN after
- `npm test` — full suite: 4192 passed, 43 skipped (the one pre-existing `project-dir-strict` failure is unrelated)
- `npm run typecheck` — clean
