### PR TITLE
Add return type annotation to cn function

### DIFF
--- a/insight/src/lib/utils.ts
+++ b/insight/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
-export function cn(...inputs: ClassValue[]) {
+export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
## Problem
The public function `cn` lacks an explicit return type annotation. This can lead to reduced type safety and readability in the codebase, as TypeScript relies on type inference which might not always be clear.

## Solution
Added an explicit return type annotation `: string` to the `cn` function in `insight/src/lib/utils.ts`. This change ensures type clarity without altering the function's behavior or API.

## Verification
- TypeScript compilation passes without errors, confirming type consistency.
- Existing tests continue to pass, as no functional changes were made.
- Code style remains consistent with the repository's conventions.