### PR TITLE
fix(pi): lazy bootstrap MCP bridge for agent turns

### DIFF
--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -149,9 +149,8 @@ let _mcpBridge: BridgeHandle | null = null;
  * can `await` the wiring deterministically without relying on internal
  * timing or `setImmediate` polling.
  *
- * Reset to a fresh promise on every `piExtension(pi)` call so repeated
- * registrations in one test process don't see a stale resolution from
- * a prior load.
+ * Starts as an already-settled promise because the bridge is now bootstrapped
+ * lazily from `before_agent_start`, not during extension discovery.
  */
 export let _mcpBridgeReady: Promise<void> = Promise.resolve();
 
@@ -314,41 +313,59 @@ function handleCommandText(
   return { text };
 }
 
-// ── Pi short-circuit argv detection (#534) ───────────────
+// ── Pi MCP bridge lazy bootstrap (#534, #809) ───────────
 //
-// Pi's runtime loads every extension during module discovery, BEFORE its
-// `runCli()` decides whether the invocation is a real session or a
-// short-lived help / version print. Without this guard, even `pi --help`
-// causes us to spawn `server.bundle.mjs` as a long-lived stdio child —
-// which is then reparented to PID 1 the moment Pi's `--help` handler
-// returns. The MCP SDK's StdioServerTransport CPU-spins on the half-closed
-// pipe until the 30 s ppid poll catches up, accumulating multi-hour orphans
-// (see issue #534, plus the historical #311 / #388 fixes that only addressed
-// the *recovery* path — not the *prevention* path).
+// Pi loads extensions in several CLI paths that never dispatch an agent turn:
+// top-level help/version, package management (`install`, `list`, ...), config,
+// metadata commands, and project-trust probing. Bootstrapping the MCP bridge
+// during extension discovery is therefore the wrong signal: there may be no
+// real agent lifecycle and no `session_shutdown` cleanup. That caused both the
+// #534 short-lived help/version orphan class and the #809 package-command hang
+// (the bridge child's stdio handles kept Pi alive after `install`/`list`).
 //
-// Token set verified against the Pi 14.x source — specifically:
-//   refs/platforms/oh-my-pi/packages/coding-agent/src/cli.ts:runCli
-//
-//     if (first === "--help" || first === "-h" || first === "--version"
-//      || first === "-v" || first === "help") { /* short-circuit */ }
-//
-// We mirror it exactly — no inferred flags, no `-V` (Pi uses lowercase `-v`),
-// no `--no-help`. Anything else (including `pi stats --help`) routes through
-// the normal launch path and the bridge bootstraps as usual.
+// The robust signal is Pi's agent lifecycle itself. `before_agent_start` fires
+// only for invocations that are about to dispatch a model call, including
+// print-mode subagents (`pi --mode json -p --no-session`). We start and await
+// the bridge from that hook so ctx_* tools are present before Pi snapshots the
+// tool registry, while CLI-only commands never spawn a bridge at all.
 
