### PR TITLE
fix(heal): make cache-root containment guards symlink-aware (#795)

### DIFF
--- a/scripts/heal-installed-plugins.mjs
+++ b/scripts/heal-installed-plugins.mjs
@@ -17,8 +17,36 @@
  * @see https://github.com/anthropics/claude-code/issues/46915
  */
 
-import { existsSync, readFileSync, writeFileSync, readdirSync, unlinkSync, statSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, readdirSync, unlinkSync, statSync, realpathSync } from "node:fs";
 import { resolve, sep } from "node:path";
+
+/**
+ * Best-effort realpath: dereference symlinks when the path exists, fall
+ * back to the lexical resolve when it doesn't (e.g. a stale installPath).
+ */
+function toRealPath(p) {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/**
+ * Containment check shared by the path-traversal guards below.
+ *
+ * `path.resolve` rejects `..` escapes but does not dereference symlinks.
+ * When the Claude config dir is relocated and symlinked back (#795 —
+ * `~/.claude` → another volume), the registry stores *physical* install
+ * paths while the computed cache root keeps the *symlink* path, the
+ * lexical forms never match, and every heal silently skips the plugin.
+ * Containment holds when either the lexical or the physical forms match;
+ * a `..` escape fails both, so the traversal guard keeps its teeth.
+ */
+function isInsideRoot(childPath, rootPath) {
+  if (resolve(childPath).startsWith(resolve(rootPath) + sep)) return true;
+  return toRealPath(childPath).startsWith(toRealPath(rootPath) + sep);
+}
 
 /**
  * @typedef {Object} HealResult
@@ -77,10 +105,8 @@ export function healInstalledPlugins({ registryPath, pluginCacheRoot, pluginKey 
     if (!installPath || typeof installPath !== "string") continue;
 
     // Path-traversal guard: only consult plugin.json files inside the
-    // declared plugin cache root.
-    const resolvedInstall = resolve(installPath);
-    const cacheRootWithSep = resolve(pluginCacheRoot) + sep;
-    if (!resolvedInstall.startsWith(cacheRootWithSep)) continue;
+    // declared plugin cache root (symlink-aware, #795).
+    if (!isInsideRoot(installPath, pluginCacheRoot)) continue;
 
     const cachePluginJson = resolve(installPath, ".claude-plugin", "plugin.json");
     if (!existsSync(cachePluginJson)) continue;
@@ -223,10 +249,8 @@ export function healPluginJsonMcpServers({ pluginRoot, pluginCacheRoot, pluginKe
   }
 
   // Path-traversal guard: refuse to touch a plugin root that escapes the
-  // declared cache root. Mirrors HEAL 3's guard.
-  const resolvedRoot = resolve(pluginRoot);
-  const cacheRootWithSep = resolve(pluginCacheRoot) + sep;
-  if (!resolvedRoot.startsWith(cacheRootWithSep)) {
+  // declared cache root (symlink-aware, #795). Mirrors HEAL 3's guard.
+  if (!isInsideRoot(pluginRoot, pluginCacheRoot)) {
     return { healed: [], skipped: "outside-cache-root" };
   }
 
@@ -332,10 +356,9 @@ export function healMcpJsonArgs({ pluginRoot, pluginCacheRoot, pluginKey }) {
   }
 
   // Path-traversal guard: refuse to touch a plugin root that escapes the
-  // declared cache root. Mirrors healPluginJsonMcpServers + HEAL 3.
-  const resolvedRoot = resolve(pluginRoot);
-  const cacheRootWithSep = resolve(pluginCacheRoot) + sep;
-  if (!resolvedRoot.startsWith(cacheRootWithSep)) {
+  // declared cache root (symlink-aware, #795). Mirrors
+  // healPluginJsonMcpServers + HEAL 3.
+  if (!isInsideRoot(pluginRoot, pluginCacheRoot)) {
     return { healed: [], skipped: "outside-cache-root" };
   }
 

--- a/tests/util/heal-installed-plugins.test.ts
+++ b/tests/util/heal-installed-plugins.test.ts
@@ -21,6 +21,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -290,6 +291,150 @@ describe("healInstalledPlugins — defensive paths", () => {
       readFileSync(resolve(__dirname, "../../package.json"), "utf-8"),
     ) as { files: string[] };
     expect(pkg.files).toContain("scripts/heal-installed-plugins.mjs");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Issue #795 — symlinked config dir (~/.claude → another volume).
+// The registry stores *physical* install paths while the heal callers
+// compute the cache root through the *symlink*, so a purely lexical
+// resolve+startsWith containment check never matches and every heal
+// silently skips the plugin. The guards must compare physical (realpath)
+// forms too — without losing their teeth against `..` escapes.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Create a directory symlink (junction on Windows — no admin needed).
+ * Returns false when the environment cannot create symlinks at all so
+ * the test can bail instead of failing on an unrelated OS restriction.
+ */
+function trySymlinkDir(target: string, linkPath: string): boolean {
+  try {
+    symlinkSync(target, linkPath, "junction");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("healInstalledPlugins — #795 symlinked cache root", () => {
+  it("heals when pluginCacheRoot is given via a symlink but the registry stores physical paths", () => {
+    const fake = buildFakeRegistry({
+      entryVersion: "1.0.99",
+      cacheVersion: "1.0.113",
+    });
+    const linkRoot = join(makeTmp("ctx-link-"), "cache-link");
+    if (!trySymlinkDir(fake.cacheRoot, linkRoot)) return; // env cannot symlink
+
+    const result = healInstalledPlugins({
+      registryPath: fake.registryPath,
+      pluginCacheRoot: linkRoot, // symlink form (what a relocated ~/.claude computes)
+      pluginKey: KEY,
+    });
+
+    expect(result.skipped).toBeUndefined();
+    expect(result.healed).toContain("entry-version");
+    const after = readRegistry(fake.registryPath) as {
+      plugins: Record<string, Array<{ version: string }>>;
+    };
+    expect(after.plugins[KEY][0].version).toBe("1.0.113");
+  });
+
+  it("heals when the registry stores symlink paths but pluginCacheRoot is physical", () => {
+    const fake = buildFakeRegistry({
+      entryVersion: "1.0.99",
+      cacheVersion: "1.0.113",
+    });
+    const linkRoot = join(makeTmp("ctx-link-"), "cache-link");
+    if (!trySymlinkDir(fake.cacheRoot, linkRoot)) return; // env cannot symlink
+
+    // Rewrite the registry entry to the symlinked form of the same dir.
+    const ip = readRegistry(fake.registryPath) as {
+      plugins: Record<string, Array<{ installPath: string }>>;
+    };
+    ip.plugins[KEY][0].installPath = join(
+      linkRoot,
+      "context-mode",
+      "context-mode",
+      "1.0.113",
+    );
+    writeFileSync(fake.registryPath, JSON.stringify(ip, null, 2) + "\n");
+
+    const result = healInstalledPlugins({
+      registryPath: fake.registryPath,
+      pluginCacheRoot: fake.cacheRoot, // physical form
+      pluginKey: KEY,
+    });
+
+    expect(result.healed).toContain("entry-version");
+  });
+
+  it("still rejects `..` escapes when the cache root is symlinked", () => {
+    const fake = buildFakeRegistry({
+      entryVersion: "1.0.99",
+      cacheVersion: "1.0.113",
+    });
+    const linkRoot = join(makeTmp("ctx-link-"), "cache-link");
+    if (!trySymlinkDir(fake.cacheRoot, linkRoot)) return; // env cannot symlink
+
+    // Tamper: a traversal path that lexically starts at the symlinked root
+    // but escapes it — must fail BOTH the lexical and the physical check.
+    const escapeDir = makeTmp("ctx-escape-");
+    const ip = readRegistry(fake.registryPath) as {
+      plugins: Record<string, Array<{ installPath: string }>>;
+    };
+    ip.plugins[KEY][0].installPath = join(linkRoot, "..", "..", escapeDir);
+    writeFileSync(fake.registryPath, JSON.stringify(ip, null, 2) + "\n");
+
+    const result = healInstalledPlugins({
+      registryPath: fake.registryPath,
+      pluginCacheRoot: linkRoot,
+      pluginKey: KEY,
+    });
+    expect(result.healed).not.toContain("entry-version");
+  });
+});
+
+describe("healPluginJsonMcpServers — #795 symlinked cache root", () => {
+  it("heals through a symlinked pluginCacheRoot", () => {
+    const fake = buildFakeRegistry({
+      entryVersion: "1.0.113",
+      cacheVersion: "1.0.113",
+    });
+    // Seed a poisoned mcpServers args[0] in the cache plugin.json.
+    const pluginJsonPath = resolve(fake.cacheDir, ".claude-plugin", "plugin.json");
+    writeFileSync(
+      pluginJsonPath,
+      JSON.stringify(
+        {
+          name: "context-mode",
+          version: "1.0.113",
+          mcpServers: {
+            "context-mode": {
+              command: "node",
+              args: ["/tmp/context-mode-upgrade-1736000000000/start.mjs"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const linkRoot = join(makeTmp("ctx-link-"), "cache-link");
+    if (!trySymlinkDir(fake.cacheRoot, linkRoot)) return; // env cannot symlink
+
+    const result = healPluginJsonMcpServers({
+      pluginRoot: fake.cacheDir, // physical (as the registry records it)
+      pluginCacheRoot: linkRoot, // symlink (as a relocated ~/.claude computes it)
+      pluginKey: KEY,
+    });
+
+    expect(result.skipped).toBeUndefined();
+    expect(result.healed).toContain("plugin-json-args");
+    const after = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
+    expect(after.mcpServers["context-mode"].args[0]).toBe(
+      "${CLAUDE_PLUGIN_ROOT}/start.mjs",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #795 — when `~/.claude` is relocated to another volume and symlinked back, the registry stores **physical** install paths while the heal callers compute the cache root through the **symlink**. The purely lexical `resolve()+startsWith` containment guards in `scripts/heal-installed-plugins.mjs` then never match, so HEAL 3/4 and both mcpServers heals silently skip context-mode — the very heals meant to repair a broken install never fire for exactly these users.

## Fix

New `isInsideRoot(childPath, rootPath)` helper: containment holds when **either** the lexical (`resolve`) **or** the physical (`realpathSync`, with lexical fallback for non-existent paths) forms match. Used by the three guards that compare an install path against `pluginCacheRoot`:

- HEAL 3 (`healInstalledPlugins` entry loop)
- `healPluginJsonMcpServers` (#523 guard)
- `healMcpJsonArgs` (#531 guard)

A `..`-escape fails **both** forms, so the path-traversal protection keeps its teeth (covered by a dedicated regression test). This mirrors the realpath canonicalization that `cli.ts` (cacheRootCanon) and `heal-partial-install.mjs` (layered lexical+realpath guards) already do — `heal-installed-plugins.mjs` was the remaining lexical-only spot.

`sweepStaleMcpJson`'s guard is intentionally untouched: both of its sides derive from the same resolved cache root, so a symlinked config dir cannot make them diverge.

## Tests

4 new tests in `tests/util/heal-installed-plugins.test.ts` (symlinks created as junctions so they work on Windows without admin; tests bail gracefully on environments that cannot symlink):

- heals when `pluginCacheRoot` is the symlink form and the registry stores physical paths (the #795 layout)
- heals in the reverse direction (registry stores symlink paths, root is physical)
- still rejects `..` escapes when the cache root is symlinked
- `healPluginJsonMcpServers` heals through a symlinked cache root

```
bun run vitest run tests/util/heal-installed-plugins.test.ts   # 40 passed
bun run vitest run tests/util tests/scripts tests/hooks tests/cli  # 787 passed; 1 pre-existing failure (project-dir build artifact, fails on clean checkout too)
bun run typecheck                                              # clean
```