### PR TITLE
fix(pi): stop mutating systemPrompt, inject via context hook to preserve prefix cache

### DIFF
--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -707,6 +707,7 @@ export default function piExtension(pi: any): void {
         _pendingContext = "";
       }
     } catch {
+      _pendingContext = ""; // Reset — ensure no stale data escapes
       // best effort — never break agent start
     }
   });
@@ -716,14 +717,18 @@ export default function piExtension(pi: any): void {
   // messages rather than mutating systemPrompt at the beginning. This preserves
   // prefix prompt cache for DeepSeek, Anthropic, and OpenAI.
   pi.on("context", (event: any) => {
-    if (!_pendingContext) return;
-    const ctx = _pendingContext;
-    _pendingContext = "";
-    event.messages.push({
-      role: "user",
-      content: ctx,
-    });
-    return { messages: event.messages };
+    try {
+      if (!_pendingContext) return;
+      const ctx = _pendingContext;
+      _pendingContext = "";
+      event.messages.push({
+        role: "user",
+        content: ctx,
+      });
+      return { messages: event.messages };
+    } catch {
+      // best effort — never break context assembly
+    }
   });
 
   // ── 4b. before_provider_response — capture response metadata ───

--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -159,6 +159,11 @@ let _buildAutoInjection:
   | ((events: Array<{ category: string; data: string }>) => string)
   | null
   | undefined = undefined;
+
+// Pending context to inject via the 'context' hook (avoiding systemPrompt mutation
+// which breaks prefix prompt cache on DeepSeek/Anthropic/OpenAI).
+// See: https://github.com/mksglu/context-mode/issues/598
+let _pendingContext = "";
 async function getAutoInjection(
   pluginRoot: string,
 ): Promise<((events: Array<{ category: string; data: string }>) => string) | null> {
@@ -598,6 +603,7 @@ export default function piExtension(pi: any): void {
 
   pi.on("before_agent_start", async (event: any) => {
     try {
+      _pendingContext = ""; // Reset — will be filled below if events exist
       // Lazily start and await the MCP bridge only when Pi is about to
       // dispatch a real agent turn. This is the non-brittle #534/#809 guard:
       // help/version/package/config CLI paths may load the extension, but they
@@ -688,14 +694,36 @@ export default function piExtension(pi: any): void {
 
       if (behavioralDirective) parts.push(behavioralDirective);
 
-      // Return modified systemPrompt only if we added something beyond existing.
+      // Store extra context (routing anchor, active_memory, resume, behavioralDirective)
+      // for injection via the 'context' hook as a message, NOT as a systemPrompt
+      // modification. Mutating systemPrompt breaks prefix prompt caching on
+      // DeepSeek/Anthropic/OpenAI because the system message sits at messages[0]
+      // and any change invalidates the entire cache chain.
       const baseLen = existingPrompt ? 1 : 0;
       if (parts.length > baseLen) {
-        return { systemPrompt: parts.join("\n\n") };
+        const extraParts = parts.slice(baseLen);
+        _pendingContext = extraParts.join("\n\n");
+      } else {
+        _pendingContext = "";
       }
     } catch {
       // best effort — never break agent start
     }
+  });
+
+  // ── 4a2. context — Inject active_memory + resume + behavioralDirective as message ──
+  // Uses the 'context' hook (like hindsight does) to append context at the END of
+  // messages rather than mutating systemPrompt at the beginning. This preserves
+  // prefix prompt cache for DeepSeek, Anthropic, and OpenAI.
+  pi.on("context", (event: any) => {
+    if (!_pendingContext) return;
+    const ctx = _pendingContext;
+    _pendingContext = "";
+    event.messages.push({
+      role: "user",
+      content: ctx,
+    });
+    return { messages: event.messages };
   });
 
   // ── 4b. before_provider_response — capture response metadata ───

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "284.6k+",
+  "message": "287.5k+",
   "color": "brightgreen",
-  "npm": "251.4k+",
+  "npm": "254.4k+",
   "marketplace": "33.1k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "281.7k+",
+  "message": "284.6k+",
   "color": "brightgreen",
-  "npm": "248.5k+",
+  "npm": "251.4k+",
   "marketplace": "33.1k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "281.5k+",
+  "message": "281.7k+",
   "color": "brightgreen",
   "npm": "248.5k+",
-  "marketplace": "32.9k+"
+  "marketplace": "33.1k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "287.3k+",
+  "message": "290k+",
   "color": "brightgreen",
-  "npm": "254.4k+",
+  "npm": "257k+",
   "marketplace": "32.9k+"
 }

--- a/stats.json
+++ b/stats.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "label": "users",
-  "message": "287.5k+",
+  "message": "287.3k+",
   "color": "brightgreen",
   "npm": "254.4k+",
-  "marketplace": "33.1k+"
+  "marketplace": "32.9k+"
 }

--- a/web/index.html
+++ b/web/index.html
@@ -127,7 +127,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(
 .hero::before{content:'';position:absolute;top:-20%;right:-10%;width:520px;height:520px;background:radial-gradient(circle,var(--accent-light) 0%,transparent 70%);opacity:.55;pointer-events:none}
 .hero::after{content:'';position:absolute;bottom:-30%;left:-15%;width:480px;height:480px;background:radial-gradient(circle,var(--accent-dev-bg) 0%,transparent 70%);opacity:.5;pointer-events:none}
 .hero-inner{position:relative;z-index:1}
-.hero-tag{font-family:var(--mono);font-size:13px;color:var(--text-4);margin-bottom:24px;letter-spacing:.04em;display:inline-flex;align-items:center;gap:10px;padding:6px 14px;background:var(--bg-alt);border:1px solid var(--border-light);border-radius:6px}
+.hero-tag{font-family:var(--mono);font-size:13px;color:var(--text-4);margin-top:24px;letter-spacing:.04em;display:inline-flex;align-items:center;gap:10px;padding:6px 14px;background:var(--bg-alt);border:1px solid var(--border-light);border-radius:6px;align-self:flex-start}
 .hero-tag .dot{width:6px;height:6px;border-radius:50%;background:var(--accent-dev);box-shadow:0 0 10px rgba(16,185,129,.6)}
 .hero-sub{font-size:clamp(1.1rem,2.5vw,1.45rem);color:var(--text-2);font-weight:300;margin-top:22px;max-width:880px;line-height:1.55}
 .hero-sub strong{color:var(--ink);font-weight:600}
@@ -445,8 +445,8 @@ footer{padding:64px 0 40px;text-align:center;background:var(--bg-alt);border-top
 <!-- ═══════════════════════════════════════ HERO ═══════════════════════════════════════ -->
 <section class="hero">
   <div class="hero-inner wrap rev">
-    <p class="hero-tag"><span class="dot"></span>open-source plugin · commercial platform · <span id="stat-tag-users">287,000+</span> developers</p>
     <h1 class="cm-master">Context Mode<span class="cursor"></span></h1>
+    <p class="hero-tag"><span class="dot"></span>open-source plugin · commercial platform · <span id="stat-tag-users">287,000+</span> developers</p>
     <p class="hero-sub">
       <strong>The other half of the context problem</strong> — for developers and for engineering orgs.
       An MCP plugin that keeps raw data out of the LLM context window. A Platform that surfaces <em>what your team is doing</em>

--- a/web/index.html
+++ b/web/index.html
@@ -119,7 +119,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-code);color:var(
 }
 
 /* ── Master wordmark (hero) ── */
-.cm-master{display:inline-flex;align-items:baseline;gap:0;line-height:1;font-family:var(--sans);font-weight:600;letter-spacing:-.035em;color:var(--ink);font-size:clamp(3rem,8vw,5.5rem)}
+.cm-master{display:flex;align-items:baseline;gap:0;line-height:1;font-family:var(--sans);font-weight:600;letter-spacing:-.035em;color:var(--ink);font-size:clamp(3rem,8vw,5.5rem)}
 .cm-master .cursor{display:inline-block;background:var(--accent);margin-left:.10em;width:.30em;height:.92em}
 
 /* ── Hero ── */

--- a/web/insight.html
+++ b/web/insight.html
@@ -114,7 +114,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-alt);color:var(-
 /* Wordmark (hero) */
 .cm-wordmark{display:flex;align-items:baseline;gap:0;line-height:1;font-size:clamp(3rem,8vw,5.5rem)}
 .cm-wordmark .sans{font-family:var(--sans);font-weight:600;color:var(--ink);letter-spacing:-.035em}
-.cm-wordmark .italic{font-family:var(--serif);font-style:italic;font-weight:400;color:var(--accent);letter-spacing:-.03em;font-size:1.18em;margin-left:.12em}
+.cm-wordmark .italic{font-family:var(--serif);font-style:italic;font-weight:400;color:var(--accent);letter-spacing:-.03em;font-size:1em;margin-left:.14em}
 .cm-wordmark .cursor{display:inline-block;background:var(--accent);width:.30em;height:.92em;margin-left:.10em}
 
 /* Hero */
@@ -122,7 +122,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-alt);color:var(-
 .hero::before{content:'';position:absolute;top:-20%;right:-10%;width:520px;height:520px;background:radial-gradient(circle,var(--accent-light) 0%,transparent 70%);opacity:.55;pointer-events:none}
 .hero::after{content:'';position:absolute;bottom:-30%;left:-15%;width:480px;height:480px;background:radial-gradient(circle,var(--accent-dev-bg) 0%,transparent 70%);opacity:.5;pointer-events:none}
 .hero-inner{position:relative;z-index:1}
-.hero-tag{font-family:var(--mono);font-size:13px;color:var(--text-4);margin-bottom:24px;letter-spacing:.04em;display:inline-flex;align-items:center;gap:10px;padding:6px 14px;background:var(--bg-alt);border:1px solid var(--border-light);border-radius:6px}
+.hero-tag{font-family:var(--mono);font-size:13px;color:var(--text-4);margin-top:24px;letter-spacing:.04em;display:inline-flex;align-items:center;gap:10px;padding:6px 14px;background:var(--bg-alt);border:1px solid var(--border-light);border-radius:6px;align-self:flex-start}
 .hero-tag .dot{width:6px;height:6px;border-radius:50%;background:var(--accent);box-shadow:0 0 10px rgba(26,86,219,.6)}
 .hero-tag a{color:var(--text-3)}
 .hero-sub{font-size:clamp(1.1rem,2.5vw,1.4rem);color:var(--text-2);font-weight:300;margin-top:22px;max-width:880px;line-height:1.55}
@@ -350,8 +350,8 @@ footer{padding:64px 0 40px;text-align:center;background:var(--bg-alt);border-top
 <!-- ═══════════════════════════════════════ HERO ═══════════════════════════════════════ -->
 <section class="hero">
   <div class="hero-inner wrap rev">
-    <p class="hero-tag"><span class="dot"></span>the first Solution on <a href="https://context-mode.com">Context Mode Platform</a></p>
     <h1 class="cm-wordmark"><span class="sans">Context Mode</span><span class="italic">Insight</span><span class="cursor"></span></h1>
+    <p class="hero-tag"><span class="dot"></span>the first Solution on <a href="https://context-mode.com">Context Mode Platform</a></p>
     <p class="hero-sub">
       <strong>Engineering signal for AI-assisted teams.</strong> Per-engineer productive rate. Retry waste per team. Patterns named, actions prescribed. Role-narrowed for <em>CTO, EM, IC, CISO, FinOps, DevOps</em> — same MCP endpoint, six different views.
     </p>

--- a/web/insight.html
+++ b/web/insight.html
@@ -112,7 +112,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-alt);color:var(-
 @media(max-width:720px){.topnav-menu{display:none}.topnav-cta .btn{height:2.25rem;padding:.5rem .75rem;font-size:13px}}
 
 /* Wordmark (hero) */
-.cm-wordmark{display:inline-flex;align-items:baseline;gap:0;line-height:1;font-size:clamp(3rem,8vw,5.5rem)}
+.cm-wordmark{display:flex;align-items:baseline;gap:0;line-height:1;font-size:clamp(3rem,8vw,5.5rem)}
 .cm-wordmark .sans{font-family:var(--sans);font-weight:600;color:var(--ink);letter-spacing:-.035em}
 .cm-wordmark .italic{font-family:var(--serif);font-style:italic;font-weight:400;color:var(--accent);letter-spacing:-.03em;font-size:1.18em;margin-left:.12em}
 .cm-wordmark .cursor{display:inline-block;background:var(--accent);width:.30em;height:.92em;margin-left:.10em}

--- a/web/oss.html
+++ b/web/oss.html
@@ -60,7 +60,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-3);color:var(--a
 
 /* ── Typography ── */
 .section-num{font-family:var(--mono);font-size:11px;font-weight:600;color:var(--text-4);letter-spacing:.12em;text-transform:uppercase}
-.h1{font-family:var(--mono);font-size:clamp(3rem,8vw,5.5rem);font-weight:600;color:var(--fg);line-height:1;letter-spacing:-.03em;display:inline-flex;align-items:baseline;gap:0}
+.h1{font-family:var(--mono);font-size:clamp(3rem,8vw,5.5rem);font-weight:600;color:var(--fg);line-height:1;letter-spacing:-.03em;display:flex;align-items:baseline;gap:0}
 .h1 .prompt{color:var(--text-4);font-weight:500;margin-right:.18em}
 .h1 .dash{color:var(--accent-2)}
 .h1 .cursor{display:inline-block;background:var(--accent);width:.30em;height:.92em;margin-left:.10em;box-shadow:0 0 24px rgba(16,185,129,.45);animation:blink 1.06s steps(2) infinite}
@@ -88,7 +88,7 @@ code{font-family:var(--mono);font-size:.9em;background:var(--bg-3);color:var(--a
 .hero::after{content:'';position:absolute;bottom:-30%;left:-15%;width:480px;height:480px;background:radial-gradient(circle,rgba(75,123,236,0.06) 0%,transparent 70%);pointer-events:none}
 .scan{position:absolute;inset:0;background:repeating-linear-gradient(0deg,transparent 0 3px,rgba(255,255,255,0.012) 4px,transparent 5px);pointer-events:none;-webkit-mask-image:radial-gradient(ellipse at center,#000 30%,transparent 80%);mask-image:radial-gradient(ellipse at center,#000 30%,transparent 80%)}
 .hero-inner{position:relative;z-index:1}
-.hero-tag{font-family:var(--mono);font-size:13px;color:var(--text-3);margin-bottom:24px;letter-spacing:.04em;display:inline-flex;align-items:center;gap:10px;padding:6px 14px;background:var(--bg-3);border:1px solid var(--border);border-radius:6px}
+.hero-tag{font-family:var(--mono);font-size:13px;color:var(--text-3);margin-top:24px;letter-spacing:.04em;display:inline-flex;align-items:center;gap:10px;padding:6px 14px;background:var(--bg-3);border:1px solid var(--border);border-radius:6px;align-self:flex-start}
 .hero-tag .dot{width:6px;height:6px;border-radius:50%;background:var(--accent);box-shadow:0 0 10px rgba(16,185,129,.7)}
 .hero-tag a{color:var(--text-3)}
 .hero-sub{font-size:clamp(1.1rem,2.5vw,1.4rem);color:var(--text-2);font-weight:300;margin-top:22px;max-width:880px;line-height:1.55}
@@ -288,8 +288,8 @@ footer{padding:64px 0 40px;text-align:center;background:var(--bg-2);border-top:1
 <section class="hero">
   <div class="scan"></div>
   <div class="hero-inner wrap rev">
-    <p class="hero-tag"><span class="dot"></span>open-source plugin · ELv2 · part of <a href="/">Context Mode</a></p>
     <h1 class="h1"><span class="prompt">$</span>context<span class="dash">-</span>mode<span class="cursor"></span></h1>
+    <p class="hero-tag"><span class="dot"></span>open-source plugin · ELv2 · part of <a href="/">Context Mode</a></p>
     <p class="hero-sub">
       <strong>The other half of the context problem.</strong> An MCP plugin that sandboxes tool output and indexes it into a local FTS5 store. Your AI coding agent searches that store instead of re-sending raw bytes every turn. <em>15 platforms. <span class="js-user-count">287,000+</span> developers. Runs entirely on your machine.</em>
     </p>


### PR DESCRIPTION
## Problem

The Pi adapter uses `before_agent_start` to inject dynamic content (active_memory, resume snapshot, behavioralDirective usage stats) into the `systemPrompt`. Since `systemPrompt` sits at `messages[0]`, **any change invalidates the entire prefix prompt cache** on DeepSeek, Anthropic, and OpenAI APIs.

This causes cache hit rates to plummet from 90%+ to ~18%, as originally reported in #598 — but the fix in that issue only moved `behavioralDirective` within the systemPrompt, which does not solve the problem for API-level prefix caching (only for vLLM's auto-prefix algorithm).

## Root Cause

Unlike Claude Code (where hook output is appended to the message stream by the CC runtime), the Pi extension API's `before_agent_start` directly modifies the system prompt. Dynamic data at the prefix position = guaranteed cache miss every turn.

## Fix

Three minimal changes to `src/adapters/pi/extension.ts`:

1. **Add `_pendingContext` module variable** — buffer for context that should reach the LLM without touching systemPrompt
2. **In `before_agent_start`**: instead of `return { systemPrompt }`, store the extra context in `_pendingContext`
3. **Register a `context` hook** — same pattern used by hindsight/other extensions — appends `_pendingContext` as a user message at the **end** of the message array

This aligns the Pi adapter with how context-mode works on Claude Code and all other platforms — content injected at the end of messages, leaving the static prefix intact.

## Before / After

| | Before | After |
|---|---|---|
| Injection method | `systemPrompt` modification | `context` hook → message append |
| Position in messages | `messages[0]` (prefix) | End of `messages` (suffix) |
| Prefix cache impact | 💥 Full invalidation every turn | ✅ Fully preserved |
| Claude Code parity | ❌ Different path | ✅ Same pattern |

## Testing

- [x] Node `--check` syntax validation on both source (`.ts`) and built (`.js`) files
- [x] TypeScript typecheck on modified file: no new errors
- [x] Verified in live Pi session with DeepSeek: systemPrompt no longer changes between turns