### PR TITLE
fix(cursor): Change installation method for Cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,14 +327,25 @@ robocopy . "$env:USERPROFILE\.cursor\plugins\local\context-mode" /MIR `
   /XF *.log .gitignore *.bundle.mjs.map
 ```
 
-**macOS / Linux:**
+**macOS / Linux:** - Cursor 3.5+ [no longer accepts](https://forum.cursor.com/t/local-plugins-symlink-on-windows-doesnt-work/159427/12) symlinks to targets outside `~/.cursor/plugins/local`, so use `rsync` to copy:
 
 ```bash
 git clone https://github.com/mksglu/context-mode.git
-ln -s "$PWD/context-mode" ~/.cursor/plugins/local/context-mode
+rsync -a --delete --exclude 'node_modules/' \
+  --exclude '.git/' \
+  --exclude 'build/' \
+  --exclude 'insight/' \
+  --exclude 'web/' \
+  --exclude 'tests/' \
+  --exclude 'scripts/' \
+  --exclude '.vscode/' \
+  --exclude '*.log' \
+  --exclude '.gitignore' \
+  --exclude '*.bundle.mjs.map' \
+  context-mode ~/.cursor/plugins/local/
 ```
 
-Restart Cursor. The plugin appears in **Settings → Plugins** as "Context Mode (Local)". To pull updates, re-run the same `robocopy` / `ln -s` line.
+Restart Cursor. The plugin appears in **Settings → Plugins** as "Context Mode (Local)". To pull updates, re-run the same `robocopy` / `rsync` line.
 
 > **Note:** if `.cursor/hooks.json` already contains context-mode entries from a prior `Option B` install, `context-mode doctor` will warn about duplicate hook firings. Remove one configuration to keep events single-fire.
 


### PR DESCRIPTION
Updated installation instructions on macOS/Linux to use rsync instead of symlink due to compatibility issues.

Cursor 3.5+ no longer accepts symlinks to targets outside `~/.cursor/plugins/local`.

## What / Why / How

<!-- Brief: what changed, why, and implementation approach. Link issue: Fixes #000 -->

## Affected platforms

<!-- Check all platforms affected by this change -->

- [ ] Claude Code
- [x] Cursor
- [ ] VS Code Copilot (GitHub Copilot)
- [ ] JetBrains Copilot
- [ ] Gemini CLI
- [ ] Qwen Code
- [ ] OpenCode
- [ ] KiloCode
- [ ] Codex CLI
- [ ] OpenClaw (Pi Agent)
- [ ] Pi
- [ ] Kiro
- [ ] Antigravity
- [ ] Zed
- [ ] All platforms

## Test plan

<!-- What tests were added or modified? -->

## Checklist

- [ ] Tests added/updated (TDD: red → green)
- [ ] `npm test` passes
- [ ] `npm run typecheck` passes
- [ ] Docs updated if needed (README, platform-support.md)
- [ ] No Windows path regressions (forward slashes only)
- [ ] Targets `next` branch (unless hotfix)

<details>
<summary><strong>Cross-platform notes</strong></summary>

Our CI runs on **Ubuntu, macOS, and Windows**.

- If touching file paths, verify forward-slash normalization on Windows
- If touching hook paths, verify no backslash separators
- Use `path.join()` / `path.resolve()`, never hardcode `/` separators
- Use event-based stdin reading — `readFileSync(0)` breaks on Windows
- Use `os.tmpdir()`, never hardcode `/tmp`

</details>