-const PI_SHORT_CIRCUIT_TOKENS = new Set(["--help", "-h", "--version", "-v", "help"]);
+function startPiMCPBridge(
+  pi: any,
+  serverBundle: string,
+  shouldKeepHandle: () => boolean,
+): Promise<void> {
+  if (existsSync(serverBundle)) {
+    _mcpBridgeReady = bootstrapMCPTools(pi, serverBundle).then(
+      (handle) => {
+        if (shouldKeepHandle()) {
+          _mcpBridge = handle;
+        } else {
+          // Bootstrap completed after this extension registration had already
+          // shut down or superseded the attempt. Do not publish a stale handle;
+          // immediately reclaim the child that bootstrap just spawned.
+          try {
+            handle.shutdown();
+          } catch {
+            // best effort — never throw from best-effort bridge cleanup
+          }
+        }
+      },
+      (err: unknown) => {
+        if (!shouldKeepHandle()) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[context-mode] WARNING: failed to bridge MCP tools to Pi (${msg}). ` +
+            `ctx_* tools will not be callable from this session.\n`,
+        );
+      },
+    );
+  } else {
+    // No bundle on disk → nothing to await. Tests can still rely on
+    // _mcpBridgeReady being a settled promise.
+    _mcpBridgeReady = Promise.resolve();
+  }
 
-/**
- * Returns true iff `argv` matches a Pi top-level short-circuit invocation
- * (help or version). Only argv[0] is inspected — Pi's runCli only checks
- * the first token, and subcommand-level `--help` (e.g. `pi stats --help`)
- * still spins up a real session, so we must NOT skip bootstrap there.
- *
- * Exported for unit tests.
- */
-export function isPiShortCircuitArgv(argv: readonly string[]): boolean {
-  if (argv.length === 0) return false;
-  return PI_SHORT_CIRCUIT_TOKENS.has(argv[0]);
+  return _mcpBridgeReady;
 }
 
 /**
@@ -405,6 +422,19 @@ export function resolvePiWorkspaceDir(opts: {
 export default function piExtension(pi: any): void {
   const buildDir = dirname(fileURLToPath(import.meta.url));
   const pluginRoot = resolve(buildDir, "..", "..", "..");
+  const serverBundle = resolve(pluginRoot, "server.bundle.mjs");
+  let mcpBridgeStarted = false;
+  let mcpBridgeGeneration = 0;
+  const ensureMCPBridge = (): Promise<void> => {
+    if (mcpBridgeStarted) return _mcpBridgeReady;
+    mcpBridgeStarted = true;
+    const generation = ++mcpBridgeGeneration;
+    return startPiMCPBridge(
+      pi,
+      serverBundle,
+      () => mcpBridgeStarted && mcpBridgeGeneration === generation,
+    );
+  };
   // Issue #545 — Pi workspace resolver. PI_CONFIG_DIR is Pi's CONFIG dir
   // (~/.pi), NOT the user's workspace; using it as the project anchor
   // collapsed every Pi session into a single phantom workspace. The
@@ -568,18 +598,15 @@ export default function piExtension(pi: any): void {
 
   pi.on("before_agent_start", async (event: any) => {
     try {
-      // Block first agent start until the MCP bridge bootstrap has
-      // settled so the LLM call dispatched right after this handler
-      // sees the ctx_* tools in Pi's registry. Each subagent starts
-      // a fresh `pi --mode json -p --no-session` process whose only
-      // window to register tools is the gap between piExtension(pi)
-      // returning and the first before_agent_start firing — that gap
-      // is too small for the spawn → initialize → tools/list →
-      // pi.registerTool round-trip, so without this await the first
-      // (and often only) prompt of a subagent goes out with an empty
-      // ctx_* registry and the routing block becomes dead weight.
-      // Resolves on bootstrap failure too — the bridge is best-effort.
-      await _mcpBridgeReady;
+      // Lazily start and await the MCP bridge only when Pi is about to
+      // dispatch a real agent turn. This is the non-brittle #534/#809 guard:
+      // help/version/package/config CLI paths may load the extension, but they
+      // never fire before_agent_start, so they never spawn server.bundle.mjs.
+      // Subagents (`pi --mode json -p --no-session`) do fire this hook; awaiting
+      // here ensures ctx_* tools are registered before Pi snapshots the tool
+      // registry for the model call. Resolves on bootstrap failure too — the
+      // bridge is best-effort.
+      await ensureMCPBridge();
 
       if (!_sessionId) return;
 
@@ -755,12 +782,13 @@ export default function piExtension(pi: any): void {
     } catch {
       // best effort — never throw during shutdown
     }
-    // Race fix (#472 round-3): if shutdown fires while bridge bootstrap
-    // is still in flight, _mcpBridge is null at this point and the
-    // freshly-spawned MCP child gets orphaned once bootstrap eventually
-    // resolves. Await the bootstrap up to a 2s ceiling so we see the
-    // real handle, then call shutdown() on it. The ceiling prevents a
-    // hung bootstrap (e.g. broken bundle) from blocking session exit.
+    // Race fix (#472 round-3 + #809 lazy follow-up): if shutdown fires while
+    // bridge bootstrap is still in flight, _mcpBridge may be null at this
+    // point. Invalidate this bootstrap generation before waiting so any handle
+    // that resolves after the 2s ceiling self-shuts down instead of publishing
+    // a stale child handle after session shutdown.
+    mcpBridgeGeneration++;
+    mcpBridgeStarted = false;
     try {
       await Promise.race([
         _mcpBridgeReady,
@@ -778,6 +806,7 @@ export default function piExtension(pi: any): void {
       }
       _mcpBridge = null;
     }
+    _mcpBridgeReady = Promise.resolve();
   });
 
   // ── 8. Slash commands ──────────────────────────────────
@@ -833,50 +862,9 @@ export default function piExtension(pi: any): void {
 
   // ── 9. MCP tool bridge (#426) ───────────────────────────
   //
-  // Pi 0.73.x has no native MCP support. Without bridging here, the
-  // routing block tells the LLM to call ctx_execute / ctx_search / etc.
-  // but those tools never appear in Pi's tool list and the LLM cannot
-  // reach them — context-mode becomes a pure cost (~2.5K tokens of
-  // system-prompt overhead, 0 actual ctx_* calls).
-  //
-  // Spawn server.bundle.mjs as a long-lived MCP child and register
-  // each of its tools via pi.registerTool() so they enter the Pi
-  // tool list under their bare names — same names the routing block
-  // emits for the Pi platform (per hooks/core/tool-naming.mjs).
-  //
-  // Best-effort: a missing bundle or a spawn failure must NOT prevent
-  // the rest of the extension (session capture, hooks, slash commands)
-  // from initializing. We log to stderr and continue.
-  // Short-circuit guard (#534): skip the MCP bridge bootstrap for
-  // `pi --help` / `pi --version` / `pi help` and similar. Pi prints and
-  // exits within milliseconds, but the bridge child would otherwise live
-  // long enough to be reparented to PID 1, half-close stdin, and pin a CPU
-  // core via the MCP SDK's stdio loop. We use process.argv directly so the
-  // guard works for any caller that boots Pi with a short-circuit token,
-  // regardless of how the runtime wires its CLI parser.
-  const piArgv = process.argv.slice(2);
-  if (isPiShortCircuitArgv(piArgv)) {
-    _mcpBridgeReady = Promise.resolve();
-    return;
-  }
-
-  const serverBundle = resolve(pluginRoot, "server.bundle.mjs");
-  if (existsSync(serverBundle)) {
-    _mcpBridgeReady = bootstrapMCPTools(pi, serverBundle).then(
-      (handle) => {
-        _mcpBridge = handle;
-      },
-      (err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        process.stderr.write(
-          `[context-mode] WARNING: failed to bridge MCP tools to Pi (${msg}). ` +
-            `ctx_* tools will not be callable from this session.\n`,
-        );
-      },
-    );
-  } else {
-    // No bundle on disk → nothing to await. Tests can still rely on
-    // _mcpBridgeReady being a settled promise.
-    _mcpBridgeReady = Promise.resolve();
-  }
+  // Intentionally no eager bootstrap here. `before_agent_start` is the first
+  // lifecycle signal that proves Pi is about to run a model call; starting the
+  // bridge there keeps ctx_* available for real agent turns while package/help
+  // commands that only load extensions never spawn a long-lived child (#809).
+  _mcpBridgeReady = Promise.resolve();
 }

--- a/tests/adapters/pi-help-skip-bootstrap.test.ts
+++ b/tests/adapters/pi-help-skip-bootstrap.test.ts
@@ -1,44 +1,32 @@
 import "../setup-home";
 /**
- * Pi extension — short-circuit guard for `pi --help` / `pi --version` (#534).
+ * Pi extension — lazy MCP bridge bootstrap for real agent turns (#534, #809).
  *
- * Problem: `piExtension(pi)` runs during Pi's extension-discovery phase, BEFORE
- * Pi's `run()` decides whether the invocation is a short-circuit (help/version)
- * or a real session. Before this fix, `bootstrapMCPTools()` always spawned the
- * `server.bundle.mjs` child. On `pi --help`, Pi prints help and exits ~50 ms
- * later; the MCP child gets reparented to PID 1 with a half-closed stdin and
- * the SDK's stdio transport CPU-spins until the 30 s lifecycle poll catches it
- * (or until `kill -9`). Issue #534 reports multi-hour orphan accumulation.
+ * Pi may load extensions for CLI-only paths such as `pi --help`, `pi install`,
+ * `pi list`, `pi config`, and `pi --list-models`. Those paths do not dispatch
+ * an agent turn or provide a dependable `session_shutdown`, so bootstrapping the
+ * long-lived MCP bridge during extension discovery can orphan the bridge child
+ * (#534) or keep package commands alive forever (#809).
  *
- * These tests pin the contract:
- *
- *   1. `isPiShortCircuitArgv(argv)` recognises exactly the tokens Pi's
- *      packages/coding-agent/src/cli.ts:runCli recognises:
- *        `--help`, `-h`, `--version`, `-v`, `help`.
- *      Verified against refs/platforms/oh-my-pi/packages/coding-agent/src/cli.ts.
- *
- *   2. `piExtension(pi)` MUST NOT call `bootstrapMCPTools()` when argv
- *      indicates a short-circuit. The rest of the extension wiring
- *      (event handlers, slash commands) still installs — those are
- *      cheap and harmless under help/version because the corresponding
- *      events never fire.
- *
- *   3. Under normal argv (e.g. `pi launch`), bootstrap still runs.
- *      Regression guard so slice-1 does not break the happy path.
+ * The bridge should instead start from `before_agent_start`, the lifecycle event
+ * that proves Pi is about to run a model call. That keeps ctx_* tools available
+ * for interactive/print/subagent runs, including `pi --mode json -p --no-session`,
+ * without maintaining a brittle list of every short-lived CLI command.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 let scratch: string;
 let originalArgv: string[];
 
+type HandlerFn = (...args: any[]) => any;
+
 beforeEach(() => {
-  scratch = mkdtempSync(join(tmpdir(), "ctx-pi-help-"));
+  scratch = mkdtempSync(join(tmpdir(), "ctx-pi-lazy-bridge-"));
   originalArgv = process.argv;
-  // Reset module cache between tests so module-level singletons are pristine.
   vi.resetModules();
 });
 
@@ -53,140 +41,89 @@ afterEach(() => {
   delete process.env.CLAUDE_PROJECT_DIR;
 });
 
-// ── Mock Pi API ──────────────────────────────────────────────
 function createMockPi() {
+  const handlers: Record<string, HandlerFn[]> = {};
   return {
-    on: vi.fn(),
+    on: vi.fn((event: string, handler: HandlerFn) => {
+      handlers[event] ??= [];
+      handlers[event].push(handler);
+    }),
     registerCommand: vi.fn(),
     registerTool: vi.fn(),
     sendMessage: vi.fn(),
+    _trigger: async (event: string, ...args: any[]) => {
+      for (const handler of handlers[event] ?? []) {
+        await handler(...args);
+      }
+    },
   };
 }
 
-// ── Slice 1.a — pure helper ─────────────────────────────────
-describe("isPiShortCircuitArgv — recognise Pi's runCli short-circuit tokens (#534)", () => {
-  it("recognises --help, -h, --version, -v, help (exact set from Pi runCli)", async () => {
-    const mod = await import("../../src/adapters/pi/extension.js");
-    const { isPiShortCircuitArgv } = mod as unknown as {
-      isPiShortCircuitArgv: (argv: readonly string[]) => boolean;
-    };
-    expect(typeof isPiShortCircuitArgv).toBe("function");
+async function registerWithBootstrapSpy(argv: string[]) {
+  process.argv = ["/usr/bin/pi", "pi-coding-agent", ...argv];
+  process.env.PI_PROJECT_DIR = scratch;
+  process.env.CLAUDE_PROJECT_DIR = scratch;
 
-    for (const token of ["--help", "-h", "--version", "-v", "help"]) {
-      expect(isPiShortCircuitArgv([token])).toBe(true);
-    }
-  });
+  const bridgeMod = await import("../../src/adapters/pi/mcp-bridge.js");
+  const spy = vi
+    .spyOn(bridgeMod, "bootstrapMCPTools")
+    .mockResolvedValue({
+      tools: [],
+      shutdown: () => {},
+      client: { _spawnEnv: null } as unknown as InstanceType<
+        typeof bridgeMod.MCPStdioClient
+      >,
+    });
 
-  it("returns false for normal subcommands (launch, stats, commit)", async () => {
-    const { isPiShortCircuitArgv } = (await import(
-      "../../src/adapters/pi/extension.js"
-    )) as unknown as { isPiShortCircuitArgv: (argv: readonly string[]) => boolean };
+  const extMod = await import("../../src/adapters/pi/extension.js");
+  const pi = createMockPi();
+  extMod.default(pi);
+  await extMod._mcpBridgeReady;
 
-    expect(isPiShortCircuitArgv(["launch"])).toBe(false);
-    expect(isPiShortCircuitArgv(["stats"])).toBe(false);
-    expect(isPiShortCircuitArgv(["commit"])).toBe(false);
-    expect(isPiShortCircuitArgv([])).toBe(false);
-  });
+  return { pi, spy };
+}
 
-  it("only matches argv[0] (first token), per Pi's runCli", async () => {
-    // Pi's runCli checks only argv[0]. `pi stats --help` is a stats subcommand
-    // with its own help — not a top-level short-circuit. The extension still
-    // loads in that case (stats runs as a normal subcommand session).
-    const { isPiShortCircuitArgv } = (await import(
-      "../../src/adapters/pi/extension.js"
-    )) as unknown as { isPiShortCircuitArgv: (argv: readonly string[]) => boolean };
-
-    expect(isPiShortCircuitArgv(["stats", "--help"])).toBe(false);
-    expect(isPiShortCircuitArgv(["launch", "-h"])).toBe(false);
-  });
-
-  it("rejects unrelated short flags (e.g. -V uppercase, --no-help)", async () => {
-    // Pi uses lowercase `-v` for version, NOT `-V`. Documented in
-    // refs/platforms/oh-my-pi/packages/coding-agent/src/cli.ts:runCli.
-    const { isPiShortCircuitArgv } = (await import(
-      "../../src/adapters/pi/extension.js"
-    )) as unknown as { isPiShortCircuitArgv: (argv: readonly string[]) => boolean };
-
-    expect(isPiShortCircuitArgv(["-V"])).toBe(false);
-    expect(isPiShortCircuitArgv(["--no-help"])).toBe(false);
-  });
-});
-
-// ── Slice 1.b — piExtension skips bootstrap on short-circuit ──
-describe("piExtension — skip MCP bootstrap on Pi short-circuit invocations (#534)", () => {
-  function withFakeBundle(): string {
-    // The bootstrap path is gated by `existsSync(serverBundle)`. Drop a
-    // sentinel file at the location piExtension resolves so we exercise the
-    // branch that USED to call bootstrapMCPTools.
-    const buildDir = resolve(__dirname, "../../build/adapters/pi");
-    // Plugin root: three levels up from the built extension file. We point
-    // PI_PROJECT_DIR at scratch; pluginRoot is derived from import.meta.url
-    // inside extension.ts. Tests run the source TS via vitest, so
-    // pluginRoot evaluates to the source repo root. Write the sentinel there.
-    const repoRoot = resolve(__dirname, "../..");
-    const bundlePath = join(repoRoot, "server.bundle.mjs");
-    // Bundle already exists from the build step; we don't overwrite it.
-    return bundlePath;
-  }
-
-  it("does NOT call bootstrapMCPTools when argv is `pi --help`", async () => {
-    process.argv = ["/usr/bin/pi", "pi-coding-agent", "--help"];
-    process.env.PI_PROJECT_DIR = scratch;
-    process.env.CLAUDE_PROJECT_DIR = scratch;
-    withFakeBundle();
-
-    const bridgeMod = await import("../../src/adapters/pi/mcp-bridge.js");
-    const spy = vi.spyOn(bridgeMod, "bootstrapMCPTools");
-
-    const extMod = await import("../../src/adapters/pi/extension.js");
-    const pi = createMockPi();
-    extMod.default(pi);
-    await extMod._mcpBridgeReady;
+describe("piExtension — lazy MCP bootstrap avoids brittle argv detection (#534, #809)", () => {
+  it.each([
+    ["--help"],
+    ["-v"],
+    ["help"],
+    ["--list-models"],
+    ["install", "npm:context-mode"],
+    ["install", "--help"],
+    ["remove", "npm:context-mode"],
+    ["uninstall", "npm:context-mode"],
+    ["update"],
+    ["list"],
+    ["config"],
+  ])("does NOT bootstrap during extension discovery for argv: %s", async (...argv) => {
+    const { spy } = await registerWithBootstrapSpy(argv);
 
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });
 
-  it("does NOT call bootstrapMCPTools when argv is `pi -v`", async () => {
-    process.argv = ["/usr/bin/pi", "pi-coding-agent", "-v"];
-    process.env.PI_PROJECT_DIR = scratch;
-    process.env.CLAUDE_PROJECT_DIR = scratch;
+  it.each([
+    [],
+    ["-p", "task"],
+    ["--print", "task"],
+    ["--resume"],
+    ["--mode", "json", "-p", "--no-session", "task"],
+    ["--model", "sonnet", "task"],
+  ])("bootstraps when before_agent_start fires for real agent argv: %s", async (...argv) => {
+    const { pi, spy } = await registerWithBootstrapSpy(argv);
 
-    const bridgeMod = await import("../../src/adapters/pi/mcp-bridge.js");
-    const spy = vi.spyOn(bridgeMod, "bootstrapMCPTools");
+    await pi._trigger("before_agent_start", { prompt: "task", systemPrompt: "" });
 
-    const extMod = await import("../../src/adapters/pi/extension.js");
-    const pi = createMockPi();
-    extMod.default(pi);
-    await extMod._mcpBridgeReady;
-
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();
   });
 
-  it("DOES call bootstrapMCPTools on normal `pi launch` argv (regression guard)", async () => {
-    process.argv = ["/usr/bin/pi", "pi-coding-agent", "launch"];
-    process.env.PI_PROJECT_DIR = scratch;
-    process.env.CLAUDE_PROJECT_DIR = scratch;
+  it("does not bootstrap more than once per extension registration", async () => {
+    const { pi, spy } = await registerWithBootstrapSpy(["-p", "task"]);
 
-    // Stub bootstrapMCPTools so we don't actually spawn a child. The spy
-    // confirms the call happens; the returned no-op handle keeps the rest
-    // of the extension wiring happy.
-    const bridgeMod = await import("../../src/adapters/pi/mcp-bridge.js");
-    const spy = vi
-      .spyOn(bridgeMod, "bootstrapMCPTools")
-      .mockResolvedValue({
-        tools: [],
-        shutdown: () => {},
-        client: { _spawnEnv: null } as unknown as InstanceType<
-          typeof bridgeMod.MCPStdioClient
-        >,
-      });
-
-    const extMod = await import("../../src/adapters/pi/extension.js");
-    const pi = createMockPi();
-    extMod.default(pi);
-    await extMod._mcpBridgeReady;
+    await pi._trigger("before_agent_start", { prompt: "first", systemPrompt: "" });
+    await pi._trigger("before_agent_start", { prompt: "second", systemPrompt: "" });
 
     expect(spy).toHaveBeenCalledTimes(1);
     spy.mockRestore();

--- a/tests/adapters/pi-no-orphan-on-help.test.ts
+++ b/tests/adapters/pi-no-orphan-on-help.test.ts
@@ -1,18 +1,18 @@
 import "../setup-home";
 /**
- * Integration — `pi --help` leaves no orphan MCP child (#534).
+ * Integration — Pi non-agent CLI paths leave no orphan MCP child (#534/#809).
  *
- * End-to-end harness: simulates the conditions of `pi --help` by importing
- * the Pi extension with `process.argv = ["pi", "--help"]` and observes that
- * no MCP child gets spawned. The companion contract is that, even if a child
- * had been spawned by an earlier code path, the bridge-child lifecycle
- * guard (slice 2) catches a dead parent within ~1 s and the stdin-EOF assist
- * (slice 3) collapses the window further.
+ * End-to-end harness: simulates the conditions of `pi --help`, `pi install`,
+ * and `pi list` by importing the Pi extension with matching `process.argv` and
+ * observing that no MCP child gets spawned. The companion contract is that,
+ * even if a child had been spawned by an earlier code path, the bridge-child
+ * lifecycle guard (slice 2) catches a dead parent within ~1 s and the stdin-EOF
+ * assist (slice 3) collapses the window further.
  *
  * Mechanism under test:
  *   - `piExtension(pi)` is import-time-invoked by Pi's extension loader.
- *   - For `pi --help`, Pi's `runCli` short-circuits BEFORE the session
- *     starts; `bootstrapMCPTools()` MUST NOT have been called.
+ *   - For help/version/list-models and package/config commands, Pi does not
+ *     start a real agent session; `bootstrapMCPTools()` MUST NOT have been called.
  *   - Therefore: zero `MCPStdioClient` instances are constructed, zero
  *     server.bundle.mjs spawns, zero orphan candidates exist.
  *
@@ -55,60 +55,53 @@ function createMockPi() {
   };
 }
 
-describe("Integration — pi --help leaves zero orphan candidates (#534)", () => {
-  it("no MCPStdioClient is constructed when piExtension runs under `pi --help`", async () => {
-    process.argv = ["/usr/bin/pi", "pi-coding-agent", "--help"];
+describe("Integration — Pi non-agent argv leaves zero orphan candidates (#534/#809)", () => {
+  async function runExtension(argv: string[]) {
+    process.argv = ["/usr/bin/pi", "pi-coding-agent", ...argv];
     process.env.PI_PROJECT_DIR = scratch;
     process.env.CLAUDE_PROJECT_DIR = scratch;
 
     const bridgeMod = await import("../../src/adapters/pi/mcp-bridge.js");
-    // Spy on the class constructor's `start()` — that's where `spawn()` happens.
+    // Spy on `start()` — that's where `spawn()` happens. Mock bootstrap so a
+    // regression fails without starting a real bridge child in CI.
     const startSpy = vi.spyOn(bridgeMod.MCPStdioClient.prototype, "start");
-    const bootstrapSpy = vi.spyOn(bridgeMod, "bootstrapMCPTools");
+    const bootstrapSpy = vi
+      .spyOn(bridgeMod, "bootstrapMCPTools")
+      .mockResolvedValue({
+        tools: [],
+        shutdown: () => {},
+        client: { _spawnEnv: null } as unknown as InstanceType<
+          typeof bridgeMod.MCPStdioClient
+        >,
+      });
 
     const extMod = await import("../../src/adapters/pi/extension.js");
     const pi = createMockPi();
     extMod.default(pi);
     await extMod._mcpBridgeReady;
+
+    return { startSpy, bootstrapSpy };
+  }
+
+  it.each([
+    ["--help"],
+    ["--version"],
+    ["help"],
+    ["--list-models"],
+    ["install", "npm:context-mode"],
+    ["install", "--help"],
+    ["list"],
+    ["remove", "npm:context-mode"],
+    ["uninstall", "npm:context-mode"],
+    ["update"],
+    ["config"],
+  ])("no MCPStdioClient is constructed under `pi %s`", async (...argv) => {
+    const { startSpy, bootstrapSpy } = await runExtension(argv);
 
     expect(bootstrapSpy).not.toHaveBeenCalled();
     expect(startSpy).not.toHaveBeenCalled();
 
     startSpy.mockRestore();
     bootstrapSpy.mockRestore();
-  });
-
-  it("no MCPStdioClient is constructed under `pi --version`", async () => {
-    process.argv = ["/usr/bin/pi", "pi-coding-agent", "--version"];
-    process.env.PI_PROJECT_DIR = scratch;
-    process.env.CLAUDE_PROJECT_DIR = scratch;
-
-    const bridgeMod = await import("../../src/adapters/pi/mcp-bridge.js");
-    const startSpy = vi.spyOn(bridgeMod.MCPStdioClient.prototype, "start");
-
-    const extMod = await import("../../src/adapters/pi/extension.js");
-    const pi = createMockPi();
-    extMod.default(pi);
-    await extMod._mcpBridgeReady;
-
-    expect(startSpy).not.toHaveBeenCalled();
-    startSpy.mockRestore();
-  });
-
-  it("no MCPStdioClient is constructed under `pi help` (Pi's `help` subcommand)", async () => {
-    process.argv = ["/usr/bin/pi", "pi-coding-agent", "help"];
-    process.env.PI_PROJECT_DIR = scratch;
-    process.env.CLAUDE_PROJECT_DIR = scratch;
-
-    const bridgeMod = await import("../../src/adapters/pi/mcp-bridge.js");
-    const startSpy = vi.spyOn(bridgeMod.MCPStdioClient.prototype, "start");
-
-    const extMod = await import("../../src/adapters/pi/extension.js");
-    const pi = createMockPi();
-    extMod.default(pi);
-    await extMod._mcpBridgeReady;
-
-    expect(startSpy).not.toHaveBeenCalled();
-    startSpy.mockRestore();
   });
 });

--- a/tests/pi-extension.test.ts
+++ b/tests/pi-extension.test.ts
@@ -1271,34 +1271,38 @@ describe("Pi MCP bridge (#426)", () => {
     }, 30_000);
   });
 
-  // ── Wiring: pi-extension.ts default export must call bootstrapMCPTools
+  // ── Wiring: before_agent_start must bootstrap MCP tools
   //
   // This is the regression that the rest of the suite does NOT catch: if
-  // a future refactor drops the `bootstrapMCPTools(pi, …)` call from
-  // src/adapters/pi/extension.ts but keeps the bridge module intact, every other
-  // bridge test stays green and the bug silently re-enters. We assert
-  // here that the extension's default export, after `_mcpBridgeReady`
-  // settles, has actually called `pi.registerTool` for at least the
-  // canonical ctx_* set.
+  // a future refactor drops the `bootstrapMCPTools(pi, …)` call from the
+  // Pi lifecycle wiring but keeps the bridge module intact, every other
+  // bridge test stays green and the bug silently re-enters. The bridge is
+  // intentionally lazy now (#809): extension discovery alone must not spawn a
+  // child, but `before_agent_start` must register at least the canonical ctx_*
+  // set before the model call.
 
   describe("pi-extension.ts wiring (#426 regression guard)", () => {
-    it("registerPiExtension awaits bridge bootstrap and registers ctx_* via pi.registerTool", async () => {
+    it("before_agent_start bootstraps and registers ctx_* via pi.registerTool", async () => {
       const wireApi = createMockPiApi();
       // PI_PROJECT_DIR / CLAUDE_PROJECT_DIR set inside registerPiExtension.
       await registerPiExtension(wireApi, { projectDir: tempDir });
 
-      // Bootstrap is fire-and-forget on extension load — wait on the
-      // exported promise so the test does not race the spawn.
+      // Lazy bootstrap: no tool should be registered during extension discovery.
+      expect((wireApi.registerTool as any).mock.calls.length).toBe(0);
+
       const mod = await import("../src/adapters/pi/extension.js");
+      await wireApi._trigger("before_agent_start", {
+        prompt: "tool registration smoke",
+        systemPrompt: "",
+      });
       await mod._mcpBridgeReady;
 
       const calls = (wireApi.registerTool as any).mock.calls as Array<[any]>;
       const registeredNames = calls.map(([t]) => t?.name).filter(Boolean);
 
       // Same canonical pin as the bridge integration test — but reached
-      // through registerPiExtension instead of bootstrapMCPTools, so
-      // dropping the wiring fails this test even when the bridge module
-      // still works.
+      // through the Pi lifecycle hook instead of bootstrapMCPTools directly,
+      // so dropping the wiring fails even when the bridge module still works.
       expect(registeredNames).toEqual(
         expect.arrayContaining([
           "ctx_execute",
@@ -1309,7 +1313,7 @@ describe("Pi MCP bridge (#426)", () => {
         ]),
       );
 
-      // Cleanup: SIGTERM the bridge child the wiring spawned so it does
+      // Cleanup: SIGTERM the bridge child the hook spawned so it does
       // not leak past this test.
       const sd = mod.default as any;
       void sd; // silence unused
@@ -1320,13 +1324,13 @@ describe("Pi MCP bridge (#426)", () => {
     //
     // Each Pi subagent spawns a fresh `pi --mode json -p --no-session`
     // process that loads context-mode and then immediately fires
-    // `before_agent_start` to dispatch the LLM call. The MCP bridge
+    // `before_agent_start` to dispatch the LLM call. The lazy MCP bridge
     // bootstrap (spawn server.bundle.mjs → initialize → tools/list →
-    // pi.registerTool × N) is fire-and-forget via `_mcpBridgeReady`, so
-    // without an explicit await the LLM call goes out with an empty
-    // ctx_* tool registry and the routing block (~2.5K tokens) becomes
-    // dead weight — the LLM is told to call ctx_execute / ctx_search /
-    // etc. but Pi has not yet registered them.
+    // pi.registerTool × N) starts in that hook, so without an explicit await
+    // the LLM call would go out with an empty ctx_* tool registry and the
+    // routing block (~2.5K tokens) would become dead weight — the LLM is told
+    // to call ctx_execute / ctx_search / etc. but Pi has not yet registered
+    // them.
     //
     // This test pins the contract: by the time `before_agent_start`
     // resolves, the canonical ctx_* tools MUST have been registered
@@ -1345,9 +1349,8 @@ describe("Pi MCP bridge (#426)", () => {
         { session_id: "race-test", project_dir: tempDir },
       );
 
-      // Sanity: bridge bootstrap is in flight, no tool registered yet.
-      // If this ever fails, the bridge stopped racing and the test
-      // loses meaning — adjust the bootstrap or remove the guard.
+      // Sanity: lazy bootstrap has not started during extension/session setup.
+      // If this ever fails, the bridge became eager again and #809 can regress.
       const preCalls = (wireApi.registerTool as any).mock.calls.length;
       expect(preCalls).toBe(0);
 
@@ -1524,11 +1527,21 @@ describe("Pi MCP bridge (#426)", () => {
       const bridgeMod = await import("../src/adapters/pi/mcp-bridge.js");
       const handles: any[] = [];
       const origBootstrap = bridgeMod.bootstrapMCPTools;
+      let markBootstrapEntered!: () => void;
+      const bootstrapEntered = new Promise<void>((resolve) => {
+        markBootstrapEntered = resolve;
+      });
+      let releaseBootstrap!: () => void;
+      const bootstrapRelease = new Promise<void>((resolve) => {
+        releaseBootstrap = resolve;
+      });
       const spy = vi
         .spyOn(bridgeMod, "bootstrapMCPTools")
         .mockImplementation(async (...args: any[]) => {
+          markBootstrapEntered();
           const handle = await (origBootstrap as any)(...args);
           handles.push(handle);
+          await bootstrapRelease;
           return handle;
         });
 
@@ -1537,8 +1550,18 @@ describe("Pi MCP bridge (#426)", () => {
 
         const mod = await import("../src/adapters/pi/extension.js");
 
-        // Fire shutdown immediately — bootstrap is still in flight.
-        await wireApi._trigger("session_shutdown");
+        // Lazy bootstrap now starts from before_agent_start. Fire shutdown while
+        // that bootstrap promise is still pending, then release it so shutdown's
+        // bounded await can see and terminate the real handle.
+        const agentStart = wireApi._trigger("before_agent_start", {
+          prompt: "race",
+          systemPrompt: "",
+        });
+        await bootstrapEntered;
+        const shutdown = wireApi._trigger("session_shutdown");
+        releaseBootstrap();
+        await shutdown;
+        await agentStart;
 
         // Wait for the in-flight bootstrap to settle. By this point the
         // child has been spawned. If session_shutdown did NOT await
@@ -1573,6 +1596,53 @@ describe("Pi MCP bridge (#426)", () => {
         }
       }
     }, 30_000);
+
+    it("shuts down a bridge handle that resolves after the shutdown timeout", async () => {
+      const wireApi = createMockPiApi();
+      const bridgeMod = await import("../src/adapters/pi/mcp-bridge.js");
+
+      const staleShutdown = vi.fn();
+      const staleHandle = {
+        tools: [],
+        shutdown: staleShutdown,
+        client: { _spawnEnv: null } as unknown as InstanceType<
+          typeof bridgeMod.MCPStdioClient
+        >,
+      };
+
+      let resolveBootstrap!: (handle: typeof staleHandle) => void;
+      const bootstrapPromise = new Promise<typeof staleHandle>((resolve) => {
+        resolveBootstrap = resolve;
+      });
+      const spy = vi
+        .spyOn(bridgeMod, "bootstrapMCPTools")
+        .mockImplementation(async () => bootstrapPromise as any);
+
+      try {
+        await registerPiExtension(wireApi, { projectDir: tempDir });
+
+        const agentStart = wireApi._trigger("before_agent_start", {
+          prompt: "late-bootstrap-race",
+          systemPrompt: "",
+        });
+        await Promise.resolve();
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        // Let session_shutdown hit its 2s ceiling while bootstrap is still
+        // pending. The late bootstrap resolution below must not publish a stale
+        // handle; it must self-shutdown the handle instead.
+        await wireApi._trigger("session_shutdown");
+        expect(staleShutdown).not.toHaveBeenCalled();
+
+        resolveBootstrap(staleHandle);
+        await agentStart;
+        await Promise.resolve();
+
+        expect(staleShutdown).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    }, 10_000);
   });
 });
 


### PR DESCRIPTION
## What / Why / How

Fixes https://github.com/mksglu/context-mode/issues/809 (the Pi package-command/help/version hang).

Previously, Pi extension loading could eagerly bootstrap the MCP bridge even for non-agent invocations such as package/help/version-style commands. That could spawn the long-lived MCP child in a context where no real agent session or reliable shutdown lifecycle follows, leaving bootstrap/orphan processes and causing command hangs.

This change makes bridge bootstrap lazy:
- extension registration no longer starts the MCP bridge
- `before_agent_start` starts and awaits bootstrap for real agent turns
- shutdown invalidates in-flight bootstrap generations so late handles are closed instead of orphaned
- `_mcpBridgeReady` is reset to a settled promise when no bridge should be running

I'm not sure if this qualifies for a hotfix since all `pi update`/`install` etc. commands are hanging without this change. Let me know what you think 🙏 

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [ ] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [X] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

Added/updated Pi adapter regression coverage.

- `tests/adapters/pi-help-skip-bootstrap.test.ts`
     - verifies extension discovery does not bootstrap for help/version/package-style argv
     - verifies real agent lifecycle starts bootstrap from `before_agent_start`
     - verifies bootstrap is not repeated more than once per extension registration

- `tests/adapters/pi-no-orphan-on-help.test.ts`
     - verifies non-agent argv does not construct/start an MCP child (verifies the fix from this specific issue)

- `tests/pi-extension.test.ts`
     - updates Pi MCP bridge wiring expectations for lazy bootstrap
     - verifies `before_agent_start` registers canonical `ctx_*` tools before model/tool registry snapshot
     - verifies shutdown handles in-flight lazy bootstrap without orphaning handles

## Checklist

- [X] Tests added/updated (TDD: red → green)
- [X] `npm test` passes
- [X] `npm run typecheck` passes
- [X] Docs updated if needed (README, platform-support.md)
- [X] No Windows path regressions (forward slashes only)
- [X] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
