### PR TITLE
fix: preserve ZodEffects preprocess in zod3tov4 conversion

### DIFF
--- a/src/adapters/opencode/zod3tov4.ts
+++ b/src/adapters/opencode/zod3tov4.ts
@@ -114,10 +114,27 @@ function zod3ToV4(v: unknown, depth = 0): z.ZodType {
       break;
     }
 
-    case "ZodEffects":
-      // Host schema only. Original Zod 3 schema still parses in execute().
-      result = zod3ToV4(def.schema, depth + 1);
+    case "ZodEffects": {
+      // Preserve preprocess coercion (coerceJsonArray, coerceBoolean, etc.)
+      // when the OpenCode plugin host receives stringified primitives from the
+      // LLM tool-call bridge. The transform function is plain JS with no Zod
+      // internals, so it works identically with Zod v4's z.preprocess().
+      // Fixes: ctx_fetch_and_index `requests` array / `force` boolean rejected
+      // as "Expected array, received string" in OpenCode in-process plugin path.
+      const effect = def.effect as Record<string, unknown> | undefined;
+      if (effect?.type === "preprocess" && typeof effect?.transform === "function") {
+        const innerSchema = zod3ToV4(def.schema, depth + 1);
+        result = z.preprocess(
+          effect.transform as (val: unknown) => unknown,
+          innerSchema,
+        );
+      } else {
+        // Refinement / transform effects — host schema only.
+        // Original Zod 3 schema still parses in execute().
+        result = zod3ToV4(def.schema, depth + 1);
+      }
       break;
+    }
 
     default:
       // Never leak raw Zod 3 schemas back to a v4 host.

--- a/tests/adapters/zod3tov4.test.ts
+++ b/tests/adapters/zod3tov4.test.ts
@@ -80,7 +80,7 @@ describe("zod3ShapeToV4", () => {
     expect((result.config as any)._zod).toBeDefined();
   });
 
-  it("converts ZodEffects (strips to inner schema)", () => {
+  it("preserves ZodEffects preprocess — coerces string to array", () => {
     const z3Shape = {
       input: z.preprocess(
         (val) => (typeof val === "string" ? val.split(",") : val),
@@ -89,6 +89,40 @@ describe("zod3ShapeToV4", () => {
     };
     const result = zod3ShapeToV4(z3Shape as Record<string, unknown>);
     expect((result.input as any)._zod).toBeDefined();
+    // The preprocess must survive: a comma-separated string should be accepted
+    // and split into an array.
+    const parsed = (result.input as any).safeParse("a,b,c");
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toEqual(["a", "b", "c"]);
+    // Non-string arrays pass through unchanged.
+    const parsed2 = (result.input as any).safeParse(["x", "y"]);
+    expect(parsed2.success).toBe(true);
+    expect(parsed2.data).toEqual(["x", "y"]);
+  });
+
+  it("preserves ZodEffects preprocess — coerces string to boolean", () => {
+    const coerceBool = (val: unknown) =>
+      typeof val === "string"
+        ? val.trim().toLowerCase() === "true"
+        : val;
+    const z3Shape = {
+      force: z.preprocess(coerceBool, z.boolean()),
+    };
+    const result = zod3ShapeToV4(z3Shape as Record<string, unknown>);
+    expect((result.force as any)._zod).toBeDefined();
+    expect((result.force as any).safeParse("true").data).toBe(true);
+    expect((result.force as any).safeParse("false").data).toBe(false);
+    expect((result.force as any).safeParse(true).data).toBe(true);
+  });
+
+  it("strips ZodEffects refinement to inner schema", () => {
+    const z3Shape = {
+      email: z.string().refine((v) => v.includes("@"), "must contain @"),
+    };
+    const result = zod3ShapeToV4(z3Shape as Record<string, unknown>);
+    expect((result.email as any)._zod).toBeDefined();
+    // Refinement is stripped — the inner string schema should accept any string
+    expect((result.email as any).safeParse("no-at-sign").success).toBe(true);
   });
 
   it("returns z.unknown() for null/non-object values", () => {


### PR DESCRIPTION
## What / Why / How

**What:** The `zod3ToV4` adapter in `src/adapters/opencode/zod3tov4.ts` stripped all `ZodEffects` (including `z.preprocess()`) when converting Zod v3 schemas to Zod v4. This caused OpenCode's in-process plugin validation to reject stringified array/boolean arguments because the coercion transforms (`coerceJsonArray`, `coerceBoolean`) never ran.

**Why:** OpenCode's plugin bridge (and several LLM providers' tool-call JSON) stringifies primitive parameters — `requests` receives a JSON string instead of a native array, `force` receives `"true"` instead of `true`. Context-mode already had defensive coercion via `z.preprocess()` in `server.ts`, but the Zod v3→v4 conversion discarded it, so OpenCode's own Zod v4 validation rejected the args before context-mode's handler could parse them.

Specifically, `ctx_fetch_and_index`'s `requests` array parameter and `force` boolean parameter were rejected with `Expected array, received string` / `Expected boolean, received string`.

**How:** In the `ZodEffects` case of `zod3ToV4()`, detect `preprocess`-type effects by checking `def.effect.type === "preprocess"`. When found, preserve the transform function by wrapping the converted inner schema in Zod v4's `z.preprocess()`. The transform functions are plain JS (no Zod internals), so they work identically across v3 and v4. Refinement/transform effects continue to be stripped as before.

## Affected platforms

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [x] OpenCode
- [x] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

- **New test:** `preserves ZodEffects preprocess — coerces string to array` — verifies that a comma-separated string is split into an array via the preserved preprocess, and native arrays pass through unchanged.
- **New test:** `preserves ZodEffects preprocess — coerces string to boolean` — verifies `"true"` / `"false"` string coercion.
- **New test:** `strips ZodEffects refinement to inner schema` — verifies non-preprocess effects (`.refine()`) are still stripped as before.
- Updated existing test from `converts ZodEffects (strips to inner schema)` to the new precise assertions.
- All 19 tests in `tests/adapters/zod3tov4.test.ts` pass.
- `npx tsc --noEmit` passes with no errors.

## Checklist

- [x] Tests added/updated (TDD: red → green)
- [x] `npm test` passes (19/19)
- [x] `npm run typecheck` passes
- [x] Docs updated if needed (README, platform-support.md) — no doc changes needed, internal fix only
- [x] No Windows path regressions (forward slashes only) — no path changes
- [x] Targets `next` branch (unless hotfix)
