### PR TITLE
fix(opencode): string-aware JSONC stripping via shared util/jsonc

### DIFF
--- a/src/adapters/opencode/index.ts
+++ b/src/adapters/opencode/index.ts
@@ -16,13 +16,6 @@
  *   - Session dir: ~/.config/opencode/context-mode/sessions/
  */
 
-/** Strip JSONC comments (// and /* *​/) and trailing commas for JSON.parse. */
-function stripJsonComments(str: string): string {
-  return str
-    .replace(/\/\/.*$/gm, "")
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/,(\s*[}\]])/g, "$1");
-}
 import {
   readFileSync,
   writeFileSync,
@@ -35,6 +28,7 @@ import { resolve, join } from "node:path";
 import { homedir } from "node:os";
 
 import { BaseAdapter, resolveContextModeDataRoot } from "../base.js";
+import { stripJsonComments } from "../../util/jsonc.js";
 
 import type {
   HookAdapter,

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,6 +61,7 @@ import {
 import { buildNodeCommand, type HookAdapter, type PlatformId, isInProcessPluginPlatform } from "./adapters/types.js";
 import { detectPlatform, getSessionDirSegments } from "./adapters/detect.js";
 import { getHookScriptPaths } from "./util/hook-config.js";
+import { stripJsonComments } from "./util/jsonc.js";
 import { resolveClaudeConfigDir } from "./util/claude-config.js";
 import { resolveProjectDir } from "./util/project-dir.js";
 import { loadDatabase } from "./db-base.js";
@@ -116,61 +117,6 @@ export function shouldSuppressMcpToolsForNativePluginHost(
   if (platform !== "opencode" && platform !== "kilo") return false;
   const settings = opts.settings ?? readNativePluginHostSettings(platform);
   return settingsHasContextModePlugin(settings) && settingsHasLegacyContextModeMcp(settings);
-}
-
-function stripJsonComments(str: string): string {
-  let out = "";
-  let inString = false;
-  let escaped = false;
-  let inBlockComment = false;
-
-  for (let i = 0; i < str.length; i++) {
-    const c = str[i];
-    const next = str[i + 1];
-
-    if (inBlockComment) {
-      if (c === "*" && next === "/") {
-        inBlockComment = false;
-        i++;
-      }
-      continue;
-    }
-
-    if (escaped) {
-      out += c;
-      escaped = false;
-      continue;
-    }
-
-    if (c === "\\") {
-      out += c;
-      escaped = inString;
-      continue;
-    }
-
-    if (c === '"') {
-      inString = !inString;
-      out += c;
-      continue;
-    }
-
-    if (!inString && c === "/" && next === "/") {
-      while (i < str.length && str[i] !== "\n") i++;
-      if (i < str.length) out += "\n";
-      continue;
-    }
-
-    if (!inString && c === "/" && next === "*") {
-      inBlockComment = true;
-      i++;
-      continue;
-    }
-
-    out += c;
-  }
-
-  return out
-    .replace(/,(\s*[}\]])/g, "$1");
 }
 
 function readNativePluginHostSettings(platform: PlatformId): Record<string, unknown> | null {

--- a/src/util/jsonc.ts
+++ b/src/util/jsonc.ts
@@ -1,0 +1,70 @@
+/**
+ * util/jsonc — string-aware JSONC comment + trailing-comma stripping and a
+ * tolerant parse. Several agent CLIs ship config files as JSONC (VS Code
+ * `mcp.json`, Zed `settings.json`), so a strict `JSON.parse` false-fails on a
+ * perfectly valid commented file. Use `parseJsonc` whenever reading a
+ * platform config we did not write ourselves.
+ */
+
+/** Strip `//` line + `/* *​/` block comments and trailing commas, string-aware. */
+export function stripJsonComments(str: string): string {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  let inBlockComment = false;
+  for (let i = 0; i < str.length; i++) {
+    const c = str[i];
+    const next = str[i + 1];
+    if (inBlockComment) {
+      if (c === "*" && next === "/") { inBlockComment = false; i++; }
+      continue;
+    }
+    if (escaped) { out += c; escaped = false; continue; }
+    if (c === "\\") { out += c; escaped = inString; continue; }
+    if (c === '"') { inString = !inString; out += c; continue; }
+    if (!inString && c === "/" && next === "/") {
+      while (i < str.length && str[i] !== "\n") i++;
+      if (i < str.length) out += "\n";
+      continue;
+    }
+    if (!inString && c === "/" && next === "*") { inBlockComment = true; i++; continue; }
+    out += c;
+  }
+  // Trailing-comma removal, string-aware. The scan above already removed
+  // comments, so this second pass over `out` only needs to track string state:
+  // a comma is "trailing" when the next significant char is `}` or `]`. Doing
+  // it here — instead of a post-hoc trailing-comma regex over the whole string —
+  // preserves commas inside string literals (e.g. "[1, ]"), which that regex
+  // silently corrupted to "[1 ]". See #787 review.
+  let result = "";
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < out.length; i++) {
+    const c = out[i];
+    if (esc) { result += c; esc = false; continue; }
+    if (c === "\\") { result += c; esc = inStr; continue; }
+    if (c === '"') { inStr = !inStr; result += c; continue; }
+    if (!inStr && c === ",") {
+      let j = i + 1;
+      while (j < out.length && (out[j] === " " || out[j] === "\t" || out[j] === "\r" || out[j] === "\n")) j++;
+      if (out[j] === "}" || out[j] === "]") continue;
+    }
+    result += c;
+  }
+  return result;
+}
+
+/**
+ * Parse JSON or JSONC. Tries strict `JSON.parse` first (fast, exact), then a
+ * comment/trailing-comma-stripped parse. Returns `undefined` when both fail.
+ */
+export function parseJsonc<T = unknown>(raw: string): T | undefined {
+  for (const candidate of [raw, stripJsonComments(raw)]) {
+    try {
+      return JSON.parse(candidate) as T;
+    } catch {
+      /* try next */
+    }
+  }
+  return undefined;
+}

--- a/tests/adapters/opencode.test.ts
+++ b/tests/adapters/opencode.test.ts
@@ -393,6 +393,47 @@ describe("OpenCodeAdapter", () => {
       rmSync(root, { recursive: true, force: true });
     });
 
+    // Issue #806: the naive line-comment regex (/\/\/.*$/gm) truncated every
+    // string value containing `//` — e.g. "$schema" or mcp URLs — so a
+    // perfectly valid opencode.jsonc failed JSON.parse, readSettings returned
+    // null, and doctor reported "[FAIL] Plugin configuration: Could not read
+    // opencode.json or opencode.jsonc".
+    it("readSettings parses opencode.jsonc whose string values contain URLs (#806)", () => {
+      const root = mkdtempSync(join(tmpdir(), "opencode-adapter-"));
+      const dir = join(root, "project");
+      const src = resolve(process.cwd(), "src", "adapters", "opencode", "index.ts");
+      const tsx = resolve(process.cwd(), "node_modules", "tsx", "dist", "cli.mjs");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "opencode.jsonc"),
+        `{
+  "$schema": "https://opencode.ai/config.json",
+  // context-mode plugin registration
+  "plugin": ["context-mode/plugin"],
+  "mcp": {
+    "context7": { "type": "remote", "url": "https://mcp.context7.com/mcp" }
+  }
+}
+`,
+      );
+      const run = spawnSync(
+        process.execPath,
+        [
+          tsx,
+          "-e",
+          `import { OpenCodeAdapter } from ${JSON.stringify(src)};const a=new OpenCodeAdapter();console.log(JSON.stringify(a.readSettings()))`,
+        ],
+        { cwd: dir, env: env(join(root, "home")), encoding: "utf-8" },
+      );
+      expect(run.status).toBe(0);
+      expect(JSON.parse(run.stdout)).toEqual({
+        $schema: "https://opencode.ai/config.json",
+        plugin: ["context-mode/plugin"],
+        mcp: { context7: { type: "remote", url: "https://mcp.context7.com/mcp" } },
+      });
+      rmSync(root, { recursive: true, force: true });
+    });
+
     it("prefers opencode.json over opencode.jsonc when both exist", () => {
       const root = mkdtempSync(join(tmpdir(), "opencode-adapter-"));
       const dir = join(root, "project");
@@ -572,6 +613,32 @@ describe("OpenCodeAdapter for KiloCode", () => {
         const a = new OpenCodeAdapter("kilo");
         const settings = a.readSettings() as { marker?: string } | null;
         expect(settings?.marker).toBe("from-dot-kilocode");
+      } finally {
+        process.chdir(prev);
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    // Issue #806 (kilo path): the same adapter parses kilo.jsonc, so URLs in
+    // string values must survive comment stripping there too.
+    it("readSettings parses kilo.jsonc whose string values contain URLs (#806)", () => {
+      const root = mkdtempSync(join(tmpdir(), "kilo-jsonc-url-"));
+      const prev = process.cwd();
+      try {
+        writeFileSync(
+          join(root, "kilo.jsonc"),
+          `{
+  // kilo config with URL-bearing string values
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["context-mode/plugin"]
+}
+`,
+        );
+        process.chdir(root);
+        const a = new OpenCodeAdapter("kilo");
+        const settings = a.readSettings() as { $schema?: string; plugin?: string[] } | null;
+        expect(settings?.$schema).toBe("https://opencode.ai/config.json");
+        expect(settings?.plugin).toEqual(["context-mode/plugin"]);
       } finally {
         process.chdir(prev);
         rmSync(root, { recursive: true, force: true });

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -44,6 +44,7 @@ import {
   StorageDirectoryError,
 } from "../../src/session/db.js";
 import { ROUTING_BLOCK } from "../../hooks/routing-block.mjs";
+import { stripJsonComments, parseJsonc } from "../../src/util/jsonc.js";
 
 // ─── Shared setup ───────────────────────────────────────────────────────────
 const runtimes = detectRuntimes();
@@ -5240,6 +5241,96 @@ test("OpenCode legacy MCP suppression parses JSONC URLs without stripping // ins
     process.chdir(cwd);
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// #787 review regression, applied to server.ts: its local stripJsonComments
+// ended with a whole-string trailing-comma regex that deleted commas INSIDE
+// string values ("[1, ]" -> "[1 ]"). That corruption always leaves the JSON
+// valid (only the comma char is deleted; the anchoring bracket stays), and
+// shouldSuppressMcpToolsForNativePluginHost() — the only public surface over
+// readNativePluginHostSettings() — checks just the plugin array for a
+// "context-mode" substring and the mcp object for a "context-mode" key, so a
+// deleted in-string comma can never flip the boolean ("context-mode" contains
+// no comma to delete and no bracket to leave behind). Pin the fix
+// structurally instead: server.ts must delegate to the shared string-aware
+// src/util/jsonc.ts — whose in-string-comma behavior IS pinned by the
+// "parseJsonc / stripJsonComments" suite below — and must not reintroduce a
+// local whole-string trailing-comma regex.
+test("server.ts delegates JSONC stripping to string-aware src/util/jsonc (#787 in-string trailing-comma regression)", async () => {
+  const serverSrc = readFileSync(resolve(__dirname, "../../src/server.ts"), "utf8");
+  expect(serverSrc).toContain('from "./util/jsonc.js"');
+  expect(serverSrc).not.toContain('.replace(/,(\\s*[}\\]])/g');
+  // End-to-end sanity through the public boolean: a JSONC config that needs
+  // the strip path (comment + real trailing comma) and embeds a
+  // trailing-comma-like pattern inside a string value still parses and
+  // suppresses.
+  const { shouldSuppressMcpToolsForNativePluginHost } = await import("../../src/server.js");
+  const dir = mkdtempSync(join(tmpdir(), "opencode-jsonc-comma-"));
+  const cwd = process.cwd();
+  try {
+    writeFileSync(join(dir, "opencode.jsonc"), `{
+      // forces the comment/trailing-comma strip path
+      "note": "array literal: [1, ]",
+      "plugin": ["context-mode"],
+      "mcp": {
+        "context-mode": { "type": "local", "command": ["context-mode"] }
+      },
+    }\n`);
+    process.chdir(dir);
+    expect(shouldSuppressMcpToolsForNativePluginHost({ platform: "opencode" })).toBe(true);
+  } finally {
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── src/util/jsonc — shared string-aware JSONC strip/parse (#787/#806) ─────
+// The naive regex strippers that lived in src/server.ts and the OpenCode
+// adapter corrupted string VALUES: `//` inside URLs was cut as a "comment"
+// (#806), and a whole-string trailing-comma regex ate commas inside string
+// literals ("[1, ]" -> "[1 ]", the 386a196 regression). These tests pin the
+// shared util that replaced both.
+describe("parseJsonc / stripJsonComments (src/util/jsonc)", () => {
+  test("preserves // inside string values (URLs) while stripping line comments", () => {
+    const jsonc = '{\n  // strip me\n  "url": "https://mcp.context7.com/mcp"\n}';
+    expect(parseJsonc<{ url: string }>(jsonc)?.url).toBe("https://mcp.context7.com/mcp");
+    expect(stripJsonComments('{"url": "https://example.com/x"}')).toBe('{"url": "https://example.com/x"}');
+  });
+
+  test("treats // after an escaped quote as still inside the string", () => {
+    const jsonc = '{ // c\n "say": "say \\"hi\\" // not a comment" }';
+    expect(parseJsonc<{ say: string }>(jsonc)?.say).toBe('say "hi" // not a comment');
+  });
+
+  test("parses CRLF input with line comments", () => {
+    const jsonc = '{\r\n  // comment\r\n  "a": 1,\r\n  "b": 2\r\n}\r\n';
+    expect(parseJsonc(jsonc)).toEqual({ a: 1, b: 2 });
+  });
+
+  test("removes trailing commas before } and ], including whitespace/comment-separated ones", () => {
+    expect(parseJsonc('{ // c\n "a": [1, 2,], "b": { "c": 3, }, }')).toEqual({ a: [1, 2], b: { c: 3 } });
+    expect(parseJsonc('{ "a": 1, /* note */ }')).toEqual({ a: 1 });
+  });
+
+  test("strips a block comment containing a URL without touching neighbors", () => {
+    const jsonc = '{ /* see https://example.com/docs */ "a": 1, // tail\n "b": 2 }';
+    expect(parseJsonc(jsonc)).toEqual({ a: 1, b: 2 });
+  });
+
+  test("preserves a comma inside a string value (the 386a196 regression)", () => {
+    const jsonc = '{\n  // forces the strip path\n  "note": "array literal: [1, ]"\n}';
+    expect(parseJsonc<{ note: string }>(jsonc)?.note).toBe("array literal: [1, ]");
+    expect(stripJsonComments('{"a":"x, ]","b":[1,]}')).toBe('{"a":"x, ]","b":[1]}');
+  });
+
+  test("plain valid JSON passes through parseJsonc unchanged", () => {
+    const raw = '{"a": [1, 2], "u": "https://example.com", "s": "x, ]"}';
+    expect(parseJsonc(raw)).toEqual(JSON.parse(raw));
+  });
+
+  test("returns undefined when input is not JSON at all", () => {
+    expect(parseJsonc("not json at all {{")).toBeUndefined();
+  });
 });
 
 // Issue #623: when ctx_* tool registration is suppressed for the legacy MCP


### PR DESCRIPTION
## What / Why / How

`ctx doctor` reported `[FAIL] Plugin configuration: Could not read opencode.json or opencode.jsonc` for perfectly valid JSONC configs whenever a string value contained `//` — which every real opencode.jsonc does (`"$schema": "https://opencode.ai/config.json"`, MCP `"url"` entries).

Fixes #806.

This PR makes all JSONC parsing string-aware:

- Adds `src/util/jsonc.ts`: a two-pass, string-aware comment + trailing-comma stripper and a tolerant `parseJsonc` (strict `JSON.parse` first, stripped parse second). Zero imports, no new dependency — esbuild inlines it, preserving the original intent of avoiding the 208 KB `jsonc-parser` package.
- `src/adapters/opencode/index.ts` drops its local naive regex stripper and routes `opencode.jsonc` / `kilo.jsonc` through the shared util, so `readSettings()` no longer returns `null` for URL-bearing configs.
- `src/server.ts` drops its local copy too. Its comment handling was already string-aware, but its trailing-comma pass was a whole-string regex that corrupted commas inside string values (e.g. a value containing `[1, ]`).
- The util is byte-identical to the implementation reviewed in #787, so both branches merge cleanly.

## Root cause

The opencode adapter shipped a 3-line regex stripper (introduced to avoid an external JSONC dependency):

```js
.replace(/\/\/.*$/gm, "")        // strips // ANYWHERE, including inside strings
.replace(/\/\*[\s\S]*?\*\//g, "")
.replace(/,(\s*[}\]])/g, "$1")
```

`/\/\/.*$/gm` matches the `//` inside `"https://..."` and deletes the rest of the line, leaving an unterminated string literal. `JSON.parse` then throws, `readSettings()` swallows the error and returns `null`, and `validateHooks()` / `checkPluginRegistration()` report the false `Could not read` FAIL/WARN. The same adapter parses `kilo.jsonc`, so KiloCode was equally affected.

## Reproduction (pre-fix)

Create `~/.config/opencode/opencode.jsonc`:

```jsonc
{
  "$schema": "https://opencode.ai/config.json",
  // enable context-mode
  "plugin": ["context-mode/plugin"],
  "mcp": {
    "context7": { "type": "remote", "url": "https://mcp.context7.com/mcp" }
  }
}
```

Run `context-mode doctor` (or `ctx doctor`) in an OpenCode session. Before this fix:

```text
[FAIL] Plugin configuration: Could not read opencode.json or opencode.jsonc
```

After this fix, the same config parses with `$schema`, `plugin`, and `mcp.context7.url` intact:

```text
Plugin registration: PASS — context-mode found in plugin array
```

## Fix

1. New `src/util/jsonc.ts`: first pass strips `//` and `/* */` comments with `inString`/`escaped` state tracking; second pass removes trailing commas string-aware, so commas inside string literals survive.
2. Opencode adapter imports `stripJsonComments` from the shared util; the `readSettings()` error contract (try each candidate path, `continue` on parse failure, `null` when exhausted) is unchanged.
3. `server.ts` imports the same util for `readNativePluginHostSettings()`, removing 56 lines of duplicated parsing and the in-string trailing-comma corruption.
4. Regression tests: URL-bearing `opencode.jsonc` and `kilo.jsonc` through the public adapter API, plus util edge cases — escaped quotes (`"say \"hi\" // not a comment"`), CRLF input, block comments containing URLs, real trailing commas (including comment-separated), in-string comma preservation, plain-JSON passthrough.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [x] OpenCode
- [x] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

```text
npx vitest run tests/adapters/opencode.test.ts
```

Result: 48 passed (includes the new opencode.jsonc / kilo.jsonc URL regression tests; both fail pre-fix).

```text
npx vitest run tests/adapters/
```

Result:

```text
Test Files  40 passed (40)
Tests       899 passed (899)
```

```text
npm run typecheck
```

Result: passed.

Full suite (`npm test`): 4200 passed | 44 skipped, with 5 failures that reproduce identically on the base commit (ed91326) in a pristine worktree — they are environmental, not from this change: running inside an active context-mode session exports `CONTEXT_MODE_PROJECT_DIR`/`CLAUDE_PROJECT_DIR`, which contaminates the project-dir strict tests, plus two load flakes that pass in isolation.

Live OpenCode runtime validation (Linux):

- Sandboxed OpenCode 1.17.1 install with `XDG_CONFIG_HOME` pointed at a fixture containing the URL-bearing `opencode.jsonc` above and the locally built plugin: opencode parsed the config, the context-mode plugin loaded, hooks fired, and session events were captured in `context-mode/sessions/<id>.db` (session ID matches the opencode run log; zero ERROR lines).
- `env -i HOME=<fixture> OPENCODE=1 ... tsx src/cli.ts doctor`: platform detected as OpenCode, `Plugin registration: PASS`, zero occurrences of the pre-fix `Could not read` failure.

Windows validation (real host, Windows 10.0.26200, node 24.13.0):

- `npm run typecheck`: passed.
- `npx vitest run tests/adapters/opencode.test.ts`: green, including both new #806 tests.
- Adapter sweep: 899 passed; the only failures observed on the host are pre-existing environmental ones (missing `build/` artifacts — green after `npx tsc` — and a POSIX `$VAR` expansion test under cmd.exe), none touching this change.
- Function-level e2e with explicit CRLF fixtures under `%USERPROFILE%`: `readSettings()` returns the parsed object with all URL values intact for both `opencode.jsonc` and `kilo.jsonc`; no `Could not read` diagnostic.

## Checklist

- [x] Tests added/updated (TDD: red -> green)
- [x] npm test passes
- [x] npm run typecheck passes
- [x] Docs updated if needed (not needed: bugfix, no capability or install-flow change)
- [x] No Windows path regressions (verified on a real Windows host, CRLF fixtures included)
- [x] Targets next branch

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on Ubuntu, macOS, and Windows.

- The comment stripper handles CRLF explicitly (line comments terminate at `\n`, the `\r` stays harmless inside the preserved newline handling); Windows checkouts with `core.autocrlf` were verified on a real Windows host.
- No path handling changed; the adapter still resolves config candidates via `homedir()`/`join()`.
- `src/util/jsonc.ts` has zero imports, so both `server.bundle.mjs` and `cli.bundle.mjs` simply inline it — no dependency-graph or bundle-layout change (bundles are refreshed by the usual CI commit, per repo convention).

</details>
